### PR TITLE
fix(auto-memory): allow explicit daily dates

### DIFF
--- a/docs/zh/auto_memory.md
+++ b/docs/zh/auto_memory.md
@@ -53,6 +53,19 @@ daily/2026-06-20/session-a.md
 这样不同对话不会混在一起。一次需求讨论、一次问题排查、一次文档修改，都可以拥有自己的记忆卡片。以后想知道这一天发生了什么，先看
 `YYYY-MM-DD.md`；想看某段对话沉淀了什么，再进入对应的 `<session_id>.md`。
 
+默认情况下，`auto_memory` 使用应用时区中的运行日期作为 daily 日期。导入历史对话、评测数据或离线 transcript 时，可以传入
+`date=YYYY-MM-DD`，让 daily note 写入对话实际发生的日期：
+
+```bash
+reme auto_memory \
+  date=2023-01-19 \
+  session_id=locomo-session \
+  messages='[{"role":"user","content":"Jon lost his job today."}]'
+```
+
+这只改变 daily 路径和当天索引，例如 `daily/2023-01-19/locomo-session.md` 与 `daily/2023-01-19.md`；原始对话仍保存在
+`session/dialog/<session_id>.jsonl`。
+
 ## 同时保存原始信息
 
 整理后的 daily note 负责“好读”，原始对话负责“可信”。

--- a/docs/zh/quick_start.md
+++ b/docs/zh/quick_start.md
@@ -157,6 +157,15 @@ reme auto_memory \
   memory_hint="记录用户偏好"
 ```
 
+如果要导入历史对话或 benchmark 数据，可显式指定 daily 日期，避免记忆被写到运行当天：
+
+```bash
+reme auto_memory \
+  date=2023-01-19 \
+  session_id=historical-chat \
+  messages='[{"role":"user","content":"Jon lost his job today."}]'
+```
+
 外部资料放入 `resource/YYYY-MM-DD/` 后，默认后台会监听 `md/txt/json/jsonl/csv/yaml/html`。也可以手动触发：
 
 ```bash

--- a/reme/config/default.yaml
+++ b/reme/config/default.yaml
@@ -128,6 +128,10 @@ jobs:
           type: string
           description: "source conversation session identifier"
           default: ""
+        date:
+          type: string
+          description: "optional daily note date in YYYY-MM-DD format; defaults to runtime date"
+          default: ""
         memory_hint:
           type: string
           description: "optional hint"
@@ -543,6 +547,10 @@ jobs:
         session_id:
           type: string
           description: "source conversation session identifier"
+        date:
+          type: string
+          description: "optional daily note date in YYYY-MM-DD format; defaults to runtime date"
+          default: ""
         content:
           type: string
           description: "body"

--- a/reme/steps/evolve/auto_memory.py
+++ b/reme/steps/evolve/auto_memory.py
@@ -8,7 +8,7 @@ from agentscope.message import Msg
 
 from ._evolve import agent_reply_result_text, format_history, now
 from ..base_step import BaseStep
-from ..file_io import refresh_day_index, validate_filename_component, validate_session_id
+from ..file_io import refresh_day_index, validate_daily_date, validate_filename_component, validate_session_id
 from ...components import R
 
 _SESSION_ID_KEY = "session_id"
@@ -201,6 +201,7 @@ class AutoMemoryStep(BaseStep):
         raw_messages = self.context.get("messages") or []
         session_id: str = self.context.get("session_id", "")
         memory_hint: str = self.context.get("memory_hint", "")
+        raw_date = str(self.context.get("date") or "").strip()
         tz = self.app_context.app_config.timezone if self.app_context is not None else None
         current = now(tz)
 
@@ -220,6 +221,12 @@ class AutoMemoryStep(BaseStep):
             self.context.response.answer = "Error: session_id is required"
             self.logger.warning(f"[{self.name}] missing session_id")
             return
+        if raw_date and (err := validate_daily_date(raw_date)):
+            self.context.response.success = False
+            self.context.response.answer = f"Error: {err}"
+            self.context.response.metadata.update({"date": raw_date})
+            self.logger.warning(f"[{self.name}] invalid date={raw_date!r} err={err}")
+            return
 
         await self._save_session_messages(session_id, messages)
 
@@ -230,7 +237,7 @@ class AutoMemoryStep(BaseStep):
             self.logger.info(f"[{self.name}] Skipped: no messages session_id={session_id!r} modified=False")
             return
 
-        day = current.strftime("%Y-%m-%d")
+        day = raw_date or current.strftime("%Y-%m-%d")
         try:
             note = await self._list_session_note(day, session_id)
         except RuntimeError as exc:
@@ -272,7 +279,7 @@ class AutoMemoryStep(BaseStep):
                 self.context.response.success = False
                 self.context.response.answer = str(exc)
                 self.context.response.metadata.update(
-                    {"path": None, "created": created, "modified": False, "n_messages": len(messages)},
+                    {"path": None, "date": day, "created": created, "modified": False, "n_messages": len(messages)},
                 )
                 self.logger.info(f"[{self.name}] post-create list failed session_id={session_id!r} answer={str(exc)!r}")
                 return
@@ -280,7 +287,7 @@ class AutoMemoryStep(BaseStep):
                 self.context.response.success = True
                 self.context.response.answer = agent_reply_result_text(result)
                 self.context.response.metadata.update(
-                    {"path": None, "created": False, "modified": False, "n_messages": len(messages)},
+                    {"path": None, "date": day, "created": False, "modified": False, "n_messages": len(messages)},
                 )
                 self.logger.info(f"[{self.name}] done without note session_id={session_id!r} modified=False")
                 return
@@ -295,6 +302,7 @@ class AutoMemoryStep(BaseStep):
                 self.context.response.metadata.update(
                     {
                         "path": note_path,
+                        "date": day,
                         "created": created,
                         "modified": self._note_modified(before_note_path, before_note_bytes, note_path),
                         "n_messages": len(messages),
@@ -315,6 +323,7 @@ class AutoMemoryStep(BaseStep):
         self.context.response.metadata.update(
             {
                 "path": note_path,
+                "date": day,
                 "created": created,
                 "modified": modified,
                 "n_messages": len(messages),

--- a/reme/steps/evolve/auto_memory.yaml
+++ b/reme/steps/evolve/auto_memory.yaml
@@ -46,7 +46,7 @@ system_prompt_zh: |
   - **永远不要设置 `status`**——它是下游处理保留的字段。
 
 user_message_create: |
-  Today: {today}
+  Daily date: {today}
   Extra hint: {note}
   Session ID: {session_id}
 
@@ -67,10 +67,10 @@ user_message_create: |
   ## Step 2 — Write
 
   Create the note in one shot:
-  `daily_write name=<name> description=<description> session_id={session_id} content=<body>`
+  `daily_write date={today} name=<name> description=<description> session_id={session_id} content=<body>`
 
   - Generate `name` as a concise, stable topic/event filename stem for this memory. Prefer a reusable topic or event summary, optionally in kebab-case.
-  - Do not include today's date or the daily directory date in `name`; the note already lives under today's daily path.
+  - Do not include today's date or the daily directory date in `name`; the note already lives under the target daily path.
   - `name` must be a valid single filename component: no slash, backslash, leading/trailing whitespace, or characters like `< > : " | ? *`.
   - `description` must be a thorough summary of the body — specific enough that the description alone conveys all key information.
 
@@ -82,7 +82,7 @@ user_message_create: |
 
   - Create at most one note for this session.
 user_message_create_zh: |
-  今天：{today}
+  日记日期：{today}
   额外提示：{note}
   Session ID：{session_id}
 
@@ -103,10 +103,10 @@ user_message_create_zh: |
   ## 步骤 2 — 写入
 
   一次性创建笔记：
-  `daily_write name=<name> description=<description> session_id={session_id} content=<正文>`
+  `daily_write date={today} name=<name> description=<description> session_id={session_id} content=<正文>`
 
   - 由你生成 `name`，作为这条记忆简洁、稳定的主题/事件文件名 stem。优先使用可复用的主题或事件总结，可以采用 kebab-case。
-  - `name` 不要包含今天日期或日记目录日期；笔记已经位于当天日记路径下。
+  - `name` 不要包含今天日期或日记目录日期；笔记已经位于目标日记路径下。
   - `name` 必须是合法的单个文件名组件：不能包含 slash、反斜杠、首尾空白，或 `< > : " | ? *` 等字符。
   - `description` 必须是正文的详尽总结——具体到仅凭 description 就能传达全部核心信息。
 
@@ -119,7 +119,7 @@ user_message_create_zh: |
   - 当前 session 最多创建一条笔记。
 
 user_message_update: |
-  Today: {today}
+  Daily date: {today}
   Extra hint: {note}
   Target path: {note_path}
 
@@ -178,7 +178,7 @@ user_message_update: |
   - `write` unconditionally overwrites body and frontmatter — use with caution.
   - Filename changes are expressed by updating frontmatter `name`.
 user_message_update_zh: |
-  今天：{today}
+  日记日期：{today}
   额外提示：{note}
   目标路径：{note_path}
 

--- a/reme/steps/file_io/__init__.py
+++ b/reme/steps/file_io/__init__.py
@@ -1,6 +1,6 @@
 """File I/O step helpers."""
 
-from ._daily_index import refresh_day_index, validate_session_id
+from ._daily_index import refresh_day_index, validate_daily_date, validate_session_id
 from ._file_io import write_file_safe
 from ._path import validate_filename_component
 from .daily_list import DailyListStep
@@ -20,6 +20,7 @@ from .write import WriteStep
 
 __all__ = [
     "refresh_day_index",
+    "validate_daily_date",
     "validate_session_id",
     "validate_filename_component",
     "write_file_safe",

--- a/reme/steps/file_io/_daily_index.py
+++ b/reme/steps/file_io/_daily_index.py
@@ -1,5 +1,6 @@
 """Daily-note helpers: session_id validation + day-index rebuild."""
 
+import datetime
 from pathlib import Path
 
 import frontmatter
@@ -13,6 +14,17 @@ logger = get_logger()
 def validate_session_id(session_id: str) -> str | None:
     """Validate a daily-note session_id. Thin wrapper over :func:`validate_filename_component`."""
     return validate_filename_component(session_id, kind="session_id")
+
+
+def validate_daily_date(date: str) -> str | None:
+    """Validate a daily directory date in ISO ``YYYY-MM-DD`` format."""
+    try:
+        parsed = datetime.date.fromisoformat(date)
+    except ValueError:
+        return "date must use YYYY-MM-DD format"
+    if parsed.isoformat() != date:
+        return "date must use YYYY-MM-DD format"
+    return None
 
 
 _NOTES_OPEN = "<!-- notes:auto -->"

--- a/reme/steps/file_io/daily_write.py
+++ b/reme/steps/file_io/daily_write.py
@@ -1,6 +1,6 @@
 """Write a daily markdown note by dispatching the generic ``write`` step."""
 
-from ._daily_index import refresh_day_index, validate_session_id
+from ._daily_index import refresh_day_index, validate_daily_date, validate_session_id
 from ._path import validate_filename_component
 from ..base_step import BaseStep
 from ...components import R
@@ -63,6 +63,18 @@ class DailyWriteStep(BaseStep):
         # ``write`` takes name/description as explicit parameters, not metadata.
         return metadata
 
+    def _target_day(self) -> str | None:
+        assert self.context is not None
+        raw_date = str(self.context.get("date") or "").strip()
+        if raw_date:
+            if err := validate_daily_date(raw_date):
+                self._fail(err, date=raw_date)
+                return None
+            return raw_date
+
+        tz = self.app_context.app_config.timezone if self.app_context is not None else None
+        return now(tz).strftime("%Y-%m-%d")
+
     async def execute(self):
         assert self.context is not None
         collected = self._collect_required()
@@ -70,8 +82,9 @@ class DailyWriteStep(BaseStep):
             return None
 
         name, description, session_id, content = collected
-        tz = self.app_context.app_config.timezone if self.app_context is not None else None
-        day = now(tz).strftime("%Y-%m-%d")
+        day = self._target_day()
+        if day is None:
+            return None
         daily_dir = self.config_value("daily_dir")
         path = f"{daily_dir}/{day}/{name}.md"
         source_conversation = self._session_link(session_id)

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -1122,6 +1122,52 @@ def test_auto_memory_reports_modified_for_create_and_false_for_skip():
     asyncio.run(run())
 
 
+def test_auto_memory_accepts_explicit_date():
+    """AutoMemoryStep uses an explicit daily date instead of runtime date when provided."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            app_ctx = _make_app_context(cwd)
+            fs = LocalFileStore(name="test_store", embedding_store="")
+            wrapper = _FakeAgentWrapper()
+            await fs.start()
+            _install_file_jobs(app_ctx, fs)
+            try:
+                wrapper.on_reply = lambda *_: write_file(
+                    cwd / "daily" / "2023-01-19" / "memory.md",
+                    "---\nname: memory\nsession_id: s1\n"
+                    "source_conversation: '[[session/dialog/s1.jsonl]]'\n---\nbody\n",
+                )
+                step = AutoMemoryStep(app_context=app_ctx, file_store=fs, agent_wrapper=wrapper)
+                resp = await step(
+                    RuntimeContext(
+                        date="2023-01-19",
+                        messages=[
+                            {
+                                "name": "user",
+                                "role": "user",
+                                "content": "Jon lost his job during this historical conversation.",
+                            },
+                        ],
+                        session_id="s1",
+                    ),
+                )
+                resp = resp or step.context.response
+
+                assert resp.success is True
+                assert resp.metadata["date"] == "2023-01-19"
+                assert resp.metadata["path"] == "daily/2023-01-19/memory.md"
+                assert "Daily date: 2023-01-19" in wrapper.inputs
+                assert "daily_write date=2023-01-19" in wrapper.inputs
+                assert (cwd / "daily" / "2023-01-19.md").is_file()
+            finally:
+                await fs.close()
+        print("✓ test_auto_memory_accepts_explicit_date passed")
+
+    asyncio.run(run())
+
+
 def test_auto_resource_result_hook_is_optional_and_isolated():
     """AutoResourceStep optionally emits host result hooks without coupling."""
 
@@ -1221,6 +1267,7 @@ if __name__ == "__main__":
     test_auto_resource_update_keeps_existing_renamed_path()
     test_auto_resource_deletes_loose_root_resource_note_for_today()
     test_auto_resource_deletes_renamed_note_by_source_resource()
+    test_auto_memory_accepts_explicit_date()
     test_auto_resource_result_hook_is_optional_and_isolated()
     # LogChangesStep
     test_log_changes_step()

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -28,6 +28,7 @@ def test_default_config_registers_daily_write_job():
     assert job["backend"] == "base"
     assert job["steps"] == [{"backend": "daily_write_step"}]
     assert job["parameters"]["required"] == ["name", "description", "session_id", "content"]
+    assert "date" in job["parameters"]["properties"]
 
 
 def test_parse_args_rejects_non_key_value_extra_argument():

--- a/tests/unit/test_daily_steps.py
+++ b/tests/unit/test_daily_steps.py
@@ -333,6 +333,35 @@ def test_daily_write_delegates_to_write_and_refreshes_index():
     asyncio.run(run())
 
 
+def test_daily_write_accepts_explicit_date():
+    """``daily_write`` can target a historical daily folder when ``date`` is provided."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            store = await _make_store_with_dailies([])
+            step = await _make_daily_write_step(store, tmp)
+
+            await step(
+                date="2023-01-19",
+                name="historical-memory",
+                description="Historical note",
+                session_id="locomo-session",
+                content="body text",
+            )
+            payload = _metadata(step)
+
+            assert step.context.response.success is True
+            assert payload["date"] == "2023-01-19"
+            assert payload["path"] == "daily/2023-01-19/historical-memory.md"
+            assert (Path(tmp) / "daily" / "2023-01-19" / "historical-memory.md").is_file()
+            assert (Path(tmp) / "daily" / "2023-01-19.md").is_file()
+            assert not (Path(tmp) / "daily" / _today()).exists()
+            await store.close()
+        print("✓ test_daily_write_accepts_explicit_date passed")
+
+    asyncio.run(run())
+
+
 def test_daily_write_reserved_metadata_keys_are_overridden():
     """User metadata cannot override daily_write's fixed frontmatter fields."""
 
@@ -378,6 +407,8 @@ def test_daily_write_rejects_invalid_name_and_session_id():
             await step(name="bad/name", description="d", session_id="ok", content="body")
             assert step.context.response.success is False
             await step(name="ok", description="d", session_id="bad/session", content="body")
+            assert step.context.response.success is False
+            await step(name="ok", description="d", session_id="ok", content="body", date="2023/01/19")
             assert step.context.response.success is False
             assert not (Path(tmp) / "daily" / _today()).exists()
             await store.close()
@@ -626,6 +657,7 @@ if __name__ == "__main__":
     test_daily_list_does_not_refresh_index()
     test_daily_list_response_shape()
     test_daily_write_delegates_to_write_and_refreshes_index()
+    test_daily_write_accepts_explicit_date()
     test_daily_write_reserved_metadata_keys_are_overridden()
     test_daily_write_rejects_invalid_name_and_session_id()
     test_day_index_lists_each_note()


### PR DESCRIPTION
## Summary
- add an optional `date` parameter to `auto_memory` and `daily_write` for historical daily-note targets
- validate explicit daily dates as `YYYY-MM-DD` while preserving the runtime-date default
- document historical conversation usage and add regression coverage

Refs #302

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --python 3.11 --with '.[dev,core]' pytest tests/unit/test_daily_steps.py tests/unit/test_background_steps.py tests/unit/test_config_parser.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python PRE_COMMIT_HOME=/tmp/pre-commit-cache uv run --with pre-commit pre-commit run --files reme/steps/file_io/_daily_index.py reme/steps/file_io/__init__.py reme/steps/file_io/daily_write.py reme/steps/evolve/auto_memory.py reme/steps/evolve/auto_memory.yaml reme/config/default.yaml tests/unit/test_daily_steps.py tests/unit/test_background_steps.py tests/unit/test_config_parser.py docs/zh/quick_start.md docs/zh/auto_memory.md`