### PR TITLE
fix(cli): avoid starting unrelated components for one-shot jobs

### DIFF
--- a/reme/application.py
+++ b/reme/application.py
@@ -3,6 +3,7 @@
 import asyncio
 import heapq
 from concurrent.futures import ThreadPoolExecutor
+from types import CodeType
 from pathlib import Path
 from typing import AsyncGenerator, TypeVar
 
@@ -173,14 +174,81 @@ class Application(BaseComponent):
                     )
         return in_degree, dependents
 
+    def _job_component_order(self, job: BaseJob) -> list[BaseComponent]:
+        """Return only the configured components referenced by a job's steps, with dependencies first."""
+        from .steps.base_step import BaseStep, Ref
+
+        nodes: dict[_NodeKey, BaseComponent] = {
+            (ctype, name): comp for ctype, group in self.context.components.items() for name, comp in group.items()
+        }
+        required: set[_NodeKey] = set()
+
+        def code_references(code: CodeType, name: str) -> bool:
+            return name in code.co_names or any(
+                isinstance(const, CodeType) and code_references(const, name) for const in code.co_consts
+            )
+
+        def step_references(step_cls: type[BaseStep], name: str) -> bool:
+            for cls in step_cls.__mro__:
+                if cls is BaseStep:
+                    break
+                for value in cls.__dict__.values():
+                    target = value
+                    if isinstance(value, (staticmethod, classmethod)):
+                        target = value.__func__
+                    elif isinstance(value, property):
+                        target = value.fget
+                    code = getattr(target, "__code__", None)
+                    if isinstance(code, CodeType) and code_references(code, name):
+                        return True
+            return False
+
+        def add_required(key: _NodeKey) -> None:
+            if key not in nodes:
+                raise ValueError(f"Job '{job.name}' depends on unregistered {key[0].value}:{key[1]}")
+            if key in required:
+                return
+            required.add(key)
+            for dep in nodes[key].dependencies:
+                dep_key = (dep.ctype, dep.name)
+                if dep_key in nodes:
+                    add_required(dep_key)
+                elif not dep.optional:
+                    raise ValueError(
+                        f"Component {key[0].value}:{key[1]} depends on unregistered " f"{dep.ctype.value}:{dep.name}",
+                    )
+
+        for step_cls, params in job.step_specs:
+            for cls in reversed(step_cls.__mro__):
+                for attr, ref in cls.__dict__.items():
+                    if not isinstance(ref, Ref):
+                        continue
+                    value = params.get(attr)
+                    if isinstance(value, BaseComponent):
+                        continue
+                    explicit = value is not None
+                    referenced = step_references(step_cls, attr)
+                    if not explicit and not referenced:
+                        continue
+                    key = (ref.comp_enum, value or "default")
+                    if ref.optional and key not in nodes:
+                        continue
+                    add_required(key)
+
+        return [comp for comp in self._topological_order() if (comp.component_type, comp.name) in required]
+
     # ----- Lifecycle -----------------------------------------------------
+
+    def _start_thread_pool(self) -> None:
+        """Initialize the shared thread pool once when configured."""
+        pool_size = self.config.thread_pool_max_workers
+        if pool_size > 0 and self.context.thread_pool is None:
+            self.context.thread_pool = ThreadPoolExecutor(max_workers=pool_size)
+            self.logger.info(f"Thread pool created with max_workers={pool_size}")
 
     async def _start(self) -> None:
         """Start components, then jobs as base > stream > background > cron."""
-        pool_size = self.config.thread_pool_max_workers
-        if pool_size > 0:
-            self.context.thread_pool = ThreadPoolExecutor(max_workers=pool_size)
-            self.logger.info(f"Thread pool created with max_workers={pool_size}")
+        self._start_thread_pool()
         try:
             components = self._topological_order()
             jobs = list(self.context.jobs.values())
@@ -190,6 +258,20 @@ class Application(BaseComponent):
             cron_jobs = [j for j in jobs if isinstance(j, CronJob)]
             for c in components + base_jobs + stream_jobs + background_jobs + cron_jobs:
                 await self._start_one(c)
+        except Exception:
+            await self._close()
+            raise
+
+    async def start_job(self, name: str) -> None:
+        """Start one job and only the components its configured steps reference."""
+        if name not in self.context.jobs:
+            raise KeyError(f"Job '{name}' not found")
+        self._start_thread_pool()
+        try:
+            job = self.context.jobs[name]
+            await self._start_one(job)
+            for component in self._job_component_order(job):
+                await self._start_one(component)
         except Exception:
             await self._close()
             raise

--- a/reme/components/service/cli_service.py
+++ b/reme/components/service/cli_service.py
@@ -96,7 +96,11 @@ class CliService(BaseService):
         if not self.job:
             raise ValueError("cli service requires service.job")
 
-        await app.start()
+        start_job = getattr(app, "start_job", None)
+        if start_job is None:
+            await app.start()
+        else:
+            await start_job(self.job)
         try:
             response = await app.run_job(self.job, **self.job_args)
             output = self._format_response(response.answer, response.metadata)

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -11,12 +11,13 @@ import pytest
 from reme.enumeration import ComponentEnum
 from reme.application import Application
 from reme.components.base_component import BaseComponent
-from reme.components.component_registry import ComponentRegistry
+from reme.components.component_registry import ComponentRegistry, R
 from reme.components.job.background_job import BackgroundJob
 from reme.components.job.base_job import BaseJob
 from reme.components.job.cron_job import CronJob
 from reme.components.job.stream_job import StreamJob
 from reme.components.job import cron_job as cron_job_module
+from reme.steps import BaseStep
 from reme.schema import ComponentConfig
 
 # -- helpers ------------------------------------------------------------------
@@ -140,6 +141,94 @@ def test_start_without_app_context_raises():
         job = BaseJob(name="j")
         with pytest.raises(RuntimeError, match="app_context must be provided"):
             await job._start()
+
+    asyncio.run(run())
+
+
+def test_application_start_job_skips_unreferenced_components(tmp_path):
+    class FailingEmbedding(BaseComponent):
+        component_type = ComponentEnum.AS_EMBEDDING
+
+        async def _start(self):
+            raise RuntimeError("embedding should not start")
+
+    R.register(FailingEmbedding, "failing_embedding_for_start_job_test")
+
+    async def run():
+        app = Application(
+            workspace_dir=str(tmp_path),
+            enable_logo=False,
+            log_to_console=False,
+            log_to_file=False,
+            service={"backend": "cli"},
+            components={
+                "as_embedding": {
+                    "default": {
+                        "backend": "failing_embedding_for_start_job_test",
+                    },
+                },
+            },
+            jobs={
+                "version": {
+                    "backend": "base",
+                    "steps": [{"backend": "version_step"}],
+                },
+            },
+        )
+        await app.start_job("version")
+        try:
+            response = await app.run_job("version")
+        finally:
+            await app.close()
+
+        assert response.success is True
+        assert response.metadata["version"]
+
+    asyncio.run(run())
+
+
+def test_application_start_job_starts_referenced_step_components(tmp_path):
+    class TrackingFileStore(BaseComponent):
+        component_type = ComponentEnum.FILE_STORE
+
+    class NeedsFileStoreStep(BaseStep):
+        async def execute(self):
+            assert self.context is not None
+            self.context.response.metadata["file_store_started"] = self.file_store.is_started
+            return self.context.response
+
+    R.register(TrackingFileStore, "tracking_file_store_for_start_job_test")
+    R.register(NeedsFileStoreStep, "needs_file_store_for_start_job_test")
+
+    async def run():
+        app = Application(
+            workspace_dir=str(tmp_path),
+            enable_logo=False,
+            log_to_console=False,
+            log_to_file=False,
+            service={"backend": "cli"},
+            components={
+                "file_store": {
+                    "default": {
+                        "backend": "tracking_file_store_for_start_job_test",
+                    },
+                },
+            },
+            jobs={
+                "needs_file_store": {
+                    "backend": "base",
+                    "steps": [{"backend": "needs_file_store_for_start_job_test"}],
+                },
+            },
+        )
+        await app.start_job("needs_file_store")
+        try:
+            response = await app.run_job("needs_file_store")
+        finally:
+            await app.close()
+
+        assert response.success is True
+        assert response.metadata["file_store_started"] is True
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary

- add an `Application.start_job()` path that starts only the selected job and the components referenced by that job's configured steps
- switch the CLI one-shot service to use the narrower job startup path
- add regression coverage for both no-dependency jobs and jobs that do need a referenced component

## Why

The new Windows smoke check in #335 runs `reme start service.backend=cli job=version` without embedding credentials. That command only needs `version_step`, but the previous CLI path called `app.start()` and initialized every configured component, including the default OpenAI embedding wrapper, which fails before the version job can run.

This keeps full `app.start()` behavior unchanged for long-running services while making one-shot CLI jobs avoid unrelated credential requirements.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python PYTHONPATH=$PWD uv run --python 3.11 --with '.[dev,core]' pytest tests/unit/test_job.py tests/unit/test_service.py tests/unit/test_config_parser.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --python 3.11 --with '.[dev,core]' reme start service.backend=cli job=version`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python PRE_COMMIT_HOME=/tmp/pre-commit-version-smoke uv run --with pre-commit pre-commit run --files reme/application.py reme/components/service/cli_service.py tests/unit/test_job.py`
