### PR TITLE
fix(embedding): make input truncation CJK-aware

### DIFF
--- a/reme/components/embedding_store/base_embedding_store.py
+++ b/reme/components/embedding_store/base_embedding_store.py
@@ -35,16 +35,18 @@ class BaseEmbeddingStore(BaseComponent):
     def _truncate(self, text: str) -> str:
         """Truncate text using a CJK-aware character budget.
 
-        Latin characters keep their historical cost of one unit. CJK and
-        other full-width characters cost 1.5 units because they commonly
-        consume more embedding tokens. Integer half-units avoid floating
-        point boundary errors.
+        ASCII text keeps its historical character limit. For non-ASCII text,
+        narrow characters cost one unit while CJK and other full-width
+        characters cost 1.5 units because they commonly consume more
+        embedding tokens. The estimate reserves a 5% safety margin, and
+        integer half-units avoid floating-point boundary errors.
         """
         limit = max(0, self.max_input_length)
         if text.isascii():
             return text[:limit]
 
-        budget = limit * 2
+        # Reserve a 5% safety margin for token estimation.
+        budget = limit * 2 * 95 // 100
         used = 0
         for index, char in enumerate(text):
             used += 3 if unicodedata.east_asian_width(char) in {"W", "F"} else 2

--- a/reme/components/embedding_store/base_embedding_store.py
+++ b/reme/components/embedding_store/base_embedding_store.py
@@ -1,6 +1,7 @@
 """Base embedding store with abstract interface for caching and retrieval."""
 
 from abc import abstractmethod
+import unicodedata
 
 import numpy as np
 
@@ -30,6 +31,26 @@ class BaseEmbeddingStore(BaseComponent):
         self.max_input_length = max_input_length
         self.max_retries = max_retries
         self.is_healthy: bool = True
+
+    def _truncate(self, text: str) -> str:
+        """Truncate text using a CJK-aware character budget.
+
+        Latin characters keep their historical cost of one unit. CJK and
+        other full-width characters cost 1.5 units because they commonly
+        consume more embedding tokens. Integer half-units avoid floating
+        point boundary errors.
+        """
+        limit = max(0, self.max_input_length)
+        if text.isascii():
+            return text[:limit]
+
+        budget = limit * 2
+        used = 0
+        for index, char in enumerate(text):
+            used += 3 if unicodedata.east_asian_width(char) in {"W", "F"} else 2
+            if used > budget:
+                return text[:index]
+        return text
 
     @abstractmethod
     async def health_check(self, timeout: float = 2.0) -> bool:

--- a/reme/components/embedding_store/local_embedding_store.py
+++ b/reme/components/embedding_store/local_embedding_store.py
@@ -84,9 +84,6 @@ class LocalEmbeddingStore(BaseEmbeddingStore):
 
     # -- Batching --
 
-    def _truncate(self, text: str) -> str:
-        return text if len(text) <= self.max_input_length else text[: self.max_input_length]
-
     def _partition_by_cache(self, texts: list[str]) -> tuple[list[np.ndarray | None], list[Miss]]:
         results: list[np.ndarray | None] = [None] * len(texts)
         misses: list[Miss] = []

--- a/tests/unit/test_local_embedding_store.py
+++ b/tests/unit/test_local_embedding_store.py
@@ -46,6 +46,19 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def test_truncate_uses_cjk_aware_integer_budget():
+    """Truncation should preserve ASCII behavior and budget non-ASCII text."""
+    store = BadNodeEmbeddingStore(name="t_base_embedding_truncate", max_input_length=10)
+
+    assert store._truncate("abcdefghijk") == "abcdefghij"
+    assert store._truncate("中文中文中文中文") == "中文中文中文"
+    assert store._truncate("éabcdefghij") == "éabcdefgh"
+
+    store.max_input_length = -1
+    assert store._truncate("text") == ""
+    assert store._truncate("中文") == ""
+
+
 def test_compute_batch_rejects_embeddings_with_wrong_dimension():
     """Provider results with wrong dimensions are not padded, truncated, or cached."""
 


### PR DESCRIPTION
## Summary

This PR makes embedding input truncation aware of CJK and other full-width characters, which typically consume more embedding tokens than ASCII text.

## Motivation

The existing local embedding store truncated every input by its raw Python character count. This treated ASCII and full-width text as equivalent even though CJK and other full-width characters commonly require a larger token budget.

The truncation helper also lived only on LocalEmbeddingStore, preventing other embedding store implementations from sharing the same input-length policy.

## Changes

- Move the truncation helper from LocalEmbeddingStore to BaseEmbeddingStore.
- Preserve the historical character limit and fast path for ASCII input.
- Assign a 1.5-unit cost to Unicode Wide and Fullwidth characters.
- Reserve a 5% safety margin when estimating non-ASCII input length.
- Use integer half-units to avoid floating-point boundary errors.
- Clamp negative maximum input lengths to an empty budget.
- Add regression coverage for ASCII, CJK, narrow non-ASCII, and negative-limit behavior.

## Behavior

Given a configured maximum input length of N:

- ASCII text is truncated to at most N characters, matching the previous behavior.
- Non-ASCII input uses 95% of the configured budget as an estimation safety margin.
- Narrow characters consume one budget unit.
- Wide and full-width characters consume 1.5 budget units.
- Truncation stops before the first character that would exceed the available budget.

## Testing

- uv run pytest tests/unit/test_local_embedding_store.py -q
  - Result: 4 passed
- Repository pre-commit hooks passed.
- Repository pre-push hooks passed, including credential leak detection.
- git diff --check passed.