### PR TITLE
refactor(embedding): update embedding model initialization and session storage paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
 [project.optional-dependencies]
 core = [
-    "agentscope==2.0.3",
+    "agentscope==2.0.4",
     "claude-agent-sdk>=0.2.91",
     "faiss-cpu>=1.13.2",
     "jieba>=0.42.1",

--- a/reme/__init__.py
+++ b/reme/__init__.py
@@ -1,6 +1,6 @@
 """ReMe CLI package."""
 
-__version__ = "0.4.0.7"
+__version__ = "0.4.0.8"
 
 from . import config
 from . import constants

--- a/reme/application.py
+++ b/reme/application.py
@@ -49,7 +49,14 @@ class Application(BaseComponent):
         cfg = self.config
         workspace_path = Path(cfg.workspace_dir).absolute()
         workspace_path.mkdir(parents=True, exist_ok=True)
-        for subdir in [cfg.metadata_dir, cfg.session_dir, cfg.resource_dir, cfg.daily_dir, cfg.digest_dir]:
+        for subdir in [
+            cfg.metadata_dir,
+            cfg.session_dir,
+            cfg.mem_session_dir,
+            cfg.resource_dir,
+            cfg.daily_dir,
+            cfg.digest_dir,
+        ]:
             if subdir:
                 (workspace_path / subdir).mkdir(parents=True, exist_ok=True)
 

--- a/reme/components/agent_wrapper/as_agent_wrapper.py
+++ b/reme/components/agent_wrapper/as_agent_wrapper.py
@@ -120,8 +120,8 @@ class AsAgentWrapper(BaseAgentWrapper):
     def session_path(self) -> Path:
         """Directory used for persisted AgentScope sessions."""
         if self.app_context is None:
-            return self.workspace_path / "session" / "agentscope"
-        return self.workspace_path / self.app_context.app_config.session_dir / "agentscope"
+            return self.workspace_path / "mem_session" / "agentscope"
+        return self.workspace_path / self.app_context.app_config.mem_session_dir / "agentscope"
 
     @staticmethod
     def _validate_session_id(session_id: str, field: str = "session_id") -> str:

--- a/reme/components/agent_wrapper/cc_agent_wrapper.py
+++ b/reme/components/agent_wrapper/cc_agent_wrapper.py
@@ -192,8 +192,8 @@ class CcAgentWrapper(BaseAgentWrapper):
     def session_path(self) -> Path:
         """Directory used for persisted Claude Code sessions."""
         if self.app_context is None:
-            return self.workspace_path / "session"
-        return self.workspace_path / self.app_context.app_config.session_dir
+            return self.workspace_path / "mem_session"
+        return self.workspace_path / self.app_context.app_config.mem_session_dir
 
     def _ensure_claude_skill_dir(self, config_dir: Path) -> None:
         """Expose project skills through Claude Code skill discovery locations."""

--- a/reme/components/as_embedding/__init__.py
+++ b/reme/components/as_embedding/__init__.py
@@ -1,6 +1,5 @@
 """AgentScope embedding model wrappers."""
 
-import inspect
 from typing import Any
 
 from agentscope.credential import (
@@ -51,21 +50,16 @@ class BaseAsEmbedding(BaseComponent):
         if model_cls is None:
             raise ValueError(f"{self.credential_cls.__name__} does not support embeddings.")
 
+        dimensions = kwargs.pop("dimensions")
         params_dict = kwargs.pop("parameters", None)
         parameters = model_cls.Parameters(**params_dict) if params_dict else None
 
-        # agentscope 2.0.3 made ``dimensions`` a required first-class
-        # constructor argument, while keeping a backward-compat backfill
-        # that promotes it from ``parameters.dimensions`` when the explicit
-        # value is ``None``.  2.0.2 has no such argument and reads
-        # ``dimensions`` straight from ``Parameters``.  Keep ``dimensions``
-        # in ``Parameters`` for both, and on 2.0.3 pass ``dimensions=None``
-        # so its backfill picks it up.
-        extra: dict[str, Any] = {}
-        if "dimensions" in inspect.signature(model_cls.__init__).parameters:
-            extra["dimensions"] = None
-
-        self.model = model_cls(credential=credential, parameters=parameters, **extra, **kwargs)
+        self.model = model_cls(
+            credential=credential,
+            dimensions=dimensions,
+            parameters=parameters,
+            **kwargs,
+        )
 
 
 @R.register("openai")

--- a/reme/config/default.yaml
+++ b/reme/config/default.yaml
@@ -603,11 +603,11 @@ components:
     default:
       backend: ${EMBEDDING_BACKEND:-openai}
       model: ${EMBEDDING_MODEL_NAME:-text-embedding-v4}
+      dimensions: 1024
       credential:
         api_key: ${EMBEDDING_API_KEY:-}
         base_url: ${EMBEDDING_BASE_URL:-https://dashscope.aliyuncs.com/compatible-mode/v1}
-      parameters:
-        dimensions: 1024
+      parameters: { }
 
   embedding_store:
     default:

--- a/reme/config/jinli_lme.yaml
+++ b/reme/config/jinli_lme.yaml
@@ -95,11 +95,11 @@ components:
     default:
       backend: ${EMBEDDING_BACKEND:-openai}
       model: ${EMBEDDING_MODEL_NAME:-text-embedding-v4}
+      dimensions: 1024
       credential:
         api_key: ${EMBEDDING_API_KEY:-}
         base_url: ${EMBEDDING_BASE_URL:-https://dashscope.aliyuncs.com/compatible-mode/v1}
-      parameters:
-        dimensions: 1024
+      parameters: { }
 
   embedding_store:
     default:

--- a/reme/schema/application_config.py
+++ b/reme/schema/application_config.py
@@ -31,6 +31,7 @@ class ApplicationConfig(BaseModel):
     workspace_dir: str = Field(default=".reme", description="Workspace root directory for runtime files")
     metadata_dir: str = Field(default="metadata", description="Subdirectory for ReMe persistent state")
     session_dir: str = Field(default="session", description="Subdirectory for persisted agent sessions")
+    mem_session_dir: str = Field(default="mem_session", description="Subdirectory for persisted agent sessions")
     resource_dir: str = Field(default="resource", description="Subdirectory for external assets")
     daily_dir: str = Field(default="daily", description="Subdirectory for daily memory")
     digest_dir: str = Field(default="digest", description="Subdirectory for digest memory")

--- a/tests/integration/_workspace_fixture.py
+++ b/tests/integration/_workspace_fixture.py
@@ -492,13 +492,12 @@ class WorkspaceEnv:
             return []
         return sorted(digest_root.rglob("*.md"))
 
-    def session_state_files(self, prefix: str = "session_state_") -> list[Path]:
-        """All session-state jsonl files (the agent wrapper writes these under
-        ``resource/`` whenever a ``session_id`` is provided)."""
-        resource_dir = self.workspace_dir / "resource"
-        if not resource_dir.exists():
+    def session_state_files(self, prefix: str = "") -> list[Path]:
+        """All AgentScope session-state jsonl files."""
+        session_dir = self.workspace_dir / "mem_session" / "agentscope"
+        if not session_dir.exists():
             return []
-        return sorted(resource_dir.rglob(f"{prefix}*.jsonl"))
+        return sorted(session_dir.rglob(f"{prefix}*.jsonl"))
 
     # ----- async wait helpers --------------------------------------------
 

--- a/tests/integration/test_auto_dream.py
+++ b/tests/integration/test_auto_dream.py
@@ -125,7 +125,7 @@ def test_auto_dream_and_proactive():
                         topic_diversity_days=7,
                     )
                 dumped = await recorder.dump()
-                session_jsonl = sorted((env.workspace_dir / "session" / "agentscope").glob("*.jsonl"))
+                session_jsonl = sorted((env.workspace_dir / "mem_session" / "agentscope").glob("*.jsonl"))
                 message_files = [*dumped, *session_jsonl]
                 _print_message_files(message_files)
 

--- a/tests/integration/test_auto_resource.py
+++ b/tests/integration/test_auto_resource.py
@@ -115,7 +115,7 @@ def test_auto_resource_create():
                 file_path = env.place_resource(RESOURCE_FILENAME, RESOURCE_CONTENT_V1)
                 note_stem = _compute_note_stem(RESOURCE_FILENAME)
                 agent_session_id = _compute_agent_session_id(file_path)
-                expected_session_jsonl = env.workspace_dir / "session" / "agentscope" / f"{agent_session_id}.jsonl"
+                expected_session_jsonl = env.workspace_dir / "mem_session" / "agentscope" / f"{agent_session_id}.jsonl"
 
                 print(f"[CREATE] file_path           = {file_path}")
                 print(f"[CREATE] note_stem           = {note_stem}")
@@ -145,7 +145,7 @@ def test_auto_resource_create():
                 assert expected_session_jsonl.is_file(), (
                     f"agent session not persisted at {expected_session_jsonl}; "
                     f"AgentScope files: "
-                    f"{[p.name for p in (env.workspace_dir / 'session' / 'agentscope').glob('*.jsonl')]}"
+                    f"{[p.name for p in (env.workspace_dir / 'mem_session' / 'agentscope').glob('*.jsonl')]}"
                 )
 
                 note_text = _print_text_file("CREATE result.md", note_path)
@@ -201,7 +201,7 @@ def test_auto_resource_update():
                 file_path = env.place_resource(RESOURCE_FILENAME, RESOURCE_CONTENT_V1)
                 note_stem = _compute_note_stem(RESOURCE_FILENAME)
                 agent_session_id = _compute_agent_session_id(file_path)
-                session_jsonl = env.workspace_dir / "session" / "agentscope" / f"{agent_session_id}.jsonl"
+                session_jsonl = env.workspace_dir / "mem_session" / "agentscope" / f"{agent_session_id}.jsonl"
 
                 response = await app.run_job("auto_resource", changes=[{"path": file_path, "change": "added"}])
                 assert response.success is True, f"Initial create failed: {response.answer!r}"


### PR DESCRIPTION
- Remove unused inspect import from as_embedding module
- Pass dimensions directly to embedding model constructor instead of using parameters
- Update session state file paths to use mem_session directory instead of resource
- Add mem_session_dir configuration option to application config schema
- Update workspace directory creation to include new mem_session directory
- Change AgentScope and Claude Code session paths to use mem_session directory
- Move embedding dimensions from parameters to top-level configuration
- Update AgentScope dependency version from 2.0.3 to 2.0.4
- Update integration tests to reflect new session file location paths