### PR TITLE
fix(as_embedding): support both agentscope 2.0.2 and 2.0.3

### DIFF
--- a/reme/components/as_embedding/__init__.py
+++ b/reme/components/as_embedding/__init__.py
@@ -1,5 +1,6 @@
 """AgentScope embedding model wrappers."""
 
+import inspect
 from typing import Any
 
 from agentscope.credential import (
@@ -50,16 +51,21 @@ class BaseAsEmbedding(BaseComponent):
         if model_cls is None:
             raise ValueError(f"{self.credential_cls.__name__} does not support embeddings.")
 
-        params_dict = dict(kwargs.pop("parameters", None) or {})
-        # agentscope >=2.0.2 takes `dimensions` as an explicit constructor
-        # argument rather than reading it from Parameters. Accept it from the
-        # component top level or (for backward-compatible configs) from
-        # parameters, and pass it through explicitly.
-        dimensions = kwargs.pop("dimensions", None)
-        if dimensions is None:
-            dimensions = params_dict.pop("dimensions", None)
+        params_dict = kwargs.pop("parameters", None)
         parameters = model_cls.Parameters(**params_dict) if params_dict else None
-        self.model = model_cls(credential=credential, dimensions=dimensions, parameters=parameters, **kwargs)
+
+        # agentscope 2.0.3 made ``dimensions`` a required first-class
+        # constructor argument, while keeping a backward-compat backfill
+        # that promotes it from ``parameters.dimensions`` when the explicit
+        # value is ``None``.  2.0.2 has no such argument and reads
+        # ``dimensions`` straight from ``Parameters``.  Keep ``dimensions``
+        # in ``Parameters`` for both, and on 2.0.3 pass ``dimensions=None``
+        # so its backfill picks it up.
+        extra: dict[str, Any] = {}
+        if "dimensions" in inspect.signature(model_cls.__init__).parameters:
+            extra["dimensions"] = None
+
+        self.model = model_cls(credential=credential, parameters=parameters, **extra, **kwargs)
 
 
 @R.register("openai")


### PR DESCRIPTION
2.0.3 promoted `dimensions` to a required first-class constructor argument while keeping a backfill from `parameters.dimensions`; 2.0.2 has no such argument and reads `dimensions` from `Parameters`. Keep `dimensions` in `Parameters` for both versions and, when the model constructor accepts `dimensions`, pass `dimensions=None` so 2.0.3's backfill promotes it out of `parameters`.