### PR TITLE
fix(core): graceful degradation when embedding model is not configured

### DIFF
--- a/reme/core/application.py
+++ b/reme/core/application.py
@@ -240,10 +240,16 @@ class Application:
             if config.backend not in R.file_stores:
                 logger.warning(f"File store backend {config.backend} is not supported.")
             else:
+                embedding_model = self.service_context.embedding_models.get(config.embedding_model)
+                if embedding_model is None and config.embedding_model:
+                    logger.warning(
+                        f"Embedding model '{config.embedding_model}' not found for file store '{name}', "
+                        f"vector search will be disabled.",
+                    )
                 config_dict = config.model_dump(exclude={"backend", "embedding_model"})
                 config_dict.update(
                     {
-                        "embedding_model": self.service_context.embedding_models[config.embedding_model],
+                        "embedding_model": embedding_model,
                         "db_path": working_path / "file_store",
                     },
                 )
@@ -254,8 +260,14 @@ class Application:
             if config.backend not in R.file_watchers:
                 logger.warning(f"File watcher backend {config.backend} is not supported.")
             else:
+                file_store = self.service_context.file_stores.get(config.file_store)
+                if file_store is None and config.file_store:
+                    logger.warning(
+                        f"File store '{config.file_store}' not found for file watcher '{name}', "
+                        f"file indexing will be disabled.",
+                    )
                 config_dict = config.model_dump(exclude={"backend", "file_store"})
-                config_dict["file_store"] = self.service_context.file_stores[config.file_store]
+                config_dict["file_store"] = file_store
                 self.service_context.file_watchers[name] = R.file_watchers[config.backend](**config_dict)
                 await self.service_context.file_watchers[name].start()
 

--- a/tests/test_application_start.py
+++ b/tests/test_application_start.py
@@ -1,0 +1,61 @@
+"""Tests for Application.start() graceful degradation when dependencies are missing.
+
+Covers the scenario where embedding model is not configured, ensuring
+file_store and file_watcher initialize without KeyError.
+
+Usage:
+    pytest tests/test_application_start.py -v
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from reme.reme_light import ReMeLight
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.mark.asyncio
+async def test_start_without_embedding_config(temp_dir):
+    """Application.start() should succeed when embedding model is not configured.
+
+    This reproduces the bug where copaw worker starts without EMBEDDING_API_KEY,
+    causing KeyError: 'default' during file_watcher initialization.
+    """
+    app = ReMeLight(
+        working_dir=str(temp_dir),
+        default_file_store_config={
+            "backend": "chroma",
+            "store_name": "copaw",
+            "vector_enabled": False,
+            "fts_enabled": True,
+        },
+    )
+
+    # Should not raise KeyError
+    await app.start()
+
+    # file_store should be initialized (with embedding_model=None)
+    assert "default" in app.service_context.file_stores
+    # file_watcher should be initialized (with file_store resolved)
+    assert "default" in app.service_context.file_watchers
+
+    await app.close()
+
+
+@pytest.mark.asyncio
+async def test_start_without_any_optional_config(temp_dir):
+    """Application.start() should succeed with minimal config (no embedding, no file_store)."""
+    app = ReMeLight(
+        working_dir=str(temp_dir),
+    )
+
+    await app.start()
+    await app.close()


### PR DESCRIPTION
## Summary

- When embedding config is missing (no `EMBEDDING_API_KEY`/`EMBEDDING_BASE_URL`), `Application.start()` crashes with `KeyError: 'default'` during file_watcher initialization
- Root cause: `application.py` uses direct dict access (`self.service_context.embedding_models[config.embedding_model]` and `self.service_context.file_stores[config.file_store]`) which raises KeyError when the referenced dependency wasn't initialized
- Fix: use `.get()` with `None` fallback and warning logs — the infrastructure already supports this (`BaseFileStore` accepts `embedding_model=None` when `vector_enabled=False`, `BaseFileWatcher` accepts `file_store=None`)

## Reproduction

CoPaw worker starts without embedding config → MemoryManager calls `ReMeLight.start()` → file_store init fails (can't find embedding_model "default") → file_watcher init crashes with `KeyError: 'default'` on `file_stores` dict.

## Test plan

- [x] Added `tests/test_application_start.py` with two cases: start without embedding config, start with minimal config
- [x] Existing tests unaffected (pre-existing failures are env-related: missing LLM_API_KEY etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)