### PR TITLE
feat(index): add bounded memory-aware batch processing

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install -e ".[core,benchmark]"
+          pip install agentscope
+          pip install -e .
 
       - name: Run version job
         run: reme start service.backend=cli job=version

--- a/reme/__init__.py
+++ b/reme/__init__.py
@@ -1,6 +1,6 @@
 """ReMe CLI package."""
 
-__version__ = "0.4.1.2"
+__version__ = "0.4.1.3"
 
 from . import config
 from . import constants

--- a/reme/steps/index/update_changes.py
+++ b/reme/steps/index/update_changes.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import math
-import os
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Callable
@@ -17,41 +16,6 @@ from ...components.file_chunker import BaseFileChunker
 from ...enumeration import ComponentEnum
 from ...schema import FileChunk, FileNode
 
-_BATCH_MAX_FILES_ENV = "REME_BATCH_MAX_FILES"
-_BATCH_AVAILABLE_MEMORY_RATIO_ENV = "REME_BATCH_AVAILABLE_MEMORY_RATIO"
-_BATCH_MEMORY_TARGET_BYTES_ENV = "REME_BATCH_MEMORY_TARGET_BYTES"
-_BATCH_MEMORY_EXPANSION_FACTOR_ENV = "REME_BATCH_MEMORY_EXPANSION_FACTOR"
-
-
-def _env_int(name: str, default: int) -> int:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except ValueError as e:
-        raise ValueError(f"{name} must be an integer") from e
-
-
-def _env_float(name: str, default: float) -> float:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    try:
-        return float(value)
-    except ValueError as e:
-        raise ValueError(f"{name} must be a number") from e
-
-
-DEFAULT_BATCH_MAX_FILES = _env_int(_BATCH_MAX_FILES_ENV, 100)
-DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO = _env_float(_BATCH_AVAILABLE_MEMORY_RATIO_ENV, 0.10)
-DEFAULT_BATCH_MEMORY_TARGET_BYTES = _env_int(_BATCH_MEMORY_TARGET_BYTES_ENV, 512 * 1024 * 1024)
-DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR = _env_float(_BATCH_MEMORY_EXPANSION_FACTOR_ENV, 8.0)
-_FILE_MEMORY_OVERHEAD_BYTES = 32 * 1024
-_CHUNK_MEMORY_OVERHEAD_BYTES = 4 * 1024
-_ESTIMATED_CHUNK_BYTES = 10_000
-_FLOAT16_BYTES = 2
-
 
 class ChangeApplyStep(BaseStep):
     """Shared added/modified/deleted handling for index update targets."""
@@ -62,10 +26,14 @@ class ChangeApplyStep(BaseStep):
     def __init__(
         self,
         persist: bool | None = None,
-        batch_max_files: int = DEFAULT_BATCH_MAX_FILES,
-        batch_available_memory_ratio: float = DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO,
-        batch_memory_target_bytes: int = DEFAULT_BATCH_MEMORY_TARGET_BYTES,
-        batch_memory_expansion_factor: float = DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR,
+        batch_max_files: int = 100,
+        batch_available_memory_ratio: float = 0.10,
+        batch_memory_target_bytes: int = 512 * 1024 * 1024,
+        batch_memory_expansion_factor: float = 8.0,
+        file_memory_overhead_bytes: int = 32 * 1024,
+        chunk_memory_overhead_bytes: int = 4 * 1024,
+        estimated_chunk_bytes: int = 10_000,
+        float16_bytes: int = 2,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -74,6 +42,10 @@ class ChangeApplyStep(BaseStep):
         self.batch_available_memory_ratio = float(batch_available_memory_ratio)
         self.batch_memory_target_bytes = int(batch_memory_target_bytes)
         self.batch_memory_expansion_factor = float(batch_memory_expansion_factor)
+        self.file_memory_overhead_bytes = int(file_memory_overhead_bytes)
+        self.chunk_memory_overhead_bytes = int(chunk_memory_overhead_bytes)
+        self.estimated_chunk_bytes = int(estimated_chunk_bytes)
+        self.float16_bytes = int(float16_bytes)
         if self.batch_max_files <= 0:
             raise ValueError("batch_max_files must be greater than zero")
         if not math.isfinite(self.batch_available_memory_ratio) or not 0 < self.batch_available_memory_ratio <= 1:
@@ -82,6 +54,14 @@ class ChangeApplyStep(BaseStep):
             raise ValueError("batch_memory_target_bytes must be greater than zero")
         if not math.isfinite(self.batch_memory_expansion_factor) or self.batch_memory_expansion_factor <= 0:
             raise ValueError("batch_memory_expansion_factor must be finite and greater than zero")
+        if self.file_memory_overhead_bytes < 0:
+            raise ValueError("file_memory_overhead_bytes must be non-negative")
+        if self.chunk_memory_overhead_bytes < 0:
+            raise ValueError("chunk_memory_overhead_bytes must be non-negative")
+        if self.estimated_chunk_bytes <= 0:
+            raise ValueError("estimated_chunk_bytes must be greater than zero")
+        if self.float16_bytes <= 0:
+            raise ValueError("float16_bytes must be greater than zero")
 
     @abstractmethod
     async def build_item(self, path: Path) -> Any:
@@ -254,7 +234,7 @@ class ChangeApplyStep(BaseStep):
     def estimate_source_memory(self, path: Path, size_bytes: int) -> int:
         """Estimate one item before reading it so the current batch can flush first."""
         del path, size_bytes
-        return _FILE_MEMORY_OVERHEAD_BYTES
+        return self.file_memory_overhead_bytes
 
     def estimate_item_memory(self, item: Any, path: Path, size_bytes: int) -> int:
         """Estimate the retained memory for one built target item."""
@@ -357,7 +337,7 @@ class UpdateIndexStep(ChangeApplyStep):
 
     def estimate_source_memory(self, path: Path, size_bytes: int) -> int:
         chunker = self._resolve_chunker(path)
-        chunk_bytes = max(1, int(getattr(chunker, "chunk_byte_size", _ESTIMATED_CHUNK_BYTES)))
+        chunk_bytes = max(1, int(getattr(chunker, "chunk_byte_size", self.estimated_chunk_bytes)))
         estimated_chunks = max(1, (size_bytes + chunk_bytes - 1) // chunk_bytes)
         return self._estimate_index_memory(size_bytes, estimated_chunks)
 
@@ -375,12 +355,12 @@ class UpdateIndexStep(ChangeApplyStep):
         embedding_store = getattr(self.file_store, "embedding_store", None)
         if embedding_store is not None:
             try:
-                embedding_bytes = max(0, int(embedding_store.dimensions)) * _FLOAT16_BYTES
+                embedding_bytes = max(0, int(embedding_store.dimensions)) * self.float16_bytes
             except (AttributeError, TypeError, ValueError):
                 embedding_bytes = 0
         expanded_content = int(size_bytes * self.batch_memory_expansion_factor)
-        per_chunk = _CHUNK_MEMORY_OVERHEAD_BYTES + embedding_bytes
-        return expanded_content + _FILE_MEMORY_OVERHEAD_BYTES + max(0, chunk_count) * per_chunk
+        per_chunk = self.chunk_memory_overhead_bytes + embedding_bytes
+        return expanded_content + self.file_memory_overhead_bytes + max(0, chunk_count) * per_chunk
 
     async def chunk_file(self, path: str | Path) -> tuple[FileNode, list[FileChunk]]:
         """Chunk a file into (node, chunks)."""

--- a/reme/steps/index/update_changes.py
+++ b/reme/steps/index/update_changes.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import math
+import os
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Callable
@@ -20,10 +21,34 @@ DEFAULT_BATCH_MAX_FILES = 100
 DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO = 0.10
 DEFAULT_BATCH_MEMORY_TARGET_BYTES = 512 * 1024 * 1024
 DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR = 8.0
+_BATCH_MAX_FILES_ENV = "REME_BATCH_MAX_FILES"
+_BATCH_AVAILABLE_MEMORY_RATIO_ENV = "REME_BATCH_AVAILABLE_MEMORY_RATIO"
+_BATCH_MEMORY_TARGET_BYTES_ENV = "REME_BATCH_MEMORY_TARGET_BYTES"
+_BATCH_MEMORY_EXPANSION_FACTOR_ENV = "REME_BATCH_MEMORY_EXPANSION_FACTOR"
 _FILE_MEMORY_OVERHEAD_BYTES = 32 * 1024
 _CHUNK_MEMORY_OVERHEAD_BYTES = 4 * 1024
 _ESTIMATED_CHUNK_BYTES = 10_000
 _FLOAT16_BYTES = 2
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as e:
+        raise ValueError(f"{name} must be an integer") from e
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError as e:
+        raise ValueError(f"{name} must be a number") from e
 
 
 class ChangeApplyStep(BaseStep):
@@ -35,18 +60,32 @@ class ChangeApplyStep(BaseStep):
     def __init__(
         self,
         persist: bool | None = None,
-        batch_max_files: int = DEFAULT_BATCH_MAX_FILES,
-        batch_available_memory_ratio: float = DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO,
-        batch_memory_target_bytes: int = DEFAULT_BATCH_MEMORY_TARGET_BYTES,
-        batch_memory_expansion_factor: float = DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR,
+        batch_max_files: int | None = None,
+        batch_available_memory_ratio: float | None = None,
+        batch_memory_target_bytes: int | None = None,
+        batch_memory_expansion_factor: float | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.persist = persist
-        self.batch_max_files = int(batch_max_files)
-        self.batch_available_memory_ratio = float(batch_available_memory_ratio)
-        self.batch_memory_target_bytes = int(batch_memory_target_bytes)
-        self.batch_memory_expansion_factor = float(batch_memory_expansion_factor)
+        self.batch_max_files = (
+            _env_int(_BATCH_MAX_FILES_ENV, DEFAULT_BATCH_MAX_FILES) if batch_max_files is None else int(batch_max_files)
+        )
+        self.batch_available_memory_ratio = (
+            _env_float(_BATCH_AVAILABLE_MEMORY_RATIO_ENV, DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO)
+            if batch_available_memory_ratio is None
+            else float(batch_available_memory_ratio)
+        )
+        self.batch_memory_target_bytes = (
+            _env_int(_BATCH_MEMORY_TARGET_BYTES_ENV, DEFAULT_BATCH_MEMORY_TARGET_BYTES)
+            if batch_memory_target_bytes is None
+            else int(batch_memory_target_bytes)
+        )
+        self.batch_memory_expansion_factor = (
+            _env_float(_BATCH_MEMORY_EXPANSION_FACTOR_ENV, DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR)
+            if batch_memory_expansion_factor is None
+            else float(batch_memory_expansion_factor)
+        )
         if self.batch_max_files <= 0:
             raise ValueError("batch_max_files must be greater than zero")
         if not math.isfinite(self.batch_available_memory_ratio) or not 0 < self.batch_available_memory_ratio <= 1:

--- a/reme/steps/index/update_changes.py
+++ b/reme/steps/index/update_changes.py
@@ -103,15 +103,14 @@ class ChangeApplyStep(BaseStep):
                     continue
                 abs_path, size_bytes = inspected
                 preliminary_bytes = self._try_estimate_memory(
-                    change,
                     path,
-                    results,
                     self.estimate_source_memory,
                     abs_path,
                     size_bytes,
                 )
+                force_single_item_batch = preliminary_bytes is None
                 if preliminary_bytes is None:
-                    continue
+                    preliminary_bytes = memory_budget + 1
                 if items and self._batch_is_full(len(items), estimated_bytes, preliminary_bytes, memory_budget):
                     await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
                     estimated_bytes = 0
@@ -121,16 +120,17 @@ class ChangeApplyStep(BaseStep):
                 if item is None:
                     continue
                 item_bytes = self._try_estimate_memory(
-                    change,
                     path,
-                    results,
                     self.estimate_item_memory,
                     item,
                     abs_path,
                     size_bytes,
                 )
                 if item_bytes is None:
-                    continue
+                    force_single_item_batch = True
+                    item_bytes = memory_budget + 1
+                elif force_single_item_batch:
+                    item_bytes = max(item_bytes, memory_budget + 1)
                 if items and self._batch_is_full(len(items), estimated_bytes, item_bytes, memory_budget):
                     await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
                     estimated_bytes = 0
@@ -143,6 +143,7 @@ class ChangeApplyStep(BaseStep):
                     await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
                     estimated_bytes = 0
                     memory_budget = self._batch_memory_budget()
+                del item
             if items:
                 await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
         return results
@@ -202,18 +203,15 @@ class ChangeApplyStep(BaseStep):
 
     def _try_estimate_memory(
         self,
-        change: Change,
         path: str,
-        results: list[dict],
         estimate: Callable[..., int],
         *args: Any,
     ) -> int | None:
-        """Estimate one item without allowing advisory batching to abort the change set."""
+        """Return an advisory estimate, or ``None`` so the caller can isolate the item."""
         try:
             return max(0, int(estimate(*args)))
         except Exception as e:
-            self.logger.exception(f"Failed to estimate memory for {path}")
-            results.append({"change": change.name, "path": path, "success": False, "error": str(e)})
+            self.logger.warning(f"Failed to estimate memory for {path}; processing it alone: {e}")
             return None
 
     def _batch_memory_budget(self) -> int:

--- a/reme/steps/index/update_changes.py
+++ b/reme/steps/index/update_changes.py
@@ -17,18 +17,10 @@ from ...components.file_chunker import BaseFileChunker
 from ...enumeration import ComponentEnum
 from ...schema import FileChunk, FileNode
 
-DEFAULT_BATCH_MAX_FILES = 100
-DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO = 0.10
-DEFAULT_BATCH_MEMORY_TARGET_BYTES = 512 * 1024 * 1024
-DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR = 8.0
 _BATCH_MAX_FILES_ENV = "REME_BATCH_MAX_FILES"
 _BATCH_AVAILABLE_MEMORY_RATIO_ENV = "REME_BATCH_AVAILABLE_MEMORY_RATIO"
 _BATCH_MEMORY_TARGET_BYTES_ENV = "REME_BATCH_MEMORY_TARGET_BYTES"
 _BATCH_MEMORY_EXPANSION_FACTOR_ENV = "REME_BATCH_MEMORY_EXPANSION_FACTOR"
-_FILE_MEMORY_OVERHEAD_BYTES = 32 * 1024
-_CHUNK_MEMORY_OVERHEAD_BYTES = 4 * 1024
-_ESTIMATED_CHUNK_BYTES = 10_000
-_FLOAT16_BYTES = 2
 
 
 def _env_int(name: str, default: int) -> int:
@@ -51,6 +43,16 @@ def _env_float(name: str, default: float) -> float:
         raise ValueError(f"{name} must be a number") from e
 
 
+DEFAULT_BATCH_MAX_FILES = _env_int(_BATCH_MAX_FILES_ENV, 100)
+DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO = _env_float(_BATCH_AVAILABLE_MEMORY_RATIO_ENV, 0.10)
+DEFAULT_BATCH_MEMORY_TARGET_BYTES = _env_int(_BATCH_MEMORY_TARGET_BYTES_ENV, 512 * 1024 * 1024)
+DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR = _env_float(_BATCH_MEMORY_EXPANSION_FACTOR_ENV, 8.0)
+_FILE_MEMORY_OVERHEAD_BYTES = 32 * 1024
+_CHUNK_MEMORY_OVERHEAD_BYTES = 4 * 1024
+_ESTIMATED_CHUNK_BYTES = 10_000
+_FLOAT16_BYTES = 2
+
+
 class ChangeApplyStep(BaseStep):
     """Shared added/modified/deleted handling for index update targets."""
 
@@ -60,32 +62,18 @@ class ChangeApplyStep(BaseStep):
     def __init__(
         self,
         persist: bool | None = None,
-        batch_max_files: int | None = None,
-        batch_available_memory_ratio: float | None = None,
-        batch_memory_target_bytes: int | None = None,
-        batch_memory_expansion_factor: float | None = None,
+        batch_max_files: int = DEFAULT_BATCH_MAX_FILES,
+        batch_available_memory_ratio: float = DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO,
+        batch_memory_target_bytes: int = DEFAULT_BATCH_MEMORY_TARGET_BYTES,
+        batch_memory_expansion_factor: float = DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.persist = persist
-        self.batch_max_files = (
-            _env_int(_BATCH_MAX_FILES_ENV, DEFAULT_BATCH_MAX_FILES) if batch_max_files is None else int(batch_max_files)
-        )
-        self.batch_available_memory_ratio = (
-            _env_float(_BATCH_AVAILABLE_MEMORY_RATIO_ENV, DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO)
-            if batch_available_memory_ratio is None
-            else float(batch_available_memory_ratio)
-        )
-        self.batch_memory_target_bytes = (
-            _env_int(_BATCH_MEMORY_TARGET_BYTES_ENV, DEFAULT_BATCH_MEMORY_TARGET_BYTES)
-            if batch_memory_target_bytes is None
-            else int(batch_memory_target_bytes)
-        )
-        self.batch_memory_expansion_factor = (
-            _env_float(_BATCH_MEMORY_EXPANSION_FACTOR_ENV, DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR)
-            if batch_memory_expansion_factor is None
-            else float(batch_memory_expansion_factor)
-        )
+        self.batch_max_files = int(batch_max_files)
+        self.batch_available_memory_ratio = float(batch_available_memory_ratio)
+        self.batch_memory_target_bytes = int(batch_memory_target_bytes)
+        self.batch_memory_expansion_factor = float(batch_memory_expansion_factor)
         if self.batch_max_files <= 0:
             raise ValueError("batch_max_files must be greater than zero")
         if not math.isfinite(self.batch_available_memory_ratio) or not 0 < self.batch_available_memory_ratio <= 1:

--- a/reme/steps/index/update_changes.py
+++ b/reme/steps/index/update_changes.py
@@ -1,9 +1,12 @@
-"""Apply file change batches to file_catalog or file_store."""
+"""Apply bounded file change batches to file_catalog or file_store."""
 
+import asyncio
+import math
 from abc import abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
+import psutil
 from watchfiles import Change
 
 from ._change_batch import bucket_changes
@@ -13,6 +16,15 @@ from ...components.file_chunker import BaseFileChunker
 from ...enumeration import ComponentEnum
 from ...schema import FileChunk, FileNode
 
+DEFAULT_BATCH_MAX_FILES = 100
+DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO = 0.10
+DEFAULT_BATCH_MEMORY_TARGET_BYTES = 512 * 1024 * 1024
+DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR = 8.0
+_FILE_MEMORY_OVERHEAD_BYTES = 32 * 1024
+_CHUNK_MEMORY_OVERHEAD_BYTES = 4 * 1024
+_ESTIMATED_CHUNK_BYTES = 10_000
+_FLOAT16_BYTES = 2
+
 
 class ChangeApplyStep(BaseStep):
     """Shared added/modified/deleted handling for index update targets."""
@@ -20,17 +32,33 @@ class ChangeApplyStep(BaseStep):
     target_name = "target"
     reads_file_content = False
 
-    def __init__(self, persist: bool | None = None, **kwargs):
+    def __init__(
+        self,
+        persist: bool | None = None,
+        batch_max_files: int = DEFAULT_BATCH_MAX_FILES,
+        batch_available_memory_ratio: float = DEFAULT_BATCH_AVAILABLE_MEMORY_RATIO,
+        batch_memory_target_bytes: int = DEFAULT_BATCH_MEMORY_TARGET_BYTES,
+        batch_memory_expansion_factor: float = DEFAULT_BATCH_MEMORY_EXPANSION_FACTOR,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.persist = persist
+        self.batch_max_files = int(batch_max_files)
+        self.batch_available_memory_ratio = float(batch_available_memory_ratio)
+        self.batch_memory_target_bytes = int(batch_memory_target_bytes)
+        self.batch_memory_expansion_factor = float(batch_memory_expansion_factor)
+        if self.batch_max_files <= 0:
+            raise ValueError("batch_max_files must be greater than zero")
+        if not math.isfinite(self.batch_available_memory_ratio) or not 0 < self.batch_available_memory_ratio <= 1:
+            raise ValueError("batch_available_memory_ratio must be in the interval (0, 1]")
+        if self.batch_memory_target_bytes <= 0:
+            raise ValueError("batch_memory_target_bytes must be greater than zero")
+        if not math.isfinite(self.batch_memory_expansion_factor) or self.batch_memory_expansion_factor <= 0:
+            raise ValueError("batch_memory_expansion_factor must be finite and greater than zero")
 
     @abstractmethod
     async def build_item(self, path: Path) -> Any:
         """Parse one existing file into the target item shape."""
-
-    @abstractmethod
-    def item_path(self, item: Any) -> str:
-        """Return the target-relative path for an upsert item."""
 
     @abstractmethod
     async def upsert_items(self, items: list[Any]) -> None:
@@ -59,26 +87,78 @@ class ChangeApplyStep(BaseStep):
 
     async def _apply_existing(self, buckets: dict[Change, list[str]]) -> list[dict]:
         results: list[dict] = []
-        for change, action in ((Change.added, "Adding"), (Change.modified, "Updating")):
+        for change in (Change.added, Change.modified):
             paths = buckets[change]
             if not paths:
                 continue
             self.logger.info(f"Detected {len(paths)} {change.name} file(s)")
-            items, ok_paths = [], []
+            items: list[Any] = []
+            ok_paths: list[str] = []
+            estimated_bytes = 0
+            memory_budget = self._batch_memory_budget()
             for path in paths:
-                item = await self._try_build_item(change, action, path, results)
-                if item is not None:
-                    items.append(item)
-                    ok_paths.append(path)
+                await asyncio.sleep(0)
+                inspected = await self._inspect_path(change, path, results)
+                if inspected is None:
+                    continue
+                abs_path, size_bytes = inspected
+                preliminary_bytes = self._try_estimate_memory(
+                    change,
+                    path,
+                    results,
+                    self.estimate_source_memory,
+                    abs_path,
+                    size_bytes,
+                )
+                if preliminary_bytes is None:
+                    continue
+                if items and self._batch_is_full(len(items), estimated_bytes, preliminary_bytes, memory_budget):
+                    await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
+                    estimated_bytes = 0
+                    memory_budget = self._batch_memory_budget()
+
+                item = await self._try_build_item(change, path, abs_path, results)
+                if item is None:
+                    continue
+                item_bytes = self._try_estimate_memory(
+                    change,
+                    path,
+                    results,
+                    self.estimate_item_memory,
+                    item,
+                    abs_path,
+                    size_bytes,
+                )
+                if item_bytes is None:
+                    continue
+                if items and self._batch_is_full(len(items), estimated_bytes, item_bytes, memory_budget):
+                    await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
+                    estimated_bytes = 0
+                    memory_budget = self._batch_memory_budget()
+
+                items.append(item)
+                ok_paths.append(path)
+                estimated_bytes += item_bytes
+                if self._batch_is_full(len(items), estimated_bytes, 0, memory_budget):
+                    await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
+                    estimated_bytes = 0
+                    memory_budget = self._batch_memory_budget()
             if items:
-                results.extend(await self._try_upsert(change, items, ok_paths))
+                await self._flush_upsert_batch(change, items, ok_paths, estimated_bytes, results)
         return results
 
-    async def _try_build_item(self, change: Change, action: str, path: str, results: list[dict]):
+    async def _inspect_path(self, change: Change, path: str, results: list[dict]) -> tuple[Path, int] | None:
         abs_path = self._to_abs_path(path)
         try:
             if not abs_path.is_file():
-                results.append({"change": change.name, "path": path, "success": False, "error": "not a file"})
+                results.append(
+                    {
+                        "change": change.name,
+                        "path": path,
+                        "success": False,
+                        "error": "not a file",
+                    },
+                )
                 return None
             size_bytes = abs_path.stat().st_size
             max_file_bytes = self.max_file_bytes()
@@ -99,16 +179,86 @@ class ChangeApplyStep(BaseStep):
                     },
                 )
                 return None
-            self.logger.info(f"{action} file: {path}")
+            return abs_path, size_bytes
+        except Exception as e:
+            self.logger.exception(f"Failed to process {path}")
+            results.append({"change": change.name, "path": path, "success": False, "error": str(e)})
+            return None
+
+    async def _try_build_item(
+        self,
+        change: Change,
+        path: str,
+        abs_path: Path,
+        results: list[dict],
+    ):
+        try:
+            self.logger.debug(f"Processing {change.name} file: {path}")
             return await self.build_item(abs_path)
         except Exception as e:
             self.logger.exception(f"Failed to process {path}")
             results.append({"change": change.name, "path": path, "success": False, "error": str(e)})
             return None
 
+    def _try_estimate_memory(
+        self,
+        change: Change,
+        path: str,
+        results: list[dict],
+        estimate: Callable[..., int],
+        *args: Any,
+    ) -> int | None:
+        """Estimate one item without allowing advisory batching to abort the change set."""
+        try:
+            return max(0, int(estimate(*args)))
+        except Exception as e:
+            self.logger.exception(f"Failed to estimate memory for {path}")
+            results.append({"change": change.name, "path": path, "success": False, "error": str(e)})
+            return None
+
+    def _batch_memory_budget(self) -> int:
+        """Return the current estimated-memory budget for a new batch."""
+        try:
+            available = max(0, int(psutil.virtual_memory().available))
+        except (AttributeError, OSError, psutil.Error) as e:
+            self.logger.warning(f"Failed to read available memory, using batch memory target: {e}")
+            return self.batch_memory_target_bytes
+        dynamic_budget = int(available * self.batch_available_memory_ratio)
+        return max(1, min(dynamic_budget, self.batch_memory_target_bytes))
+
+    def estimate_source_memory(self, path: Path, size_bytes: int) -> int:
+        """Estimate one item before reading it so the current batch can flush first."""
+        del path, size_bytes
+        return _FILE_MEMORY_OVERHEAD_BYTES
+
+    def estimate_item_memory(self, item: Any, path: Path, size_bytes: int) -> int:
+        """Estimate the retained memory for one built target item."""
+        del item
+        return self.estimate_source_memory(path, size_bytes)
+
+    def _batch_is_full(self, item_count: int, estimated_bytes: int, next_bytes: int, memory_budget: int) -> bool:
+        return item_count >= self.batch_max_files or estimated_bytes + next_bytes > memory_budget
+
+    async def _flush_upsert_batch(
+        self,
+        change: Change,
+        items: list[Any],
+        ok_paths: list[str],
+        estimated_bytes: int,
+        results: list[dict],
+    ) -> None:
+        if not items:
+            return
+        self.logger.info(
+            f"Applying {change.name} batch to {self.target_name}: "
+            f"files={len(items)} estimated_bytes={estimated_bytes}",
+        )
+        results.extend(await self._try_upsert(change, items, ok_paths))
+        items.clear()
+        ok_paths.clear()
+
     async def _try_upsert(self, change: Change, items: list[Any], ok_paths: list[str]) -> list[dict]:
         try:
-            await self.delete_paths([self.item_path(item) for item in items])
             await self.upsert_items(items)
             return [{"change": change.name, "path": p, "success": True} for p in ok_paths]
         except Exception as e:
@@ -119,12 +269,17 @@ class ChangeApplyStep(BaseStep):
         if not deleted:
             return []
         self.logger.info(f"Detected {len(deleted)} deleted file(s)")
-        try:
-            await self.delete_paths([self.to_workspace_relative(p) for p in deleted])
-            return [{"change": "deleted", "path": p, "success": True} for p in deleted]
-        except Exception as e:
-            self.logger.exception(f"Failed to delete {len(deleted)} file(s) from {self.target_name}")
-            return [{"change": "deleted", "path": p, "success": False, "error": str(e)} for p in deleted]
+        results: list[dict] = []
+        for start in range(0, len(deleted), self.batch_max_files):
+            await asyncio.sleep(0)
+            batch = deleted[start : start + self.batch_max_files]
+            try:
+                await self.delete_paths([self.to_workspace_relative(p) for p in batch])
+                results.extend({"change": "deleted", "path": p, "success": True} for p in batch)
+            except Exception as e:
+                self.logger.exception(f"Failed to delete {len(batch)} file(s) from {self.target_name}")
+                results.extend({"change": "deleted", "path": p, "success": False, "error": str(e)} for p in batch)
+        return results
 
     def _to_abs_path(self, path: str | Path) -> Path:
         p = Path(path)
@@ -140,9 +295,6 @@ class UpdateCatalogStep(ChangeApplyStep):
     async def build_item(self, path: Path) -> FileNode:
         stat = path.stat()
         return FileNode(path=self.to_workspace_relative(path), st_mtime=stat.st_mtime)
-
-    def item_path(self, item: FileNode) -> str:
-        return item.path
 
     async def upsert_items(self, items: list[FileNode]) -> None:
         if self.file_catalog is None:
@@ -169,9 +321,6 @@ class UpdateIndexStep(ChangeApplyStep):
     async def build_item(self, path: Path) -> tuple[FileNode, list[FileChunk]]:
         return await self.chunk_file(path)
 
-    def item_path(self, item: tuple[FileNode, list[FileChunk]]) -> str:
-        return item[0].path
-
     async def upsert_items(self, items: list[tuple[FileNode, list[FileChunk]]]) -> None:
         await self.file_store.upsert(items)
 
@@ -180,6 +329,33 @@ class UpdateIndexStep(ChangeApplyStep):
 
     async def dump_target(self) -> None:
         await self.file_store.dump()
+
+    def estimate_source_memory(self, path: Path, size_bytes: int) -> int:
+        chunker = self._resolve_chunker(path)
+        chunk_bytes = max(1, int(getattr(chunker, "chunk_byte_size", _ESTIMATED_CHUNK_BYTES)))
+        estimated_chunks = max(1, (size_bytes + chunk_bytes - 1) // chunk_bytes)
+        return self._estimate_index_memory(size_bytes, estimated_chunks)
+
+    def estimate_item_memory(
+        self,
+        item: tuple[FileNode, list[FileChunk]],
+        path: Path,
+        size_bytes: int,
+    ) -> int:
+        del path
+        return self._estimate_index_memory(size_bytes, len(item[1]))
+
+    def _estimate_index_memory(self, size_bytes: int, chunk_count: int) -> int:
+        embedding_bytes = 0
+        embedding_store = getattr(self.file_store, "embedding_store", None)
+        if embedding_store is not None:
+            try:
+                embedding_bytes = max(0, int(embedding_store.dimensions)) * _FLOAT16_BYTES
+            except (AttributeError, TypeError, ValueError):
+                embedding_bytes = 0
+        expanded_content = int(size_bytes * self.batch_memory_expansion_factor)
+        per_chunk = _CHUNK_MEMORY_OVERHEAD_BYTES + embedding_bytes
+        return expanded_content + _FILE_MEMORY_OVERHEAD_BYTES + max(0, chunk_count) * per_chunk
 
     async def chunk_file(self, path: str | Path) -> tuple[FileNode, list[FileChunk]]:
         """Chunk a file into (node, chunks)."""

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -13,8 +13,6 @@ downstream ``update_index_step`` to consume; tests assert against that key.
 import asyncio
 import datetime
 import os
-import subprocess
-import sys
 import tempfile
 import warnings
 import weakref
@@ -618,6 +616,10 @@ def test_update_catalog_memory_target_limits_cumulative_batch_size():
         ({"batch_available_memory_ratio": float("nan")}, "batch_available_memory_ratio"),
         ({"batch_memory_target_bytes": 0}, "batch_memory_target_bytes"),
         ({"batch_memory_expansion_factor": float("inf")}, "batch_memory_expansion_factor"),
+        ({"file_memory_overhead_bytes": -1}, "file_memory_overhead_bytes"),
+        ({"chunk_memory_overhead_bytes": -1}, "chunk_memory_overhead_bytes"),
+        ({"estimated_chunk_bytes": 0}, "estimated_chunk_bytes"),
+        ({"float16_bytes": 0}, "float16_bytes"),
     ],
 )
 def test_update_step_rejects_invalid_batch_memory_settings(kwargs, message):
@@ -626,59 +628,27 @@ def test_update_step_rejects_invalid_batch_memory_settings(kwargs, message):
         UpdateCatalogStep(**kwargs)
 
 
-def test_update_step_reads_batch_defaults_from_environment():
-    """REME-prefixed environment variables populate constructor defaults at import time."""
-    env = {
-        **os.environ,
-        "REME_BATCH_MAX_FILES": "25",
-        "REME_BATCH_AVAILABLE_MEMORY_RATIO": "0.25",
-        "REME_BATCH_MEMORY_TARGET_BYTES": "1048576",
-        "REME_BATCH_MEMORY_EXPANSION_FACTOR": "4.5",
-    }
-    script = """
-from reme.steps.index.update_changes import UpdateCatalogStep
-step = UpdateCatalogStep()
-print(step.batch_max_files)
-print(step.batch_available_memory_ratio)
-print(step.batch_memory_target_bytes)
-print(step.batch_memory_expansion_factor)
-"""
-
-    output = subprocess.check_output([sys.executable, "-c", script], env=env, text=True)
-
-    assert output.splitlines() == ["25", "0.25", "1048576", "4.5"]
-
-
-def test_update_step_accepts_explicit_batch_setting():
-    """Explicit Step configuration overrides the constructor default."""
-    step = UpdateCatalogStep(batch_max_files=10)
-
-    assert step.batch_max_files == 10
-
-
-@pytest.mark.parametrize(
-    "env_name",
-    [
-        "REME_BATCH_MAX_FILES",
-        "REME_BATCH_AVAILABLE_MEMORY_RATIO",
-        "REME_BATCH_MEMORY_TARGET_BYTES",
-        "REME_BATCH_MEMORY_EXPANSION_FACTOR",
-    ],
-)
-def test_update_step_rejects_non_numeric_batch_environment_values(env_name):
-    """Invalid environment defaults fail with the responsible variable name."""
-    env = {**os.environ, env_name: "invalid"}
-
-    result = subprocess.run(
-        [sys.executable, "-c", "import reme.steps.index.update_changes"],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+def test_update_step_accepts_configured_batch_memory_settings():
+    """Step configuration can override all batching and memory-estimation defaults."""
+    step = UpdateCatalogStep(
+        batch_max_files=25,
+        batch_available_memory_ratio=0.25,
+        batch_memory_target_bytes=1024 * 1024,
+        batch_memory_expansion_factor=4.5,
+        file_memory_overhead_bytes=1024,
+        chunk_memory_overhead_bytes=512,
+        estimated_chunk_bytes=5000,
+        float16_bytes=4,
     )
 
-    assert result.returncode != 0
-    assert env_name in result.stderr
+    assert step.batch_max_files == 25
+    assert step.batch_available_memory_ratio == 0.25
+    assert step.batch_memory_target_bytes == 1024 * 1024
+    assert step.batch_memory_expansion_factor == 4.5
+    assert step.file_memory_overhead_bytes == 1024
+    assert step.chunk_memory_overhead_bytes == 512
+    assert step.estimated_chunk_bytes == 5000
+    assert step.float16_bytes == 4
 
 
 @pytest.mark.parametrize("estimate_method", ["estimate_source_memory", "estimate_item_memory"])

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -18,6 +18,8 @@ import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pytest
 from watchfiles import Change
 
 from reme.components.agent_wrapper import BaseAgentWrapper
@@ -462,6 +464,292 @@ def test_update_catalog_relative_path_uses_workspace():
     asyncio.run(run())
 
 
+def test_update_catalog_upserts_in_batches_of_at_most_100_files():
+    """Large change sets are committed incrementally instead of retained as one list."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            paths = [write_file(cwd / "daily" / f"{index:03d}.md", "x") for index in range(205)]
+            catalog = LocalFileCatalog(name="test_catalog")
+            await catalog.start()
+            batch_sizes = []
+            original_upsert = catalog.upsert
+
+            async def record_upsert(nodes):
+                batch_sizes.append(len(nodes))
+                await original_upsert(nodes)
+
+            try:
+                step = UpdateCatalogStep(file_catalog=catalog, persist=False, app_context=_make_app_context(cwd))
+                changes = [{"change": "added", "path": str(path)} for path in paths]
+                available = MagicMock(available=8 * 1024 * 1024 * 1024)
+                with (
+                    patch.object(catalog, "upsert", side_effect=record_upsert),
+                    patch("reme.steps.index.update_changes.psutil.virtual_memory", return_value=available),
+                ):
+                    response = await step(RuntimeContext(changes=changes))
+
+                assert response.success is True
+                assert batch_sizes == [100, 100, 5]
+                assert len(await catalog.get_nodes()) == 205
+            finally:
+                await catalog.close()
+
+    asyncio.run(run())
+
+
+def test_update_catalog_deletes_in_batches_of_at_most_100_paths():
+    """Large delete sets use the same bounded failure domain as upserts."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            deleted = [cwd / "daily" / f"{index:03d}.md" for index in range(205)]
+            catalog = LocalFileCatalog(name="test_catalog")
+            await catalog.start()
+            batch_sizes = []
+            original_delete = catalog.delete
+
+            async def record_delete(paths):
+                batch_sizes.append(len(paths))
+                await original_delete(paths)
+
+            try:
+                step = UpdateCatalogStep(file_catalog=catalog, persist=False, app_context=_make_app_context(cwd))
+                changes = [{"change": "deleted", "path": str(path)} for path in deleted]
+                with patch.object(catalog, "delete", side_effect=record_delete):
+                    response = await step(RuntimeContext(changes=changes))
+
+                assert response.success is True
+                assert batch_sizes == [100, 100, 5]
+                assert len(response.answer) == 205
+            finally:
+                await catalog.close()
+
+    asyncio.run(run())
+
+
+def test_update_index_memory_budget_can_reduce_batches_to_one_file():
+    """A file larger than the target batch budget is still processed alone."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            paths = [write_file(cwd / "daily" / f"{index}.md", f"# Note {index}\nbody\n") for index in range(3)]
+            fs = LocalFileStore(name="default", embedding_store="")
+            chunker = DefaultFileChunker(supported_extensions=["md"])
+            await fs.start()
+            await chunker.start()
+            batch_sizes = []
+            original_upsert = fs.upsert
+
+            async def record_upsert(items):
+                batch_sizes.append(len(items))
+                await original_upsert(items)
+
+            try:
+                app_ctx = _make_app_context(cwd)
+                app_ctx.components = {ComponentEnum.FILE_CHUNKER: {"default": chunker}}
+                step = UpdateIndexStep(file_store=fs, persist=False, app_context=app_ctx)
+                changes = [{"change": "added", "path": str(path)} for path in paths]
+                available = MagicMock(available=1_000)
+                with (
+                    patch.object(fs, "upsert", side_effect=record_upsert),
+                    patch("reme.steps.index.update_changes.psutil.virtual_memory", return_value=available),
+                ):
+                    response = await step(RuntimeContext(changes=changes))
+
+                assert response.success is True
+                assert batch_sizes == [1, 1, 1]
+                assert len(await fs.get_nodes()) == 3
+            finally:
+                await chunker.close()
+                await fs.close()
+
+    asyncio.run(run())
+
+
+def test_update_catalog_memory_target_limits_cumulative_batch_size():
+    """The memory target applies to the accumulated batch, not only individual files."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            paths = [write_file(cwd / "daily" / f"{index}.md", "x") for index in range(3)]
+            catalog = LocalFileCatalog(name="test_catalog")
+            await catalog.start()
+            batch_sizes = []
+            original_upsert = catalog.upsert
+
+            async def record_upsert(nodes):
+                batch_sizes.append(len(nodes))
+                await original_upsert(nodes)
+
+            try:
+                step = UpdateCatalogStep(
+                    file_catalog=catalog,
+                    persist=False,
+                    batch_memory_target_bytes=64 * 1024,
+                    app_context=_make_app_context(cwd),
+                )
+                changes = [{"change": "added", "path": str(path)} for path in paths]
+                available = MagicMock(available=8 * 1024 * 1024 * 1024)
+                with (
+                    patch.object(catalog, "upsert", side_effect=record_upsert),
+                    patch("reme.steps.index.update_changes.psutil.virtual_memory", return_value=available),
+                ):
+                    response = await step(RuntimeContext(changes=changes))
+
+                assert response.success is True
+                assert batch_sizes == [2, 1]
+            finally:
+                await catalog.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"batch_available_memory_ratio": float("nan")}, "batch_available_memory_ratio"),
+        ({"batch_memory_target_bytes": 0}, "batch_memory_target_bytes"),
+        ({"batch_memory_expansion_factor": float("inf")}, "batch_memory_expansion_factor"),
+    ],
+)
+def test_update_step_rejects_invalid_batch_memory_settings(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        UpdateCatalogStep(**kwargs)
+
+
+def test_update_catalog_continues_after_one_batch_fails():
+    """An upsert failure is isolated to its bounded batch and later files continue."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            paths = [write_file(cwd / "daily" / f"{index}.md", "x") for index in range(3)]
+            catalog = LocalFileCatalog(name="test_catalog")
+            await catalog.start()
+            original_upsert = catalog.upsert
+            call_count = 0
+
+            async def fail_first_batch(nodes):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise RuntimeError("batch failed")
+                await original_upsert(nodes)
+
+            try:
+                step = UpdateCatalogStep(
+                    file_catalog=catalog,
+                    persist=False,
+                    batch_max_files=2,
+                    app_context=_make_app_context(cwd),
+                )
+                changes = [{"change": "added", "path": str(path)} for path in paths]
+                available = MagicMock(available=8 * 1024 * 1024 * 1024)
+                with (
+                    patch.object(catalog, "upsert", side_effect=fail_first_batch),
+                    patch("reme.steps.index.update_changes.psutil.virtual_memory", return_value=available),
+                ):
+                    response = await step(RuntimeContext(changes=changes))
+
+                assert response.success is False
+                assert [result["success"] for result in response.answer] == [False, False, True]
+                assert [node.path for node in await catalog.get_nodes()] == ["daily/2.md"]
+            finally:
+                await catalog.close()
+
+    asyncio.run(run())
+
+
+def test_update_catalog_yields_to_event_loop_while_building_batch():
+    """Synchronous file inspection does not monopolize the application event loop."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            source = write_file(cwd / "daily" / "a.md", "alpha")
+            catalog = LocalFileCatalog(name="test_catalog")
+            await catalog.start()
+            yielded = False
+            observed = []
+            original_upsert = catalog.upsert
+
+            def mark_yielded():
+                nonlocal yielded
+                yielded = True
+
+            async def observe_upsert(nodes):
+                observed.append(yielded)
+                await original_upsert(nodes)
+
+            try:
+                step = UpdateCatalogStep(file_catalog=catalog, persist=False, app_context=_make_app_context(cwd))
+                asyncio.get_running_loop().call_soon(mark_yielded)
+                with patch.object(catalog, "upsert", side_effect=observe_upsert):
+                    response = await step(RuntimeContext(changes=[{"change": "added", "path": str(source)}]))
+
+                assert response.success is True
+                assert observed == [True]
+            finally:
+                await catalog.close()
+
+    asyncio.run(run())
+
+
+class _CountingEmbeddingStore:
+    dimensions = 2
+    max_batch_size = 10
+
+    def __init__(self):
+        self.calls = 0
+
+    async def get_node_embeddings(self, nodes, **_kwargs):
+        """Record one embedding call and populate deterministic vectors."""
+        self.calls += 1
+        for node in nodes:
+            node.embedding = np.array([1.0, 0.0], dtype=np.float16)
+        return nodes
+
+
+def test_update_index_modified_file_reuses_unchanged_embedding():
+    """The step relies on replace-aware upsert instead of deleting reusable chunks first."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            source = write_file(cwd / "daily" / "a.md", "alpha")
+            fs = LocalFileStore(name="default", embedding_store="")
+            chunker = DefaultFileChunker(supported_extensions=["md"])
+            await fs.start()
+            await chunker.start()
+            embedding_store = _CountingEmbeddingStore()
+            fs.embedding_store = embedding_store
+            try:
+                app_ctx = _make_app_context(cwd)
+                app_ctx.components = {ComponentEnum.FILE_CHUNKER: {"default": chunker}}
+                await fs.upsert([await chunker.chunk(source)])
+                assert embedding_store.calls == 1
+
+                step = UpdateIndexStep(file_store=fs, persist=False, app_context=app_ctx)
+                with patch.object(fs, "delete", wraps=fs.delete) as delete_mock:
+                    response = await step(
+                        RuntimeContext(changes=[{"change": "modified", "path": str(source)}]),
+                    )
+
+                assert response.success is True
+                assert embedding_store.calls == 1
+                delete_mock.assert_not_awaited()
+            finally:
+                await chunker.close()
+                await fs.close()
+
+    asyncio.run(run())
+
+
 def test_update_index_skips_oversized_file_and_clears_stale_index():
     """Oversized content is not read and any previous index entry is removed."""
 
@@ -513,22 +801,49 @@ def test_update_index_handles_file_removed_before_stat():
 
     async def run():
         with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
-            step = UpdateIndexStep(app_context=_make_app_context(Path.cwd()))
-            results = []
+            step = UpdateIndexStep(persist=False, app_context=_make_app_context(Path.cwd()))
 
             with (
                 patch.object(Path, "is_file", return_value=True),
                 patch.object(Path, "stat", side_effect=FileNotFoundError("file disappeared")),
             ):
-                item = await step._try_build_item(Change.modified, "Updating", "daily/a.md", results)
+                response = await step(RuntimeContext(changes=[{"change": "modified", "path": "daily/a.md"}]))
 
-            assert item is None
-            assert results == [
+            assert response.success is False
+            assert response.answer == [
                 {
                     "change": "modified",
                     "path": "daily/a.md",
                     "success": False,
                     "error": "file disappeared",
+                },
+            ]
+
+    asyncio.run(run())
+
+
+def test_update_index_reports_memory_estimation_failure_without_aborting():
+    """A missing chunker is isolated to the affected file and returned as a normal failure."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            source = write_file(cwd / "daily" / "a.unknown", "alpha")
+            app_ctx = _make_app_context(cwd)
+            app_ctx.components = {ComponentEnum.FILE_CHUNKER: {}}
+            step = UpdateIndexStep(persist=False, app_context=app_ctx)
+
+            response = await step(RuntimeContext(changes=[{"change": "added", "path": str(source)}]))
+
+            assert response.success is False
+            assert response.answer == [
+                {
+                    "change": "added",
+                    "path": str(source),
+                    "success": False,
+                    "error": (
+                        f"No file chunker supports {source} (suffix='unknown') and no default chunker is configured"
+                    ),
                 },
             ]
 

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -624,6 +624,50 @@ def test_update_step_rejects_invalid_batch_memory_settings(kwargs, message):
         UpdateCatalogStep(**kwargs)
 
 
+@pytest.mark.parametrize(
+    ("env_name", "value", "attribute", "expected"),
+    [
+        ("REME_BATCH_MAX_FILES", "25", "batch_max_files", 25),
+        ("REME_BATCH_AVAILABLE_MEMORY_RATIO", "0.25", "batch_available_memory_ratio", 0.25),
+        ("REME_BATCH_MEMORY_TARGET_BYTES", "1048576", "batch_memory_target_bytes", 1048576),
+        ("REME_BATCH_MEMORY_EXPANSION_FACTOR", "4.5", "batch_memory_expansion_factor", 4.5),
+    ],
+)
+def test_update_step_reads_batch_defaults_from_environment(monkeypatch, env_name, value, attribute, expected):
+    """REME-prefixed environment variables override built-in batch defaults."""
+    monkeypatch.setenv(env_name, value)
+
+    step = UpdateCatalogStep()
+
+    assert getattr(step, attribute) == expected
+
+
+def test_update_step_explicit_batch_setting_overrides_environment(monkeypatch):
+    """Step configuration remains more specific than process-wide defaults."""
+    monkeypatch.setenv("REME_BATCH_MAX_FILES", "25")
+
+    step = UpdateCatalogStep(batch_max_files=10)
+
+    assert step.batch_max_files == 10
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "REME_BATCH_MAX_FILES",
+        "REME_BATCH_AVAILABLE_MEMORY_RATIO",
+        "REME_BATCH_MEMORY_TARGET_BYTES",
+        "REME_BATCH_MEMORY_EXPANSION_FACTOR",
+    ],
+)
+def test_update_step_rejects_non_numeric_batch_environment_values(monkeypatch, env_name):
+    """Invalid environment defaults fail with the responsible variable name."""
+    monkeypatch.setenv(env_name, "invalid")
+
+    with pytest.raises(ValueError, match=env_name):
+        UpdateCatalogStep()
+
+
 @pytest.mark.parametrize("estimate_method", ["estimate_source_memory", "estimate_item_memory"])
 def test_update_catalog_memory_estimate_failure_processes_each_file_alone(estimate_method):
     """Advisory estimate failures isolate files without skipping their updates."""

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -15,6 +15,7 @@ import datetime
 import os
 import tempfile
 import warnings
+import weakref
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -618,8 +619,90 @@ def test_update_catalog_memory_target_limits_cumulative_batch_size():
     ],
 )
 def test_update_step_rejects_invalid_batch_memory_settings(kwargs, message):
+    """Invalid batch-memory settings fail during step construction."""
     with pytest.raises(ValueError, match=message):
         UpdateCatalogStep(**kwargs)
+
+
+@pytest.mark.parametrize("estimate_method", ["estimate_source_memory", "estimate_item_memory"])
+def test_update_catalog_memory_estimate_failure_processes_each_file_alone(estimate_method):
+    """Advisory estimate failures isolate files without skipping their updates."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            paths = [write_file(cwd / "daily" / f"{index}.md", "x") for index in range(2)]
+            catalog = LocalFileCatalog(name="test_catalog")
+            await catalog.start()
+            batch_sizes = []
+            original_upsert = catalog.upsert
+
+            async def record_upsert(nodes):
+                batch_sizes.append(len(nodes))
+                await original_upsert(nodes)
+
+            try:
+                step = UpdateCatalogStep(file_catalog=catalog, persist=False, app_context=_make_app_context(cwd))
+                changes = [{"change": "added", "path": str(path)} for path in paths]
+                with (
+                    patch.object(step, estimate_method, side_effect=RuntimeError("estimate failed")),
+                    patch.object(catalog, "upsert", side_effect=record_upsert),
+                ):
+                    response = await step(RuntimeContext(changes=changes))
+
+                assert response.success is True
+                assert batch_sizes == [1, 1]
+                assert len(await catalog.get_nodes()) == 2
+            finally:
+                await catalog.close()
+
+    asyncio.run(run())
+
+
+def test_update_catalog_releases_flushed_item_before_building_next_file():
+    """A one-file batch does not retain its payload while the next payload is built."""
+
+    class TrackedItem:
+        """Weak-referenceable payload used to observe the local item lifetime."""
+
+    class TrackingCatalogStep(UpdateCatalogStep):
+        """Catalog step that records whether the prior payload was released."""
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.previous_item = None
+            self.release_observations = []
+
+        async def build_item(self, path):
+            """Build a payload and inspect the preceding payload reference."""
+            del path
+            if self.previous_item is not None:
+                self.release_observations.append(self.previous_item() is None)
+            item = TrackedItem()
+            self.previous_item = weakref.ref(item)
+            return item
+
+        async def upsert_items(self, items):
+            """Discard the batch so only the apply loop could retain its payload."""
+            del items
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
+            cwd = Path.cwd()
+            paths = [write_file(cwd / "daily" / f"{index}.md", "x") for index in range(2)]
+            step = TrackingCatalogStep(
+                persist=False,
+                batch_max_files=1,
+                app_context=_make_app_context(cwd),
+            )
+            changes = [{"change": "added", "path": str(path)} for path in paths]
+
+            response = await step(RuntimeContext(changes=changes))
+
+            assert response.success is True
+            assert step.release_observations == [True]
+
+    asyncio.run(run())
 
 
 def test_update_catalog_continues_after_one_batch_fails():

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -13,6 +13,8 @@ downstream ``update_index_step`` to consume; tests assert against that key.
 import asyncio
 import datetime
 import os
+import subprocess
+import sys
 import tempfile
 import warnings
 import weakref
@@ -624,28 +626,31 @@ def test_update_step_rejects_invalid_batch_memory_settings(kwargs, message):
         UpdateCatalogStep(**kwargs)
 
 
-@pytest.mark.parametrize(
-    ("env_name", "value", "attribute", "expected"),
-    [
-        ("REME_BATCH_MAX_FILES", "25", "batch_max_files", 25),
-        ("REME_BATCH_AVAILABLE_MEMORY_RATIO", "0.25", "batch_available_memory_ratio", 0.25),
-        ("REME_BATCH_MEMORY_TARGET_BYTES", "1048576", "batch_memory_target_bytes", 1048576),
-        ("REME_BATCH_MEMORY_EXPANSION_FACTOR", "4.5", "batch_memory_expansion_factor", 4.5),
-    ],
-)
-def test_update_step_reads_batch_defaults_from_environment(monkeypatch, env_name, value, attribute, expected):
-    """REME-prefixed environment variables override built-in batch defaults."""
-    monkeypatch.setenv(env_name, value)
+def test_update_step_reads_batch_defaults_from_environment():
+    """REME-prefixed environment variables populate constructor defaults at import time."""
+    env = {
+        **os.environ,
+        "REME_BATCH_MAX_FILES": "25",
+        "REME_BATCH_AVAILABLE_MEMORY_RATIO": "0.25",
+        "REME_BATCH_MEMORY_TARGET_BYTES": "1048576",
+        "REME_BATCH_MEMORY_EXPANSION_FACTOR": "4.5",
+    }
+    script = """
+from reme.steps.index.update_changes import UpdateCatalogStep
+step = UpdateCatalogStep()
+print(step.batch_max_files)
+print(step.batch_available_memory_ratio)
+print(step.batch_memory_target_bytes)
+print(step.batch_memory_expansion_factor)
+"""
 
-    step = UpdateCatalogStep()
+    output = subprocess.check_output([sys.executable, "-c", script], env=env, text=True)
 
-    assert getattr(step, attribute) == expected
+    assert output.splitlines() == ["25", "0.25", "1048576", "4.5"]
 
 
-def test_update_step_explicit_batch_setting_overrides_environment(monkeypatch):
-    """Step configuration remains more specific than process-wide defaults."""
-    monkeypatch.setenv("REME_BATCH_MAX_FILES", "25")
-
+def test_update_step_accepts_explicit_batch_setting():
+    """Explicit Step configuration overrides the constructor default."""
     step = UpdateCatalogStep(batch_max_files=10)
 
     assert step.batch_max_files == 10
@@ -660,12 +665,20 @@ def test_update_step_explicit_batch_setting_overrides_environment(monkeypatch):
         "REME_BATCH_MEMORY_EXPANSION_FACTOR",
     ],
 )
-def test_update_step_rejects_non_numeric_batch_environment_values(monkeypatch, env_name):
+def test_update_step_rejects_non_numeric_batch_environment_values(env_name):
     """Invalid environment defaults fail with the responsible variable name."""
-    monkeypatch.setenv(env_name, "invalid")
+    env = {**os.environ, env_name: "invalid"}
 
-    with pytest.raises(ValueError, match=env_name):
-        UpdateCatalogStep()
+    result = subprocess.run(
+        [sys.executable, "-c", "import reme.steps.index.update_changes"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert env_name in result.stderr
 
 
 @pytest.mark.parametrize("estimate_method", ["estimate_source_memory", "estimate_item_memory"])


### PR DESCRIPTION
## 变更背景

索引更新任务此前会先把同一批次中的所有新增或修改文件全部解析并保留在内存中，再一次性写入 catalog 或 index。对于初始化扫描、大规模文件变更或较大的文档集合，这种处理方式容易形成较高的瞬时内存占用，也会扩大单次写入失败的影响范围。

本 PR 将文件变更处理调整为有界分批执行，同时结合文件数量与可用内存动态控制批次大小，降低大规模索引更新时的内存压力，并增强长批次任务的容错性与事件循环公平性。

## 主要改动

### 1. 对新增、修改和删除操作进行有界分批

- 新增和修改文件不再累积到完整变更集结束后统一写入，而是在达到批次上限时立即提交。
- 删除操作同样按 `batch_max_files` 拆分，避免一次传递过多路径。
- 默认每批最多处理 100 个文件；例如 205 个文件会拆分为 `100 + 100 + 5` 三批。
- 每批完成后会及时清空已提交的对象与路径引用，避免已处理 payload 在构建下一批时仍被持有。

### 2. 使用文件数和内存预算双重限制批次大小

每个新增或修改批次同时受以下两个条件约束：

- 文件数达到 `batch_max_files`；
- 当前批次的累计预估内存加上下一个文件的预估内存超过批次预算。

批次内存预算按以下方式动态计算：

```text
min(当前系统可用内存 × batch_available_memory_ratio,
    batch_memory_target_bytes)
```

默认参数如下：

| 参数 | 默认值 | 说明 |
| --- | ---: | --- |
| `batch_max_files` | `100` | 单批最大文件数 |
| `batch_available_memory_ratio` | `0.10` | 单批最多使用当前可用内存的比例 |
| `batch_memory_target_bytes` | `512 MiB` | 单批内存预算硬上限 |
| `batch_memory_expansion_factor` | `8.0` | 索引处理中源文件内容的内存膨胀估算系数 |
| `file_memory_overhead_bytes` | `32 KiB` | 单个文件的固定内存开销估算 |
| `chunk_memory_overhead_bytes` | `4 KiB` | 单个 chunk 的固定内存开销估算 |
| `estimated_chunk_bytes` | `10,000` | chunker 未提供 chunk 大小时使用的估算值 |
| `float16_bytes` | `2` | 单个 float16 embedding 元素的字节数 |

这些默认值直接定义在 Step 初始化参数中，均可通过 Step 配置覆盖。初始化时会校验参数，非法的数量、比例、字节数或非有限浮点值会立即抛出清晰的 `ValueError`。

### 3. 为索引构建增加更贴近实际负载的内存估算

- 在读取文件前，根据文件大小与 chunker 的 `chunk_byte_size` 预估 chunk 数量，以便必要时先提交当前批次。
- 文件解析完成后，根据实际 chunk 数重新估算该对象在批次中的保留内存。
- 估算包含源内容膨胀、文件固定开销、chunk 固定开销，以及可获取维度时的 float16 embedding 空间。
- catalog 更新使用较轻量的固定文件开销估算。
- 如果系统可用内存读取失败，则回退到配置的内存目标值；如果单个文件的内存估算失败，则将该文件隔离为单文件批次继续处理，不会因为辅助性的估算失败而跳过更新。

### 4. 缩小失败影响范围并保持后续任务可继续执行

- upsert 或 delete 失败只影响当前批次，结果仍会逐文件记录错误，后续批次继续执行。
- 文件检查、解析和内存估算的异常仍按文件隔离并返回明确结果。
- 在逐文件构建批次以及逐批删除时主动让出事件循环，避免大型同步扫描长时间占用应用事件循环。

### 5. 保留未变化 chunk 的 embedding

修改文件时不再在 upsert 前显式删除旧路径，而是依赖 file store 的 replace-aware upsert 语义完成替换。这样未变化的 chunk 可以复用已有 embedding，避免不必要的重复计算和远程 embedding 调用。

## 测试覆盖

新增和调整的单元测试覆盖以下场景：

- 205 个 catalog upsert 和 delete 按 `100 + 100 + 5` 分批；
- 可用内存较低时，索引更新自动缩小为单文件批次；
- 内存目标按批次累计值生效；
- 非法批处理与内存参数在构造阶段被拒绝；
- 某一批 upsert 失败后，后续批次仍能成功执行；
- 构建批次时会让出事件循环；
- 修改文件时复用未变化 chunk 的 embedding，且不会预先调用 delete；
- 系统内存读取失败时使用配置上限作为回退预算；
- 源文件或构建结果的内存估算失败时，文件仍以单文件批次处理；
- 已提交批次的对象会在构建下一个文件前释放；
- 文件在 `stat` 前消失、文件过大等既有边界行为保持正常。
