### PR TITLE
fix(search): honor min_score in plain search steps

### DIFF
--- a/reme/steps/index/bm25_search.py
+++ b/reme/steps/index/bm25_search.py
@@ -47,6 +47,7 @@ class Bm25SearchStep(BaseStep):
         assert self.context is not None
         query: str = (self.context.get("query", "") or "").strip()
         limit: int = int(self.context.get("limit") or 5)
+        min_score: float = float(self.context.get("min_score") or 0.0)
         tool_context_id: str = (self.context.get("tool_context_id", "") or "").strip()
 
         if not query:
@@ -58,6 +59,9 @@ class Bm25SearchStep(BaseStep):
         candidates = min(_MAX_CANDIDATES, max(1, limit * 5))
         results = await self.file_store.keyword_search(query, candidates, {})
         self.logger.info(f"[{self.name}] query={query!r} candidates={candidates} hits={len(results)}")
+
+        if min_score > 0.0:
+            results = [chunk for chunk in results if chunk.score >= min_score]
 
         if tool_context_id:
             results = self._dedupe_tool_context(results, tool_context_id, limit)

--- a/reme/steps/index/vector_search.py
+++ b/reme/steps/index/vector_search.py
@@ -47,6 +47,7 @@ class VectorSearchStep(BaseStep):
         assert self.context is not None
         query: str = (self.context.get("query", "") or "").strip()
         limit: int = int(self.context.get("limit") or 5)
+        min_score: float = float(self.context.get("min_score") or 0.0)
         tool_context_id: str = (self.context.get("tool_context_id", "") or "").strip()
 
         if not query:
@@ -58,6 +59,9 @@ class VectorSearchStep(BaseStep):
         candidates = min(_MAX_CANDIDATES, max(1, limit * 5))
         results = await self.file_store.vector_search(query, candidates, {})
         self.logger.info(f"[{self.name}] query={query!r} candidates={candidates} hits={len(results)}")
+
+        if min_score > 0.0:
+            results = [chunk for chunk in results if chunk.score >= min_score]
 
         if tool_context_id:
             results = self._dedupe_tool_context(results, tool_context_id, limit)

--- a/tests/unit/test_search_step.py
+++ b/tests/unit/test_search_step.py
@@ -7,7 +7,7 @@ from reme.components import ApplicationContext
 from reme.components.runtime_context import RuntimeContext
 from reme.enumeration import LinkScopeEnum
 from reme.schema import FileChunk, FileLink, FileNode
-from reme.steps.index import AddDraftStep, ReadAllDraftStep, SearchStep
+from reme.steps.index import AddDraftStep, Bm25SearchStep, ReadAllDraftStep, SearchStep, VectorSearchStep
 
 
 class FakeSearchStore(BaseFileStore):
@@ -147,6 +147,38 @@ def test_search_step_keyword_only_uses_keyword_scores_and_min_score():
         assert "keyword=4.0000" not in resp.answer
         assert "score=4.0000" in resp.answer
         assert "daily/low.md" not in resp.answer
+
+    asyncio.run(run())
+
+
+def test_plain_search_steps_apply_min_score_before_truncation():
+    """Vector-only and BM25-only tools should not return hits below ``min_score``."""
+
+    async def run():
+        vector_store = FakeSearchStore(
+            vector_results=[
+                _chunk("vector-high", "daily/high.md", "strong vector hit", "vector", 0.9),
+                _chunk("vector-low", "daily/low.md", "weak vector hit", "vector", 0.2),
+            ],
+        )
+        keyword_store = FakeSearchStore(
+            keyword_results=[
+                _chunk("keyword-high", "daily/high.md", "strong keyword hit", "keyword", 4.0),
+                _chunk("keyword-low", "daily/low.md", "weak keyword hit", "keyword", 0.2),
+            ],
+        )
+
+        vector = await VectorSearchStep(file_store=vector_store)(
+            RuntimeContext(query="alpha", limit=5, min_score=0.5),
+        )
+        keyword = await Bm25SearchStep(file_store=keyword_store)(
+            RuntimeContext(query="alpha", limit=5, min_score=1.0),
+        )
+
+        assert [result["id"] for result in vector.metadata["results"]] == ["vector-high"]
+        assert [result["id"] for result in keyword.metadata["results"]] == ["keyword-high"]
+        assert vector.answer == "strong vector hit"
+        assert keyword.answer == "strong keyword hit"
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary

- apply `min_score` to the standalone vector and BM25 search steps
- filter low-scoring chunks before tool-context deduplication and result truncation
- add regression coverage for both search backends

## Root cause

`VectorSearchStep` and `Bm25SearchStep` document score filtering, but their execution paths never read `RuntimeContext.min_score`. As a result, low-confidence hits were returned even when callers supplied a threshold.

## Impact

Custom jobs and agent tools that use the plain vector or BM25 steps now get the same threshold behavior already provided by the hybrid `SearchStep`. The default threshold remains `0.0`, so existing calls without `min_score` are unchanged.

## Verification

```text
PYTHONPATH=$PWD uv run --no-sync --with '.[dev,core]' pytest tests/unit/test_search_step.py -q
# 14 passed

pre-commit run --files reme/steps/index/vector_search.py reme/steps/index/bm25_search.py tests/unit/test_search_step.py
# all hooks passed
```
