### PR TITLE
fix(auto-memory): preserve temporal grounding in notes

### DIFF
--- a/docs/zh/auto_memory.md
+++ b/docs/zh/auto_memory.md
@@ -95,9 +95,9 @@ reme auto_memory \
   messages='[{"role":"user","content":"Jon lost his job today."}]'
 ```
 
-生成记忆时，Auto Memory 还会要求正文显式区分 `conversation date`、`event date` 和 `relative time`。例如
-`"today"` 会尽量按消息时间解析为事件日期，而不是按系统运行日期解释；不能确定的相对时间会保留原始表达并标明不确定性。
-新建 daily note 时也会写入 `conversation_date` frontmatter，便于后续检索或评测对齐。
+生成记忆时，Auto Memory 会在相关时清楚保留时间事实，避免把 `"today"`、`"yesterday"`、`"recently"` 等相对时间按系统运行日期误解。
+对有歧义的历史导入，可以在正文中使用 `conversation date`、`event date`、`relative time` 这类显式标签，但默认记忆格式不会强制每条
+note 都套用固定标签。新建 daily note 时也会写入 `conversation_date` frontmatter，作为原始对话日期的 provenance 字段；它不一定等同于事件发生日期。
 
 ## 后续流向
 

--- a/docs/zh/auto_memory.md
+++ b/docs/zh/auto_memory.md
@@ -95,6 +95,10 @@ reme auto_memory \
   messages='[{"role":"user","content":"Jon lost his job today."}]'
 ```
 
+生成记忆时，Auto Memory 还会要求正文显式区分 `conversation date`、`event date` 和 `relative time`。例如
+`"today"` 会尽量按消息时间解析为事件日期，而不是按系统运行日期解释；不能确定的相对时间会保留原始表达并标明不确定性。
+新建 daily note 时也会写入 `conversation_date` frontmatter，便于后续检索或评测对齐。
+
 ## 后续流向
 
 Auto Memory 只生成 daily 层记忆。要把这些材料进一步沉淀为长期 `digest/` 节点，使用 [Auto Dream](./auto_dream.md)；要搜索

--- a/reme/steps/evolve/auto_memory.yaml
+++ b/reme/steps/evolve/auto_memory.yaml
@@ -16,10 +16,21 @@ system_prompt: |
 
   Free-form — use whatever structure best fits the content (headings, lists, etc.). The only hard rule is **completeness**.
 
+  ## Temporal Grounding Rules
+
+  When a message includes time information, preserve it explicitly in the note body. Distinguish:
+
+  - `conversation date`: when the source message/conversation happened.
+  - `event date`: when the remembered event happened, if the conversation says or implies it.
+  - `relative time`: phrases such as "today", "yesterday", "last week", or "recently"; resolve them against the conversation date when possible, and keep the original phrase when not certain.
+
+  Do not replace event dates with the system runtime date. If an event date is uncertain, write the uncertainty instead of guessing.
+
   ## Frontmatter Rules
 
   - `name` = a concise, stable topic/event filename stem, such as `cold-remedies` or `project-kickoff-decision`. Do not include today's date or the daily directory date; the outer daily path already records the date. For existing notes, update it when a better filename is clearly warranted.
   - `description` = a thorough summary; vague descriptions like "notes" / "misc" are unacceptable.
+  - `conversation_date` = the daily note date passed to `daily_write` when creating a note.
   - **Never set `status`** — it is a field reserved for downstream processing.
 system_prompt_zh: |
   你是自动记忆系统。你的职责是将最近对话中的核心信息记录到日记记忆中。思考人类会从这段对话中自然地记住什么——不是所有内容，而是真正重要的信息。
@@ -39,10 +50,21 @@ system_prompt_zh: |
 
   自由格式——用最适合内容的结构（标题、列表等）。唯一的硬性规则是**完整性**。
 
+  ## 时间锚定规则
+
+  当消息包含时间信息时，必须在正文中显式保留。区分：
+
+  - `conversation date`：原始消息/对话发生的日期。
+  - `event date`：被记住的事件实际发生日期；如果对话明确或隐含给出，就写出来。
+  - `relative time`：如“今天”“昨天”“上周”“最近”等相对时间；能根据 conversation date 推断时就解析，不能确定时保留原始表达。
+
+  不要用系统运行日期替代事件日期。如果事件日期不确定，就写明不确定，不要猜。
+
   ## Frontmatter 规则
 
   - `name` = 简洁、稳定的主题/事件文件名 stem，例如 `cold-remedies` 或 `project-kickoff-decision`。不要包含今天日期或日记目录日期；外层日记路径已经记录日期。对已有笔记，如果明显有更好的文件名，就更新它。
   - `description` = 详细总结；模糊的描述如 "notes" / "misc" 不可接受。
+  - `conversation_date` = 创建笔记时传给 `daily_write` 的 daily note 日期。
   - **永远不要设置 `status`**——它是下游处理保留的字段。
 
 user_message_create: |
@@ -67,12 +89,13 @@ user_message_create: |
   ## Step 2 — Write
 
   Create the note in one shot:
-  `daily_write name=<name> description=<description> session_id={session_id} date={today} content=<body>`
+  `daily_write name=<name> description=<description> session_id={session_id} date={today} metadata={{"conversation_date":"{today}"}} content=<body>`
 
   - Generate `name` as a concise, stable topic/event filename stem for this memory. Prefer a reusable topic or event summary, optionally in kebab-case.
   - Do not include today's date or the daily directory date in `name`; the note already lives under today's daily path.
   - `name` must be a valid single filename component: no slash, backslash, leading/trailing whitespace, or characters like `< > : " | ? *`.
   - `description` must be a thorough summary of the body — specific enough that the description alone conveys all key information.
+  - In the body, write temporal facts with explicit labels when useful, for example `conversation date: 2023-01-19` and `event date: 2023-01-19`.
 
   ## Step 3 — Summary
 
@@ -103,12 +126,13 @@ user_message_create_zh: |
   ## 步骤 2 — 写入
 
   一次性创建笔记：
-  `daily_write name=<name> description=<description> session_id={session_id} date={today} content=<正文>`
+  `daily_write name=<name> description=<description> session_id={session_id} date={today} metadata={{"conversation_date":"{today}"}} content=<正文>`
 
   - 由你生成 `name`，作为这条记忆简洁、稳定的主题/事件文件名 stem。优先使用可复用的主题或事件总结，可以采用 kebab-case。
   - `name` 不要包含今天日期或日记目录日期；笔记已经位于当天日记路径下。
   - `name` 必须是合法的单个文件名组件：不能包含 slash、反斜杠、首尾空白，或 `< > : " | ? *` 等字符。
   - `description` 必须是正文的详尽总结——具体到仅凭 description 就能传达全部核心信息。
+  - 正文中适合时用显式标签记录时间事实，例如 `conversation date: 2023-01-19` 和 `event date: 2023-01-19`。
 
   ## 步骤 3 — 总结
 

--- a/reme/steps/evolve/auto_memory.yaml
+++ b/reme/steps/evolve/auto_memory.yaml
@@ -18,11 +18,11 @@ system_prompt: |
 
   ## Temporal Grounding Rules
 
-  When a message includes time information, preserve it explicitly in the note body. Distinguish:
+  When a message includes time information that matters for future recall, preserve it clearly in the note body. Do not force a rigid schema for ordinary memories, but keep these distinctions understandable when relevant:
 
-  - `conversation date`: when the source message/conversation happened.
-  - `event date`: when the remembered event happened, if the conversation says or implies it.
-  - `relative time`: phrases such as "today", "yesterday", "last week", or "recently"; resolve them against the conversation date when possible, and keep the original phrase when not certain.
+  - conversation date: when the source message/conversation happened.
+  - event date: when the remembered event happened, if the conversation says or implies it.
+  - relative time: phrases such as "today", "yesterday", "last week", or "recently"; resolve them against the conversation date when possible, and keep the original phrase when not certain.
 
   Do not replace event dates with the system runtime date. If an event date is uncertain, write the uncertainty instead of guessing.
 
@@ -30,7 +30,7 @@ system_prompt: |
 
   - `name` = a concise, stable topic/event filename stem, such as `cold-remedies` or `project-kickoff-decision`. Do not include today's date or the daily directory date; the outer daily path already records the date. For existing notes, update it when a better filename is clearly warranted.
   - `description` = a thorough summary; vague descriptions like "notes" / "misc" are unacceptable.
-  - `conversation_date` = the daily note date passed to `daily_write` when creating a note.
+  - `conversation_date` = the daily note date passed to `daily_write` when creating a note; this is provenance for the source conversation, not necessarily the event date.
   - **Never set `status`** — it is a field reserved for downstream processing.
 system_prompt_zh: |
   你是自动记忆系统。你的职责是将最近对话中的核心信息记录到日记记忆中。思考人类会从这段对话中自然地记住什么——不是所有内容，而是真正重要的信息。
@@ -52,11 +52,11 @@ system_prompt_zh: |
 
   ## 时间锚定规则
 
-  当消息包含时间信息时，必须在正文中显式保留。区分：
+  当消息包含对未来召回有意义的时间信息时，在正文中清楚保留。普通记忆不要强制套用固定格式，但相关时要让这些区别可理解：
 
-  - `conversation date`：原始消息/对话发生的日期。
-  - `event date`：被记住的事件实际发生日期；如果对话明确或隐含给出，就写出来。
-  - `relative time`：如“今天”“昨天”“上周”“最近”等相对时间；能根据 conversation date 推断时就解析，不能确定时保留原始表达。
+  - conversation date：原始消息/对话发生的日期。
+  - event date：被记住的事件实际发生日期；如果对话明确或隐含给出，就写出来。
+  - relative time：如“今天”“昨天”“上周”“最近”等相对时间；能根据 conversation date 推断时就解析，不能确定时保留原始表达。
 
   不要用系统运行日期替代事件日期。如果事件日期不确定，就写明不确定，不要猜。
 
@@ -64,7 +64,7 @@ system_prompt_zh: |
 
   - `name` = 简洁、稳定的主题/事件文件名 stem，例如 `cold-remedies` 或 `project-kickoff-decision`。不要包含今天日期或日记目录日期；外层日记路径已经记录日期。对已有笔记，如果明显有更好的文件名，就更新它。
   - `description` = 详细总结；模糊的描述如 "notes" / "misc" 不可接受。
-  - `conversation_date` = 创建笔记时传给 `daily_write` 的 daily note 日期。
+  - `conversation_date` = 创建笔记时传给 `daily_write` 的 daily note 日期；这是原始对话的 provenance，不一定是事件日期。
   - **永远不要设置 `status`**——它是下游处理保留的字段。
 
 user_message_create: |
@@ -95,7 +95,7 @@ user_message_create: |
   - Do not include today's date or the daily directory date in `name`; the note already lives under today's daily path.
   - `name` must be a valid single filename component: no slash, backslash, leading/trailing whitespace, or characters like `< > : " | ? *`.
   - `description` must be a thorough summary of the body — specific enough that the description alone conveys all key information.
-  - In the body, write temporal facts with explicit labels when useful, for example `conversation date: 2023-01-19` and `event date: 2023-01-19`.
+  - In the body, preserve temporal facts clearly when relevant. Explicit labels such as `conversation date: 2023-01-19` and `event date: 2023-01-19` are useful for ambiguous historical imports, but are not required for every note.
 
   ## Step 3 — Summary
 
@@ -132,7 +132,7 @@ user_message_create_zh: |
   - `name` 不要包含今天日期或日记目录日期；笔记已经位于当天日记路径下。
   - `name` 必须是合法的单个文件名组件：不能包含 slash、反斜杠、首尾空白，或 `< > : " | ? *` 等字符。
   - `description` 必须是正文的详尽总结——具体到仅凭 description 就能传达全部核心信息。
-  - 正文中适合时用显式标签记录时间事实，例如 `conversation date: 2023-01-19` 和 `event date: 2023-01-19`。
+  - 正文中相关时清楚保留时间事实。对有歧义的历史导入，可使用 `conversation date: 2023-01-19` 和 `event date: 2023-01-19` 这类显式标签，但不是每条笔记都必须使用。
 
   ## 步骤 3 — 总结
 

--- a/tests/unit/test_evolve_utils.py
+++ b/tests/unit/test_evolve_utils.py
@@ -136,3 +136,25 @@ def test_auto_memory_derives_latest_day_from_message_timestamps():
     ]
 
     assert AutoMemoryStep._messages_day(messages) == "2023-01-20"
+
+
+def test_auto_memory_prompt_preserves_temporal_grounding_rules():
+    """The memory-writing prompt should keep event time distinct from runtime time."""
+    step = AutoMemoryStep()
+
+    system_prompt = step.prompt_format("system_prompt")
+    create_prompt = step.prompt_format(
+        "user_message_create",
+        today="2023-01-19",
+        note="(none)",
+        session_id="locomo-session",
+        history="[user @ 2023-01-19T08:00:00] Jon lost his job today.",
+    )
+
+    assert "Temporal Grounding Rules" in system_prompt
+    assert "conversation date" in system_prompt
+    assert "event date" in system_prompt
+    assert "relative time" in system_prompt
+    assert "Do not replace event dates with the system runtime date" in system_prompt
+    assert 'metadata={"conversation_date":"2023-01-19"}' in create_prompt
+    assert "event date: 2023-01-19" in create_prompt

--- a/tests/unit/test_evolve_utils.py
+++ b/tests/unit/test_evolve_utils.py
@@ -139,7 +139,7 @@ def test_auto_memory_derives_latest_day_from_message_timestamps():
 
 
 def test_auto_memory_prompt_preserves_temporal_grounding_rules():
-    """The memory-writing prompt should keep event time distinct from runtime time."""
+    """The memory-writing prompt should keep event time distinct without a rigid default format."""
     step = AutoMemoryStep()
 
     system_prompt = step.prompt_format("system_prompt")
@@ -155,6 +155,8 @@ def test_auto_memory_prompt_preserves_temporal_grounding_rules():
     assert "conversation date" in system_prompt
     assert "event date" in system_prompt
     assert "relative time" in system_prompt
+    assert "Do not force a rigid schema for ordinary memories" in system_prompt
     assert "Do not replace event dates with the system runtime date" in system_prompt
+    assert "not necessarily the event date" in system_prompt
     assert 'metadata={"conversation_date":"2023-01-19"}' in create_prompt
-    assert "event date: 2023-01-19" in create_prompt
+    assert "not required for every note" in create_prompt


### PR DESCRIPTION
## Summary
- add explicit temporal grounding rules to the auto-memory prompt
- require created notes to store conversation_date metadata
- document how conversation date, event date, and relative time should be preserved for historical imports

Refs #302

## Verification
- .......                                                                  [100%]
7 passed in 0.91s
- check python ast.........................................................Passed
check yaml...............................................................Passed
check xml............................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
Check package with Pyroma................................................Passed