### PR TITLE
fix(auto-memory): preserve message timestamps

### DIFF
--- a/docs/zh/auto_memory.md
+++ b/docs/zh/auto_memory.md
@@ -68,6 +68,23 @@ session/
 
 daily note 会指向对应的原始对话。需要核对某条记忆时，可以顺着链接回到当时的完整上下文。
 
+## 消息时间
+
+Auto Memory 会在 prompt 和原始会话 JSONL 中保留每条消息的 `created_at`。导入历史对话或 benchmark 数据时，建议为每条
+message 提供真实发生时间，避免模型把事件时间误解为运行时间：
+
+```bash
+reme auto_memory \
+  session_id=locomo-session \
+  messages='[
+    {"role":"user","content":"Jon lost his job today.","created_at":"2023-01-19T08:00:00"},
+    {"role":"assistant","content":"I am sorry to hear that.","created_at":"2023-01-19T08:01:00"}
+  ]'
+```
+
+为了兼容常见数据集字段，`auto_memory` 也会在缺少 `created_at` 时读取 `time_created`、`timestamp`、`createdAt`、
+`timeCreated` 或 `created_time`。这些字段可以放在 message 顶层，也可以放在 `metadata` 中。
+
 ## 后续流向
 
 Auto Memory 只生成 daily 层记忆。要把这些材料进一步沉淀为长期 `digest/` 节点，使用 [Auto Dream](./auto_dream.md)；要搜索

--- a/docs/zh/auto_memory.md
+++ b/docs/zh/auto_memory.md
@@ -85,6 +85,16 @@ reme auto_memory \
 为了兼容常见数据集字段，`auto_memory` 也会在缺少 `created_at` 时读取 `time_created`、`timestamp`、`createdAt`、
 `timeCreated` 或 `created_time`。这些字段可以放在 message 顶层，也可以放在 `metadata` 中。
 
+当调用没有显式传入 `date` 时，Auto Memory 会使用消息中最早的有效 `created_at` 日期作为 daily note 日期；如果消息没有有效时间，
+则回退到当前日期。历史导入也可以显式指定目标日期：
+
+```bash
+reme auto_memory \
+  session_id=locomo-session \
+  date=2023-01-19 \
+  messages='[{"role":"user","content":"Jon lost his job today."}]'
+```
+
 ## 后续流向
 
 Auto Memory 只生成 daily 层记忆。要把这些材料进一步沉淀为长期 `digest/` 节点，使用 [Auto Dream](./auto_dream.md)；要搜索

--- a/reme/config/default.yaml
+++ b/reme/config/default.yaml
@@ -131,6 +131,10 @@ jobs:
         memory_hint:
           type: string
           description: "optional hint"
+        date:
+          type: string
+          description: "YYYY-MM-DD daily note date; empty = infer from message timestamps or today"
+          default: ""
       required:
         - messages
     steps:
@@ -546,6 +550,10 @@ jobs:
         content:
           type: string
           description: "body"
+        date:
+          type: string
+          description: "YYYY-MM-DD daily note date; empty = today"
+          default: ""
         metadata:
           type: object
           description: "Optional extra frontmatter fields."

--- a/reme/steps/evolve/auto_memory.py
+++ b/reme/steps/evolve/auto_memory.py
@@ -8,7 +8,7 @@ from agentscope.message import Msg
 
 from ._evolve import agent_reply_result_text, format_history, now
 from ..base_step import BaseStep
-from ..file_io import refresh_day_index, validate_filename_component, validate_session_id
+from ..file_io import extract_daily_date, refresh_day_index, validate_filename_component, validate_session_id
 from ...components import R
 
 _SESSION_ID_KEY = "session_id"
@@ -218,12 +218,18 @@ class AutoMemoryStep(BaseStep):
             item = {**item, "content": [{"type": "text", "text": item["content"]}]}
         return Msg.model_validate(item)
 
+    @staticmethod
+    def _messages_day(messages: list[Msg]) -> str | None:
+        days = [day for msg in messages if (day := extract_daily_date(msg.created_at))]
+        return min(days) if days else None
+
     # pylint: disable=too-many-return-statements
     async def execute(self):
         assert self.context is not None
         raw_messages = self.context.get("messages") or []
         session_id: str = self.context.get("session_id", "")
         memory_hint: str = self.context.get("memory_hint", "")
+        raw_date = self.context.get("date", "")
         tz = self.app_context.app_config.timezone if self.app_context is not None else None
         current = now(tz)
 
@@ -246,19 +252,27 @@ class AutoMemoryStep(BaseStep):
 
         await self._save_session_messages(session_id, messages)
 
+        day = extract_daily_date(raw_date) if raw_date else self._messages_day(messages) or current.strftime("%Y-%m-%d")
+        if raw_date and day is None:
+            self.context.response.success = False
+            self.context.response.answer = "Error: date must be YYYY-MM-DD"
+            self.context.response.metadata.update({"date": raw_date, "modified": False, "n_messages": len(messages)})
+            self.logger.warning(f"[{self.name}] invalid date={raw_date!r}")
+            return
+
         if not messages:
             self.context.response.success = True
             self.context.response.answer = "Skipped: no messages"
-            self.context.response.metadata.update({"modified": False, "n_messages": 0})
+            self.context.response.metadata.update({"date": day, "modified": False, "n_messages": 0})
             self.logger.info(f"[{self.name}] Skipped: no messages session_id={session_id!r} modified=False")
             return
 
-        day = current.strftime("%Y-%m-%d")
         try:
             note = await self._list_session_note(day, session_id)
         except RuntimeError as exc:
             self.context.response.success = False
             self.context.response.answer = str(exc)
+            self.context.response.metadata.update({"date": day, "modified": False, "n_messages": len(messages)})
             self.logger.info(f"[{self.name}] list failed session_id={session_id!r} answer={str(exc)!r}")
             return
 
@@ -295,7 +309,7 @@ class AutoMemoryStep(BaseStep):
                 self.context.response.success = False
                 self.context.response.answer = str(exc)
                 self.context.response.metadata.update(
-                    {"path": None, "created": created, "modified": False, "n_messages": len(messages)},
+                    {"date": day, "path": None, "created": created, "modified": False, "n_messages": len(messages)},
                 )
                 self.logger.info(f"[{self.name}] post-create list failed session_id={session_id!r} answer={str(exc)!r}")
                 return
@@ -303,7 +317,7 @@ class AutoMemoryStep(BaseStep):
                 self.context.response.success = True
                 self.context.response.answer = agent_reply_result_text(result)
                 self.context.response.metadata.update(
-                    {"path": None, "created": False, "modified": False, "n_messages": len(messages)},
+                    {"date": day, "path": None, "created": False, "modified": False, "n_messages": len(messages)},
                 )
                 self.logger.info(f"[{self.name}] done without note session_id={session_id!r} modified=False")
                 return
@@ -317,6 +331,7 @@ class AutoMemoryStep(BaseStep):
                 self.context.response.answer = str(exc)
                 self.context.response.metadata.update(
                     {
+                        "date": day,
                         "path": note_path,
                         "created": created,
                         "modified": self._note_modified(before_note_path, before_note_bytes, note_path),
@@ -337,6 +352,7 @@ class AutoMemoryStep(BaseStep):
         self.context.response.answer = agent_reply_result_text(result)
         self.context.response.metadata.update(
             {
+                "date": day,
                 "path": note_path,
                 "created": created,
                 "modified": modified,

--- a/reme/steps/evolve/auto_memory.py
+++ b/reme/steps/evolve/auto_memory.py
@@ -13,6 +13,7 @@ from ...components import R
 
 _SESSION_ID_KEY = "session_id"
 _SOURCE_CONVERSATION_KEY = "source_conversation"
+_MESSAGE_TIME_ALIASES = ("time_created", "timestamp", "createdAt", "timeCreated", "created_time")
 
 
 def _sanitize_msg_for_save(msg: Msg) -> Msg:
@@ -32,6 +33,26 @@ def _sanitize_msg_for_save(msg: Msg) -> Msg:
     if not changed:
         return msg
     return msg.model_copy(update={"content": new_content})
+
+
+def _normalize_msg_timestamp(item: dict) -> dict:
+    """Map common message timestamp aliases to AgentScope's ``created_at`` field."""
+    if item.get("created_at"):
+        return item
+
+    for key in _MESSAGE_TIME_ALIASES:
+        value = item.get(key)
+        if value:
+            return {**item, "created_at": value}
+
+    metadata = item.get("metadata")
+    if isinstance(metadata, dict):
+        for key in _MESSAGE_TIME_ALIASES:
+            value = metadata.get(key)
+            if value:
+                return {**item, "created_at": value}
+
+    return item
 
 
 @R.register("auto_memory_step")
@@ -191,6 +212,8 @@ class AutoMemoryStep(BaseStep):
     def _to_msg(item) -> Msg:
         if isinstance(item, Msg):
             return item
+        if isinstance(item, dict):
+            item = _normalize_msg_timestamp(item)
         if isinstance(item, dict) and isinstance(item.get("content"), str):
             item = {**item, "content": [{"type": "text", "text": item["content"]}]}
         return Msg.model_validate(item)

--- a/reme/steps/evolve/auto_memory.py
+++ b/reme/steps/evolve/auto_memory.py
@@ -8,7 +8,8 @@ from agentscope.message import Msg
 
 from ._evolve import agent_reply_result_text, format_history, now
 from ..base_step import BaseStep
-from ..file_io import extract_daily_date, refresh_day_index, validate_filename_component, validate_session_id
+from ..file_io import extract_daily_date, parse_daily_date, refresh_day_index
+from ..file_io import validate_filename_component, validate_session_id
 from ...components import R
 
 _SESSION_ID_KEY = "session_id"
@@ -221,7 +222,7 @@ class AutoMemoryStep(BaseStep):
     @staticmethod
     def _messages_day(messages: list[Msg]) -> str | None:
         days = [day for msg in messages if (day := extract_daily_date(msg.created_at))]
-        return min(days) if days else None
+        return max(days) if days else None
 
     # pylint: disable=too-many-return-statements
     async def execute(self):
@@ -250,15 +251,15 @@ class AutoMemoryStep(BaseStep):
             self.logger.warning(f"[{self.name}] missing session_id")
             return
 
-        await self._save_session_messages(session_id, messages)
-
-        day = extract_daily_date(raw_date) if raw_date else self._messages_day(messages) or current.strftime("%Y-%m-%d")
+        day = parse_daily_date(raw_date) if raw_date else self._messages_day(messages) or current.strftime("%Y-%m-%d")
         if raw_date and day is None:
             self.context.response.success = False
             self.context.response.answer = "Error: date must be YYYY-MM-DD"
             self.context.response.metadata.update({"date": raw_date, "modified": False, "n_messages": len(messages)})
             self.logger.warning(f"[{self.name}] invalid date={raw_date!r}")
             return
+
+        await self._save_session_messages(session_id, messages)
 
         if not messages:
             self.context.response.success = True

--- a/reme/steps/evolve/auto_memory.yaml
+++ b/reme/steps/evolve/auto_memory.yaml
@@ -67,7 +67,7 @@ user_message_create: |
   ## Step 2 — Write
 
   Create the note in one shot:
-  `daily_write name=<name> description=<description> session_id={session_id} content=<body>`
+  `daily_write name=<name> description=<description> session_id={session_id} date={today} content=<body>`
 
   - Generate `name` as a concise, stable topic/event filename stem for this memory. Prefer a reusable topic or event summary, optionally in kebab-case.
   - Do not include today's date or the daily directory date in `name`; the note already lives under today's daily path.
@@ -103,7 +103,7 @@ user_message_create_zh: |
   ## 步骤 2 — 写入
 
   一次性创建笔记：
-  `daily_write name=<name> description=<description> session_id={session_id} content=<正文>`
+  `daily_write name=<name> description=<description> session_id={session_id} date={today} content=<正文>`
 
   - 由你生成 `name`，作为这条记忆简洁、稳定的主题/事件文件名 stem。优先使用可复用的主题或事件总结，可以采用 kebab-case。
   - `name` 不要包含今天日期或日记目录日期；笔记已经位于当天日记路径下。

--- a/reme/steps/file_io/__init__.py
+++ b/reme/steps/file_io/__init__.py
@@ -1,6 +1,6 @@
 """File I/O step helpers."""
 
-from ._daily_index import extract_daily_date, refresh_day_index, validate_session_id
+from ._daily_index import extract_daily_date, parse_daily_date, refresh_day_index, validate_session_id
 from ._file_io import write_file_safe
 from ._path import validate_filename_component
 from .daily_list import DailyListStep
@@ -21,6 +21,7 @@ from .write import WriteStep
 __all__ = [
     "refresh_day_index",
     "extract_daily_date",
+    "parse_daily_date",
     "validate_session_id",
     "validate_filename_component",
     "write_file_safe",

--- a/reme/steps/file_io/__init__.py
+++ b/reme/steps/file_io/__init__.py
@@ -1,6 +1,6 @@
 """File I/O step helpers."""
 
-from ._daily_index import refresh_day_index, validate_session_id
+from ._daily_index import extract_daily_date, refresh_day_index, validate_session_id
 from ._file_io import write_file_safe
 from ._path import validate_filename_component
 from .daily_list import DailyListStep
@@ -20,6 +20,7 @@ from .write import WriteStep
 
 __all__ = [
     "refresh_day_index",
+    "extract_daily_date",
     "validate_session_id",
     "validate_filename_component",
     "write_file_safe",

--- a/reme/steps/file_io/_daily_index.py
+++ b/reme/steps/file_io/_daily_index.py
@@ -1,5 +1,6 @@
 """Daily-note helpers: session_id validation + day-index rebuild."""
 
+import datetime
 from pathlib import Path
 
 import frontmatter
@@ -13,6 +14,18 @@ logger = get_logger()
 def validate_session_id(session_id: str) -> str | None:
     """Validate a daily-note session_id. Thin wrapper over :func:`validate_filename_component`."""
     return validate_filename_component(session_id, kind="session_id")
+
+
+def extract_daily_date(value) -> str | None:
+    """Return ``YYYY-MM-DD`` from a date or timestamp-like value, or ``None`` when invalid."""
+    text = str(value or "").strip()
+    if not text:
+        return None
+    candidate = text[:10]
+    try:
+        return datetime.date.fromisoformat(candidate).isoformat()
+    except ValueError:
+        return None
 
 
 _NOTES_OPEN = "<!-- notes:auto -->"

--- a/reme/steps/file_io/_daily_index.py
+++ b/reme/steps/file_io/_daily_index.py
@@ -28,6 +28,12 @@ def extract_daily_date(value) -> str | None:
         return None
 
 
+def parse_daily_date(value) -> str | None:
+    """Return a strict ``YYYY-MM-DD`` date, or ``None`` when invalid."""
+    text = str(value or "").strip()
+    return extract_daily_date(text) if len(text) == 10 else None
+
+
 _NOTES_OPEN = "<!-- notes:auto -->"
 _NOTES_CLOSE = "<!-- /notes:auto -->"
 _INDEX_HIDDEN_METADATA_KEYS = {"session_id", "source_conversation"}

--- a/reme/steps/file_io/daily_write.py
+++ b/reme/steps/file_io/daily_write.py
@@ -1,6 +1,6 @@
 """Write a daily markdown note by dispatching the generic ``write`` step."""
 
-from ._daily_index import refresh_day_index, validate_session_id
+from ._daily_index import extract_daily_date, refresh_day_index, validate_session_id
 from ._path import validate_filename_component
 from ..base_step import BaseStep
 from ...components import R
@@ -71,7 +71,11 @@ class DailyWriteStep(BaseStep):
 
         name, description, session_id, content = collected
         tz = self.app_context.app_config.timezone if self.app_context is not None else None
-        day = now(tz).strftime("%Y-%m-%d")
+        raw_date = self.context.get("date", "")
+        day = extract_daily_date(raw_date) if raw_date else now(tz).strftime("%Y-%m-%d")
+        if raw_date and day is None:
+            self._fail("date must be YYYY-MM-DD", date=raw_date)
+            return self.context.response
         daily_dir = self.config_value("daily_dir")
         path = f"{daily_dir}/{day}/{name}.md"
         source_conversation = self._session_link(session_id)

--- a/reme/steps/file_io/daily_write.py
+++ b/reme/steps/file_io/daily_write.py
@@ -1,6 +1,6 @@
 """Write a daily markdown note by dispatching the generic ``write`` step."""
 
-from ._daily_index import extract_daily_date, refresh_day_index, validate_session_id
+from ._daily_index import parse_daily_date, refresh_day_index, validate_session_id
 from ._path import validate_filename_component
 from ..base_step import BaseStep
 from ...components import R
@@ -72,7 +72,7 @@ class DailyWriteStep(BaseStep):
         name, description, session_id, content = collected
         tz = self.app_context.app_config.timezone if self.app_context is not None else None
         raw_date = self.context.get("date", "")
-        day = extract_daily_date(raw_date) if raw_date else now(tz).strftime("%Y-%m-%d")
+        day = parse_daily_date(raw_date) if raw_date else now(tz).strftime("%Y-%m-%d")
         if raw_date and day is None:
             self._fail("date must be YYYY-MM-DD", date=raw_date)
             return self.context.response

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -1122,6 +1122,57 @@ def test_auto_memory_reports_modified_for_create_and_false_for_skip():
     asyncio.run(run())
 
 
+def test_auto_memory_uses_message_day_for_historical_create():
+    """AutoMemoryStep creates historical daily notes from message timestamps."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            app_ctx = _make_app_context(cwd)
+            fs = LocalFileStore(name="test_store", embedding_store="")
+            wrapper = _FakeAgentWrapper()
+            await fs.start()
+            _install_file_jobs(app_ctx, fs)
+            try:
+                historical_day = "2023-01-19"
+
+                def write_historical_note(inputs, _kwargs):
+                    assert f"Today: {historical_day}" in inputs
+                    assert f"date={historical_day}" in inputs
+                    write_file(
+                        cwd / "daily" / historical_day / "memory.md",
+                        "---\nname: memory\nsession_id: s1\n"
+                        "source_conversation: '[[session/dialog/s1.jsonl]]'\n---\nbody\n",
+                    )
+
+                wrapper.on_reply = write_historical_note
+                step = AutoMemoryStep(app_context=app_ctx, file_store=fs, agent_wrapper=wrapper)
+                resp = await step(
+                    RuntimeContext(
+                        messages=[
+                            {
+                                "name": "user",
+                                "role": "user",
+                                "content": "remember historical project detail",
+                                "created_at": "2023-01-19T08:00:00",
+                            },
+                        ],
+                        session_id="s1",
+                    ),
+                )
+                resp = resp or step.context.response
+
+                assert resp.success is True
+                assert resp.metadata["date"] == historical_day
+                assert resp.metadata["path"] == "daily/2023-01-19/memory.md"
+                assert (cwd / "daily" / historical_day / "memory.md").is_file()
+            finally:
+                await fs.close()
+        print("✓ test_auto_memory_uses_message_day_for_historical_create passed")
+
+    asyncio.run(run())
+
+
 def test_auto_resource_result_hook_is_optional_and_isolated():
     """AutoResourceStep optionally emits host result hooks without coupling."""
 

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -1173,6 +1173,52 @@ def test_auto_memory_uses_message_day_for_historical_create():
     asyncio.run(run())
 
 
+def test_auto_memory_rejects_invalid_explicit_date_before_saving_session():
+    """Invalid explicit dates fail before writing session history."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            app_ctx = _make_app_context(cwd)
+            fs = LocalFileStore(name="test_store", embedding_store="")
+            wrapper = _FakeAgentWrapper()
+            await fs.start()
+            _install_file_jobs(app_ctx, fs)
+            try:
+                step = AutoMemoryStep(app_context=app_ctx, file_store=fs, agent_wrapper=wrapper)
+                resp = await step(
+                    RuntimeContext(
+                        messages=[
+                            {
+                                "name": "user",
+                                "role": "user",
+                                "content": "remember historical project detail",
+                                "created_at": "2023-01-19T08:00:00",
+                            },
+                        ],
+                        session_id="s1",
+                        date="2023-01-19T08:00:00",
+                    ),
+                )
+                resp = resp or step.context.response
+
+                assert resp.success is False
+                assert resp.answer == "Error: date must be YYYY-MM-DD"
+                assert resp.metadata == {
+                    "date": "2023-01-19T08:00:00",
+                    "modified": False,
+                    "n_messages": 1,
+                }
+                assert not (cwd / "session" / "dialog" / "s1.jsonl").exists()
+                assert not (cwd / "daily").exists()
+                assert wrapper.inputs == ""
+            finally:
+                await fs.close()
+        print("✓ test_auto_memory_rejects_invalid_explicit_date_before_saving_session passed")
+
+    asyncio.run(run())
+
+
 def test_auto_resource_result_hook_is_optional_and_isolated():
     """AutoResourceStep optionally emits host result hooks without coupling."""
 
@@ -1270,6 +1316,8 @@ if __name__ == "__main__":
     test_auto_resource_uniquifies_conflicting_generated_name()
     test_auto_resource_update_finds_renamed_note_by_source_resource()
     test_auto_resource_update_keeps_existing_renamed_path()
+    test_auto_memory_uses_message_day_for_historical_create()
+    test_auto_memory_rejects_invalid_explicit_date_before_saving_session()
     test_auto_resource_deletes_loose_root_resource_note_for_today()
     test_auto_resource_deletes_renamed_note_by_source_resource()
     test_auto_resource_result_hook_is_optional_and_isolated()

--- a/tests/unit/test_daily_steps.py
+++ b/tests/unit/test_daily_steps.py
@@ -333,6 +333,36 @@ def test_daily_write_delegates_to_write_and_refreshes_index():
     asyncio.run(run())
 
 
+def test_daily_write_accepts_explicit_date():
+    """``daily_write`` can write historical notes instead of always using today's folder."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            store = await _make_store_with_dailies([])
+            step = await _make_daily_write_step(store, tmp)
+
+            await step(
+                name="historical-event",
+                description="Historical note",
+                session_id="locomo-session",
+                content="body text",
+                date="2023-01-19",
+            )
+            payload = _metadata(step)
+
+            assert step.context.response.success is True
+            assert payload["date"] == "2023-01-19"
+            assert payload["path"] == "daily/2023-01-19/historical-event.md"
+            assert (Path(tmp) / "daily" / "2023-01-19" / "historical-event.md").is_file()
+            assert "[[daily/2023-01-19/historical-event.md]]" in (Path(tmp) / "daily" / "2023-01-19.md").read_text(
+                encoding="utf-8",
+            )
+            await store.close()
+        print("✓ test_daily_write_accepts_explicit_date passed")
+
+    asyncio.run(run())
+
+
 def test_daily_write_reserved_metadata_keys_are_overridden():
     """User metadata cannot override daily_write's fixed frontmatter fields."""
 
@@ -626,6 +656,7 @@ if __name__ == "__main__":
     test_daily_list_does_not_refresh_index()
     test_daily_list_response_shape()
     test_daily_write_delegates_to_write_and_refreshes_index()
+    test_daily_write_accepts_explicit_date()
     test_daily_write_reserved_metadata_keys_are_overridden()
     test_daily_write_rejects_invalid_name_and_session_id()
     test_day_index_lists_each_note()

--- a/tests/unit/test_daily_steps.py
+++ b/tests/unit/test_daily_steps.py
@@ -363,6 +363,32 @@ def test_daily_write_accepts_explicit_date():
     asyncio.run(run())
 
 
+def test_daily_write_rejects_timestamp_as_explicit_date():
+    """Explicit ``date`` is strict YYYY-MM-DD, not a timestamp-like value."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            store = await _make_store_with_dailies([])
+            step = await _make_daily_write_step(store, tmp)
+
+            await step(
+                name="historical-event",
+                description="Historical note",
+                session_id="locomo-session",
+                content="body text",
+                date="2023-01-19T08:00:00",
+            )
+
+            assert step.context.response.success is False
+            assert step.context.response.answer == "Error: date must be YYYY-MM-DD"
+            assert step.context.response.metadata["date"] == "2023-01-19T08:00:00"
+            assert not (Path(tmp) / "daily").exists()
+            await store.close()
+        print("✓ test_daily_write_rejects_timestamp_as_explicit_date passed")
+
+    asyncio.run(run())
+
+
 def test_daily_write_reserved_metadata_keys_are_overridden():
     """User metadata cannot override daily_write's fixed frontmatter fields."""
 
@@ -657,6 +683,7 @@ if __name__ == "__main__":
     test_daily_list_response_shape()
     test_daily_write_delegates_to_write_and_refreshes_index()
     test_daily_write_accepts_explicit_date()
+    test_daily_write_rejects_timestamp_as_explicit_date()
     test_daily_write_reserved_metadata_keys_are_overridden()
     test_daily_write_rejects_invalid_name_and_session_id()
     test_day_index_lists_each_note()

--- a/tests/unit/test_evolve_utils.py
+++ b/tests/unit/test_evolve_utils.py
@@ -1,9 +1,11 @@
 """Tests for shared evolve helpers."""
 
+# pylint: disable=protected-access
+
 from agentscope.message import Msg
 
-from reme.steps.evolve._evolve import agent_reply_result_text
-from reme.steps.evolve.auto_memory import _sanitize_msg_for_save
+from reme.steps.evolve._evolve import agent_reply_result_text, format_history
+from reme.steps.evolve.auto_memory import AutoMemoryStep, _sanitize_msg_for_save
 
 
 def test_agent_reply_result_text_uses_last_text_block():
@@ -67,3 +69,46 @@ def test_sanitize_msg_for_save_drops_tool_results_and_base64_data():
     assert [block.type for block in sanitized.content] == ["text", "tool_call"]
     assert sanitized.content[0].text == "real conversation"
     assert sanitized.content[1].name == "memory_search"
+
+
+def test_auto_memory_accepts_message_timestamp_aliases():
+    """AutoMemoryStep preserves historical message timestamps from common benchmark fields."""
+    top_level = AutoMemoryStep._to_msg(
+        {
+            "name": "user",
+            "role": "user",
+            "content": "first event",
+            "time_created": "2023-01-19T08:00:00",
+        },
+    )
+    nested = AutoMemoryStep._to_msg(
+        {
+            "name": "assistant",
+            "role": "assistant",
+            "content": "second event",
+            "metadata": {"timestamp": "2023-01-20T09:30:00"},
+        },
+    )
+
+    history = format_history([top_level, nested])
+
+    assert top_level.created_at == "2023-01-19T08:00:00"
+    assert nested.created_at == "2023-01-20T09:30:00"
+    assert "[user @ 2023-01-19T08:00:00]" in history
+    assert "[assistant @ 2023-01-20T09:30:00]" in history
+
+
+def test_auto_memory_created_at_takes_precedence_over_aliases():
+    """Explicit AgentScope ``created_at`` values are not overwritten by compatibility aliases."""
+    msg = AutoMemoryStep._to_msg(
+        {
+            "name": "user",
+            "role": "user",
+            "content": "event",
+            "created_at": "2023-02-01T00:00:00",
+            "time_created": "2023-01-19T08:00:00",
+            "metadata": {"timestamp": "2023-01-20T09:30:00"},
+        },
+    )
+
+    assert msg.created_at == "2023-02-01T00:00:00"

--- a/tests/unit/test_evolve_utils.py
+++ b/tests/unit/test_evolve_utils.py
@@ -112,3 +112,27 @@ def test_auto_memory_created_at_takes_precedence_over_aliases():
     )
 
     assert msg.created_at == "2023-02-01T00:00:00"
+
+
+def test_auto_memory_derives_day_from_message_timestamps():
+    """Historical imports should anchor the daily note date to message time, not runtime time."""
+    messages = [
+        AutoMemoryStep._to_msg(
+            {
+                "name": "assistant",
+                "role": "assistant",
+                "content": "second event",
+                "created_at": "2023-01-20T09:30:00",
+            },
+        ),
+        AutoMemoryStep._to_msg(
+            {
+                "name": "user",
+                "role": "user",
+                "content": "first event",
+                "metadata": {"timestamp": "2023-01-19T08:00:00"},
+            },
+        ),
+    ]
+
+    assert AutoMemoryStep._messages_day(messages) == "2023-01-19"

--- a/tests/unit/test_evolve_utils.py
+++ b/tests/unit/test_evolve_utils.py
@@ -114,8 +114,8 @@ def test_auto_memory_created_at_takes_precedence_over_aliases():
     assert msg.created_at == "2023-02-01T00:00:00"
 
 
-def test_auto_memory_derives_day_from_message_timestamps():
-    """Historical imports should anchor the daily note date to message time, not runtime time."""
+def test_auto_memory_derives_latest_day_from_message_timestamps():
+    """Historical imports should anchor the daily note date to the latest message time."""
     messages = [
         AutoMemoryStep._to_msg(
             {
@@ -135,4 +135,4 @@ def test_auto_memory_derives_day_from_message_timestamps():
         ),
     ]
 
-    assert AutoMemoryStep._messages_day(messages) == "2023-01-19"
+    assert AutoMemoryStep._messages_day(messages) == "2023-01-20"


### PR DESCRIPTION
## Summary
- normalize common message timestamp aliases to AgentScope's `created_at` field before auto-memory processing
- support aliases at the message top level and inside `metadata` for benchmark imports
- document per-message timestamps in the Auto Memory guide

Refs #302
Follow-up to review feedback on #305.

## Verification
- `PYTHONPATH=$PWD UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --python 3.11 --with '.[dev,core]' pytest tests/unit/test_evolve_utils.py -q`
- `PYLINT_HOME=/tmp/pylint-cache UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python PRE_COMMIT_HOME=/tmp/pre-commit-cache uv run --with pre-commit pre-commit run --files reme/steps/evolve/auto_memory.py tests/unit/test_evolve_utils.py docs/zh/auto_memory.md`