### PR TITLE
fix(mcp): resolve circular import issues and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 [project.optional-dependencies]
 core = [
     "agentscope>=2.0.2",
+    "claude-agent-sdk>=0.2.91",
     "faiss-cpu>=1.13.2",
     "jieba>=0.42.1",
     "rjieba>=0.2.1",

--- a/reme/__init__.py
+++ b/reme/__init__.py
@@ -1,6 +1,6 @@
 """ReMe CLI package."""
 
-__version__ = "0.4.0.3"
+__version__ = "0.4.0.4"
 
 from . import config
 from . import constants

--- a/reme/components/client/mcp_client.py
+++ b/reme/components/client/mcp_client.py
@@ -3,21 +3,16 @@
 import json
 import os
 from collections.abc import AsyncGenerator
-from typing import Any
-
-from fastmcp import Client
-from fastmcp.client import SSETransport, StdioTransport, StreamableHttpTransport
-from fastmcp.client.client import CallToolResult
+from typing import TYPE_CHECKING, Any
 
 from .base_client import BaseClient
 from ..component_registry import R
 from ...constants import REME_SERVICE_INFO, REME_DEFAULT_HOST, REME_DEFAULT_PORT
 
-_TRANSPORT_MAP = {
-    "sse": SSETransport,
-    "stdio": StdioTransport,
-    "streamable-http": StreamableHttpTransport,
-}
+if TYPE_CHECKING:
+    from fastmcp.client.client import CallToolResult
+
+_VALID_TRANSPORTS = {"sse", "stdio", "streamable-http"}
 
 
 @R.register("mcp")
@@ -52,8 +47,8 @@ class MCPClient(BaseClient):
     ):
         super().__init__(**kwargs)
 
-        if isinstance(transport, str) and transport not in _TRANSPORT_MAP:
-            raise ValueError(f"Unknown transport: {transport!r}, expected one of {list(_TRANSPORT_MAP)}")
+        if isinstance(transport, str) and transport not in _VALID_TRANSPORTS:
+            raise ValueError(f"Unknown transport: {transport!r}, expected one of {sorted(_VALID_TRANSPORTS)}")
 
         if isinstance(transport, str) and transport != "stdio":
             if not (host and port):
@@ -77,7 +72,14 @@ class MCPClient(BaseClient):
         if not isinstance(self.transport, str):
             return self.transport
 
-        cls = _TRANSPORT_MAP[self.transport]
+        from fastmcp.client import SSETransport, StdioTransport, StreamableHttpTransport
+
+        transport_map = {
+            "sse": SSETransport,
+            "stdio": StdioTransport,
+            "streamable-http": StreamableHttpTransport,
+        }
+        cls = transport_map[self.transport]
 
         if self.transport == "stdio":
             command = self.kwargs.get("command", "")
@@ -91,6 +93,8 @@ class MCPClient(BaseClient):
     # pylint: disable=unnecessary-dunder-call
     async def _start(self) -> None:
         if self.client is None:
+            from fastmcp import Client
+
             self.client = Client(self._build_transport(), timeout=self.timeout)
             await self.client.__aenter__()
 
@@ -99,7 +103,7 @@ class MCPClient(BaseClient):
         if self.client is None:
             raise RuntimeError("Client not initialized. Call _start() first.")
 
-        result: CallToolResult = await self.client.call_tool(action, payload)
+        result: "CallToolResult" = await self.client.call_tool(action, payload)
         yield self._extract_text(result)
 
     async def list_actions(self) -> list[dict]:
@@ -116,7 +120,7 @@ class MCPClient(BaseClient):
             self.client = None
 
     @staticmethod
-    def _extract_text(result: CallToolResult) -> str:
+    def _extract_text(result: "CallToolResult") -> str:
         for block in result.content:
             if hasattr(block, "text"):
                 return block.text

--- a/reme/components/service/mcp_service.py
+++ b/reme/components/service/mcp_service.py
@@ -27,12 +27,6 @@ silently drops keys with hyphens / other chars when projecting onto
 import re
 from typing import TYPE_CHECKING
 
-from fastmcp import FastMCP
-from fastmcp.server.server import Transport
-from fastmcp.tools import FunctionTool
-from mcp.shared.message import SessionMessage
-from mcp.types import JSONRPCMessage, JSONRPCNotification
-
 from .base_service import BaseService
 from ..component_registry import R
 from ..job import BaseJob, StreamJob
@@ -40,6 +34,7 @@ from ...constants import REME_DEFAULT_HOST, REME_DEFAULT_PORT
 from ...utils import get_logger
 
 if TYPE_CHECKING:
+    from fastmcp.server.server import Transport
     from mcp.server.session import ServerSession
 
     from ...application import Application
@@ -69,6 +64,9 @@ class ChannelSink:
         session = self._session
         if session is None:
             return
+
+        from mcp.shared.message import SessionMessage
+        from mcp.types import JSONRPCMessage, JSONRPCNotification
 
         clean_meta = {k: str(v) for k, v in (meta or {}).items() if _IDENT_RE.match(k)}
         message = SessionMessage(
@@ -115,7 +113,7 @@ class MCPService(BaseService):
 
     def __init__(
         self,
-        transport: Transport = "sse",
+        transport: "Transport" = "sse",
         host: str = REME_DEFAULT_HOST,
         port: int = REME_DEFAULT_PORT,
         **kwargs,
@@ -129,6 +127,8 @@ class MCPService(BaseService):
 
     def build_service(self, app: "Application") -> None:
         """Construct the FastMCP server and publish an unbound ChannelSink."""
+        from fastmcp import FastMCP
+
         app.context.metadata["channel_sink"] = ChannelSink()
         self.service = FastMCP(
             name=app.config.app_name,
@@ -138,6 +138,8 @@ class MCPService(BaseService):
 
     def add_job(self, job: BaseJob) -> bool:
         """Register a non-stream job as an MCP tool; StreamJobs are unsupported."""
+        from fastmcp.tools import FunctionTool
+
         if isinstance(job, StreamJob):
             return False
 

--- a/tests/unit/test_daily_steps.py
+++ b/tests/unit/test_daily_steps.py
@@ -24,10 +24,8 @@ to the plugin layer.
 import asyncio
 import os
 import tempfile
-from datetime import date as _date
-from pathlib import Path
-
 import warnings
+from pathlib import Path
 
 import frontmatter
 

--- a/tests/unit/test_daily_steps.py
+++ b/tests/unit/test_daily_steps.py
@@ -61,7 +61,9 @@ class temp_chdir:
 
 
 def _today() -> str:
-    return _date.today().isoformat()
+    from reme.steps.evolve import now
+
+    return now("Asia/Shanghai").strftime("%Y-%m-%d")
 
 
 async def _make_store_with_dailies(entries: list[tuple[str, str, str]]) -> LocalFileStore:

--- a/tests/unit/test_daily_steps.py
+++ b/tests/unit/test_daily_steps.py
@@ -120,7 +120,9 @@ def test_daily_list_default_date_is_today():
                     ("2026-05-17", "yesterday", "y"),
                 ],
             )
-            step = daily_list_step.DailyListStep(file_store=store)
+            app_context = ApplicationContext(workspace_dir=tmp)
+            app_context.components[ComponentEnum.FILE_STORE] = {"default": store}
+            step = daily_list_step.DailyListStep(file_store=store, app_context=app_context)
             await step()
             payload = _metadata(step)
             assert payload["date"] == _today()


### PR DESCRIPTION
- Moved fastmcp imports inside functions to prevent circular dependencies
- Replaced _TRANSPORT_MAP with _VALID_TRANSPORTS set for transport validation
- Updated version number from 0.4.0.3 to 0.4.0.4
- Added claude-agent-sdk dependency to core optional dependencies
- Used TYPE_CHECKING imports for FastMCP related types
- Restructured transport mapping logic within function scope
- Fixed string annotation for CallToolResult type hints