### PR TITLE
fix: Resolve TypeError in DeleteMemoryOp by using attribute access for VectorNode

### DIFF
--- a/reme_ai/vector_store/delete_memory_op.py
+++ b/reme_ai/vector_store/delete_memory_op.py
@@ -48,10 +48,11 @@ class DeleteMemoryOp(BaseAsyncOp):
 
         deleted_memory_ids = []
         for node in nodes:
-            freq = node["metadata"]["metadata"]["freq"]
-            utility = node["metadata"]["metadata"]["utility"]
+            # VectorNode 对象需要使用属性访问，不是字典访问
+            freq = node.metadata.get("freq", 0)
+            utility = node.metadata.get("utility", 0)
             if freq >= freq_threshold:
                 if utility * 1.0 / freq < utility_threshold:
-                    deleted_memory_ids.append(node["unique_id"])
+                    deleted_memory_ids.append(node.unique_id)
 
         self.context.deleted_memory_ids = deleted_memory_ids


### PR DESCRIPTION
## Description
This PR fixes a `TypeError: 'VectorNode' object is not subscriptable` encountered in `DeleteMemoryOp`.

## Problem
The `DeleteMemoryOp` was attempting to access `VectorNode` properties using dictionary syntax (e.g., `node["metadata"]`), which caused a runtime error because `VectorNode` is a Pydantic model object, not a dictionary.

**Error Log:**
```text
TypeError: 'VectorNode' object is not subscriptable
  File "reme_ai/vector_store/delete_memory_op.py", line 51, in async_execute
    freq = node["metadata"]["metadata"]["freq"]
```
    
**Changes**
Updated delete_memory_op.py to use attribute access (dot notation) instead of dictionary subscription.
Changed node["metadata"] to node.metadata
Changed node["unique_id"] to `node.unique_id`
**Verification**
Verified that the TypeError is resolved and memory deletion operations proceed correctly.