### PR TITLE
fix(search): boost explicit temporal matches

### DIFF
--- a/docs/zh/memory_search.md
+++ b/docs/zh/memory_search.md
@@ -103,6 +103,7 @@ search:
     - backend: search_step
       vector_weight: 0.7
       candidate_multiplier: 3.0
+      temporal_boost: 0.0
       expand_links: true
       max_links_per_direction: 10
 ```
@@ -137,6 +138,11 @@ fused_score = vector_weight / (60 + vector_rank)
 ```
 
 默认 `vector_weight=0.7`，所以启用 embedding 后语义召回权重更高；关键词仍能把精确词命中的 chunk 拉上来。
+
+`temporal_boost` 默认是 `0.0`，即关闭。将它设为正数后，`search_step` 会从 query 中提取显式日期（例如 `2023-05-07`、
+`19 January 2023` 或 `January 19, 2023`），并轻微提升 path、metadata 或正文中包含同一日期的 chunk。这个机制只适合作为可选的
+reranking fallback；如果问题没有显式日期，例如“Jon 什么时候失业？”，仍应由上层 agent 或策略先推断时间范围，再结合
+`start_date` / `end_date` 过滤或多次检索。
 
 ## BM25 怎么工作
 

--- a/reme/config/default.yaml
+++ b/reme/config/default.yaml
@@ -294,6 +294,7 @@ jobs:
       - backend: search_step
         vector_weight: 0.7
         candidate_multiplier: 3.0
+        temporal_boost: 0.0
         expand_links: true
         max_links_per_direction: 10
 

--- a/reme/steps/index/search.py
+++ b/reme/steps/index/search.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime
+import re
 
 from ..base_step import BaseStep
 from ..file_io import extract_daily_date
@@ -11,6 +12,45 @@ from ...utils import expand_links, render_expansion_lines
 
 _RRF_K = 60
 _MAX_CANDIDATES = 200
+_ISO_DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+_DAY_MONTH_RE = re.compile(
+    r"\b(?P<day>\d{1,2})\s+(?P<month>Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|"
+    r"Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Sept(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)"
+    r",?\s+(?P<year>\d{4})\b",
+    re.IGNORECASE,
+)
+_MONTH_DAY_RE = re.compile(
+    r"\b(?P<month>Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|"
+    r"Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Sept(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)"
+    r"\s+(?P<day>\d{1,2}),?\s+(?P<year>\d{4})\b",
+    re.IGNORECASE,
+)
+_MONTHS = {
+    "jan": 1,
+    "january": 1,
+    "feb": 2,
+    "february": 2,
+    "mar": 3,
+    "march": 3,
+    "apr": 4,
+    "april": 4,
+    "may": 5,
+    "jun": 6,
+    "june": 6,
+    "jul": 7,
+    "july": 7,
+    "aug": 8,
+    "august": 8,
+    "sep": 9,
+    "sept": 9,
+    "september": 9,
+    "oct": 10,
+    "october": 10,
+    "nov": 11,
+    "november": 11,
+    "dec": 12,
+    "december": 12,
+}
 
 
 @R.register("search_step")
@@ -59,7 +99,63 @@ class SearchStep(BaseStep):
             for k in ("vector", "keyword"):
                 v = scores.get(k)
                 parts.append(f"{k}={v:.4f}" if v is not None else f"{k}=-")
+        if scores.get("temporal"):
+            parts.append(f"temporal={scores['temporal']:.4f}")
         return " ".join(parts)
+
+    @staticmethod
+    def _date_from_parts(year: str, month: str, day: str) -> str | None:
+        month_num = _MONTHS.get(month.lower())
+        if month_num is None:
+            return None
+        try:
+            return datetime.date(int(year), month_num, int(day)).isoformat()
+        except ValueError:
+            return None
+
+    @classmethod
+    def _query_dates(cls, query: str) -> set[str]:
+        """Extract explicit date constraints from the query."""
+        dates = set(_ISO_DATE_RE.findall(query))
+        for pattern in (_DAY_MONTH_RE, _MONTH_DAY_RE):
+            for match in pattern.finditer(query):
+                date = cls._date_from_parts(match.group("year"), match.group("month"), match.group("day"))
+                if date:
+                    dates.add(date)
+        return dates
+
+    @staticmethod
+    def _chunk_temporal_text(chunk: FileChunk) -> str:
+        metadata = " ".join(str(value) for value in chunk.metadata.values())
+        return " ".join([chunk.path, metadata, chunk.text])
+
+    @classmethod
+    def _apply_temporal_boost(
+        cls,
+        chunks: list[FileChunk],
+        query: str,
+        temporal_boost: float,
+    ) -> list[FileChunk]:
+        """Optionally boost chunks that mention explicit dates from the query."""
+        if temporal_boost <= 0.0:
+            return chunks
+        query_dates = cls._query_dates(query)
+        if not query_dates:
+            return chunks
+
+        boosted: list[FileChunk] = []
+        for chunk in chunks:
+            temporal_text = cls._chunk_temporal_text(chunk)
+            matched = [date for date in query_dates if date in temporal_text]
+            if not matched:
+                boosted.append(chunk)
+                continue
+            c = chunk.model_copy(deep=False)
+            score = chunk.score * (1.0 + temporal_boost)
+            c.scores = {**chunk.scores, "score": score, "temporal": temporal_boost}
+            boosted.append(c)
+        boosted.sort(key=lambda r: r.score, reverse=True)
+        return boosted
 
     async def execute(self):
         assert self.context is not None
@@ -68,6 +164,7 @@ class SearchStep(BaseStep):
         min_score: float = float(self.context.get("min_score") or 0.0)
         vector_weight: float = float(self.kwargs.get("vector_weight", 0.7))
         candidate_multiplier: float = float(self.kwargs.get("candidate_multiplier", 3.0))
+        temporal_boost: float = float(self.kwargs.get("temporal_boost", 0.0))
         expand_links_enabled: bool = bool(self.kwargs.get("expand_links", True))
         max_links_per_direction: int = int(self.kwargs.get("max_links_per_direction", 10))
         strict_date_filter: bool = bool(
@@ -140,6 +237,8 @@ class SearchStep(BaseStep):
             fused = keyword_results
         else:
             fused = self._rrf_merge(vector_results, keyword_results, vector_weight)
+
+        fused = self._apply_temporal_boost(fused, query, temporal_boost)
 
         if min_score > 0.0:
             fused = [c for c in fused if c.score >= min_score]

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -30,6 +30,15 @@ def test_default_config_registers_daily_write_job():
     assert job["parameters"]["required"] == ["name", "description", "session_id", "content"]
 
 
+def test_default_config_exposes_search_temporal_boost():
+    """``search`` exposes an opt-in temporal reranking weight."""
+    cfg = _load_config("default.yaml")
+
+    step = cfg["jobs"]["search"]["steps"][0]
+    assert step["backend"] == "search_step"
+    assert step["temporal_boost"] == 0.0
+
+
 def test_parse_args_rejects_non_key_value_extra_argument():
     """Extra CLI arguments must use key=value syntax."""
     with pytest.raises(ValueError, match="expected key=value"):

--- a/tests/unit/test_search_step.py
+++ b/tests/unit/test_search_step.py
@@ -64,6 +64,7 @@ def _chunk(
     score_key: str,
     score: float,
     line: int = 1,
+    metadata: dict | None = None,
 ) -> FileChunk:
     return FileChunk(
         id=chunk_id,
@@ -71,6 +72,7 @@ def _chunk(
         text=text,
         start_line=line,
         end_line=line,
+        metadata=metadata or {},
         scores={score_key: score, "score": score},
     )
 
@@ -141,6 +143,78 @@ def test_search_step_empty_query_fails_before_store_calls():
         assert resp.success is False
         assert resp.answer == "Error: query cannot be empty"
         assert not store.calls
+
+    asyncio.run(run())
+
+
+def test_search_step_boosts_chunks_matching_query_dates_when_enabled():
+    """Explicit-date boosting is available when explicitly enabled."""
+
+    async def run():
+        generic = _chunk("generic", "daily/2026-06-28/generic.md", "Jon lost his job.", "keyword", 1.0)
+        temporal = _chunk(
+            "temporal",
+            "daily/2023-01-19/jon-job.md",
+            "conversation date: 2023-01-19\nevent date: 2023-01-19\nJon lost his job.",
+            "keyword",
+            0.9,
+        )
+        store = FakeSearchStore(keyword_results=[generic, temporal])
+        step = SearchStep(file_store=store, temporal_boost=0.2, expand_links=False)
+
+        resp = await step(RuntimeContext(query="When did Jon lose his job on 19 January 2023?", limit=2))
+
+        assert [r["id"] for r in resp.metadata["results"]] == ["temporal", "generic"]
+        assert resp.metadata["results"][0]["scores"]["temporal"] == 0.2
+        assert "temporal=0.2000" in resp.answer
+
+    asyncio.run(run())
+
+
+def test_search_step_temporal_boost_is_off_by_default():
+    """Default search ranking does not apply heuristic explicit-date boosts."""
+
+    async def run():
+        generic = _chunk("generic", "daily/2026-06-28/generic.md", "Jon lost his job.", "keyword", 1.0)
+        temporal = _chunk(
+            "temporal",
+            "daily/2023-01-19/jon-job.md",
+            "conversation date: 2023-01-19\nevent date: 2023-01-19\nJon lost his job.",
+            "keyword",
+            0.9,
+        )
+        store = FakeSearchStore(keyword_results=[generic, temporal])
+        step = SearchStep(file_store=store, expand_links=False)
+
+        resp = await step(RuntimeContext(query="When did Jon lose his job on 19 January 2023?", limit=2))
+
+        assert [r["id"] for r in resp.metadata["results"]] == ["generic", "temporal"]
+        assert "temporal" not in resp.metadata["results"][0]["scores"]
+        assert "temporal=" not in resp.answer
+
+    asyncio.run(run())
+
+
+def test_search_step_temporal_boost_uses_chunk_metadata():
+    """Temporal boost can match structured date metadata when chunks carry it."""
+
+    async def run():
+        generic = _chunk("generic", "daily/generic.md", "Caroline attended a support group.", "keyword", 1.0)
+        temporal = _chunk(
+            "temporal",
+            "daily/caroline.md",
+            "Caroline attended a support group.",
+            "keyword",
+            0.9,
+            metadata={"conversation_date": "2023-05-07"},
+        )
+        store = FakeSearchStore(keyword_results=[generic, temporal])
+        step = SearchStep(file_store=store, temporal_boost=0.2, expand_links=False)
+
+        resp = await step(RuntimeContext(query="Caroline support group 2023-05-07", limit=2))
+
+        assert [r["id"] for r in resp.metadata["results"]] == ["temporal", "generic"]
+        assert resp.metadata["results"][0]["scores"]["temporal"] == 0.2
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- extract explicit dates from search queries, including ISO dates and common English date forms
- apply a small temporal score boost when chunk path, metadata, or text mentions the same date
- expose temporal score contributions in search output metadata/answer lines

Refs #302

## Verification
- .....                                                                    [100%]
5 passed in 0.86s
- check python ast.........................................................Passed
check yaml...........................................(no files to check)Skipped
check xml............................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
Check package with Pyroma................................................Passed