### PR TITLE
feat: add Novita backend support

### DIFF
--- a/reme/core/embedding/__init__.py
+++ b/reme/core/embedding/__init__.py
@@ -3,13 +3,18 @@
 from .base_embedding_model import BaseEmbeddingModel
 from .openai_embedding_model import OpenAIEmbeddingModel
 from .openai_embedding_model_sync import OpenAIEmbeddingModelSync
+from .novita_embedding_model import NovitaEmbeddingModel, NovitaEmbeddingModelSync
 from ..registry_factory import R
 
 __all__ = [
     "BaseEmbeddingModel",
     "OpenAIEmbeddingModel",
     "OpenAIEmbeddingModelSync",
+    "NovitaEmbeddingModel",
+    "NovitaEmbeddingModelSync",
 ]
 
 R.embedding_models.register("openai")(OpenAIEmbeddingModel)
 R.embedding_models.register("openai_sync")(OpenAIEmbeddingModelSync)
+R.embedding_models.register("novita")(NovitaEmbeddingModel)
+R.embedding_models.register("novita_sync")(NovitaEmbeddingModelSync)

--- a/reme/core/embedding/novita_embedding_model.py
+++ b/reme/core/embedding/novita_embedding_model.py
@@ -1,0 +1,25 @@
+"""Novita-compatible embedding model implementation."""
+
+from typing import Literal
+from .openai_embedding_model import OpenAIEmbeddingModel
+from .openai_embedding_model_sync import OpenAIEmbeddingModelSync
+
+
+class NovitaEmbeddingModel(OpenAIEmbeddingModel):
+    """Asynchronous embedding model implementation compatible with Novita APIs."""
+
+    def __init__(self, encoding_format: Literal["float", "base64"] = "float", **kwargs):
+        """Initialize the Novita async embedding model, defaulting to Novita's API endpoint."""
+        if "base_url" not in kwargs or kwargs["base_url"] is None:
+            kwargs["base_url"] = "https://api.novita.ai/openai"
+        super().__init__(encoding_format=encoding_format, **kwargs)
+
+
+class NovitaEmbeddingModelSync(OpenAIEmbeddingModelSync):
+    """Synchronous embedding model implementation compatible with Novita APIs."""
+
+    def __init__(self, encoding_format: Literal["float", "base64"] = "float", **kwargs):
+        """Initialize the Novita sync embedding model, defaulting to Novita's API endpoint."""
+        if "base_url" not in kwargs or kwargs["base_url"] is None:
+            kwargs["base_url"] = "https://api.novita.ai/openai"
+        super().__init__(encoding_format=encoding_format, **kwargs)

--- a/reme/core/llm/__init__.py
+++ b/reme/core/llm/__init__.py
@@ -5,6 +5,7 @@ from .lite_llm import LiteLLM
 from .lite_llm_sync import LiteLLMSync
 from .openai_llm import OpenAILLM
 from .openai_llm_sync import OpenAILLMSync
+from .novita_llm import NovitaLLM, NovitaLLMSync
 from ..registry_factory import R
 
 __all__ = [
@@ -13,9 +14,13 @@ __all__ = [
     "LiteLLMSync",
     "OpenAILLM",
     "OpenAILLMSync",
+    "NovitaLLM",
+    "NovitaLLMSync",
 ]
 
 R.llms.register("litellm")(LiteLLM)
 R.llms.register("litellm_sync")(LiteLLMSync)
 R.llms.register("openai")(OpenAILLM)
 R.llms.register("openai_sync")(OpenAILLMSync)
+R.llms.register("novita")(NovitaLLM)
+R.llms.register("novita_sync")(NovitaLLMSync)

--- a/reme/core/llm/novita_llm.py
+++ b/reme/core/llm/novita_llm.py
@@ -1,0 +1,27 @@
+"""Novita-compatible LLM implementation."""
+
+from typing import AsyncGenerator, Generator
+from openai import AsyncOpenAI, OpenAI
+
+from .openai_llm import OpenAILLM
+from .openai_llm_sync import OpenAILLMSync
+
+
+class NovitaLLM(OpenAILLM):
+    """Asynchronous LLM client for Novita-compatible APIs."""
+
+    def __init__(self, **kwargs):
+        """Initialize the Novita async client, defaulting to Novita's API endpoint."""
+        if "base_url" not in kwargs or kwargs["base_url"] is None:
+            kwargs["base_url"] = "https://api.novita.ai/openai"
+        super().__init__(**kwargs)
+
+
+class NovitaLLMSync(OpenAILLMSync):
+    """Synchronous LLM client for Novita-compatible APIs."""
+
+    def __init__(self, **kwargs):
+        """Initialize the Novita sync client, defaulting to Novita's API endpoint."""
+        if "base_url" not in kwargs or kwargs["base_url"] is None:
+            kwargs["base_url"] = "https://api.novita.ai/openai"
+        super().__init__(**kwargs)


### PR DESCRIPTION
This PR adds Novita-compatible backend support for LLM and embeddings. It introduces NovitaLLM and NovitaEmbeddingModel (both async and sync) which default to the Novita API endpoint: https://api.novita.ai/openai