### PR TITLE
feat(benchmark): add lme_one_question job to jinli_lme.yaml

### DIFF
--- a/reme/config/jinli_lme.yaml
+++ b/reme/config/jinli_lme.yaml
@@ -92,6 +92,41 @@ jobs:
     steps:
       - backend: python_execute_step
 
+  lme_one_question:
+    backend: base
+    description: "Run context_answer_step + answer_judge_step for a single LME question."
+    parameters:
+      type: object
+      properties:
+        query:
+          type: string
+          description: "the LME question being answered"
+        session_context:
+          type: string
+          description: "concatenated chat history for the relevant session"
+        current_date:
+          type: string
+          description: "today's date in YYYY-MM-DD, used to resolve relative phrases"
+        agent_answer:
+          type: string
+          description: "answer from the agent-under-test; can be the value of `context_answer` from a prior call"
+        golden_answer:
+          type: string
+          description: "ground-truth answer from the LME dataset"
+        question_type:
+          type: string
+          description: "LME category; one of temporal_reasoning / knowledge_update / single_session_preference / other"
+      required:
+        - query
+        - session_context
+        - current_date
+        - agent_answer
+        - golden_answer
+        - question_type
+    steps:
+      - backend: context_answer_step
+      - backend: answer_judge_step
+
 components:
   tokenizer:
     default:

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -86,3 +86,27 @@ def test_expand_env_vars_converts_expanded_scalar_types(monkeypatch):
         "url": "http://localhost:18080",
         "string_bool": "false",
     }
+
+
+def test_jinli_lme_config_registers_lme_one_question_job():
+    """``jinli_lme.yaml`` exposes a ``lme_one_question`` job that bundles the
+    LME ``context_answer`` and ``answer_judge`` steps and requires every
+    input the two steps consume."""
+    cfg = _load_config("jinli_lme.yaml")
+
+    job = cfg["jobs"]["lme_one_question"]
+    assert job["backend"] == "base"
+    assert [step["backend"] for step in job["steps"]] == [
+        "context_answer_step",
+        "answer_judge_step",
+    ]
+    assert job["parameters"]["required"] == [
+        "query",
+        "session_context",
+        "current_date",
+        "agent_answer",
+        "golden_answer",
+        "question_type",
+    ]
+    props = set(job["parameters"]["properties"])
+    assert props == set(job["parameters"]["required"])


### PR DESCRIPTION
## Summary
- Appends a single new job `lme_one_question` to `reme/config/jinli_lme.yaml`.
- The job wires the two LME steps added in #326 (`context_answer_step`, `answer_judge_step`) so the LME harness can POST one HTTP request per question and get both the direct-context answer and the LLM-judge verdict back in one round trip.
- All six LME-relevant fields (`query`, `session_context`, `current_date`, `agent_answer`, `golden_answer`, `question_type`) are declared as required parameters with per-field descriptions, matching the input contract of the two steps.
- No runtime code, prompts, or `default.yaml` are touched.

## Why a separate, additive PR
The shipped `jinli_lme.yaml` only registered `update_index` / `auto_memory` / `version` / `search`, leaving benchmark authors to either re-derive the wiring or write a duplicate config. Adding a dedicated job matches #326's intent, is one self-contained stanza, and is documented in the new `docs/en|lme_benchmark.md`/`zh` pages (PR #332) as the canonical harness entry point.

The job is opt-in: existing jobs in `jinli_lme.yaml` keep their behavior, and `reme start config=jinli_lme.yaml` does not auto-register any new dispatch. Only an explicit `reme app lme_one_question ...` invocation reaches the new path.

## Verification
- `python -c 'import yaml; yaml.safe_load(open("reme/config/jinli_lme.yaml"))'` → loads with `jobs.lme_one_question` present, steps `[context_answer_step, answer_judge_step]`, all six parameters required.
- `pre-commit run --files reme/config/jinli_lme.yaml` → all hooks green (yaml check + pyroma only; Python-side hooks skipped as expected for a YAML-only diff).