### PR TITLE
fix: support BGE-M3 embedding (dense_embedding fallback)

### DIFF
--- a/reme/core/embedding/openai_embedding_model.py
+++ b/reme/core/embedding/openai_embedding_model.py
@@ -45,7 +45,9 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
 
         result_emb = [[] for _ in range(len(input_text))]
         for emb in completion.data:
-            result_emb[emb.index] = emb.embedding
+            # BGE-M3 returns dense_embedding instead of embedding; use as fallback
+            vec = getattr(emb, "embedding", None) or getattr(emb, "dense_embedding", None)
+            result_emb[emb.index] = list(vec) if vec is not None else []
         return result_emb
 
     async def start(self):


### PR DESCRIPTION
BGE-M3 returns `dense_embedding` instead of `embedding`; ReMe expects `embedding` and causes `TypeError: object of type 'NoneType' has no len()`.

This adds a fallback in `_get_embeddings` to use `dense_embedding` when `embedding` is None.

Related: CoPaw PR #1780 (which used a monkey-patch; this fixes the root cause in ReMe).

Made with [Cursor](https://cursor.com)