### PR TITLE
fix(file_io): stop ReadStep small-file path over-counting total lines by 1

### DIFF
--- a/reme/steps/file_io/read.py
+++ b/reme/steps/file_io/read.py
@@ -112,6 +112,12 @@ class ReadStep(BaseStep):
                 return None
 
             all_lines = content.split("\n")
+            if content.endswith("\n"):
+                # split() yields a trailing empty element for the final newline;
+                # drop it so total matches the large-file path (line-by-line
+                # iteration) and the indexer (default_file_chunker), both of
+                # which do not count that trailing newline as its own line.
+                all_lines.pop()
             total = len(all_lines)
             bounds = self._resolve_range(total, start_line, end_line, target)
             if bounds is None:

--- a/tests/unit/test_crud_steps.py
+++ b/tests/unit/test_crud_steps.py
@@ -703,6 +703,39 @@ def test_read_start_line_exceeds_total():
     _run(run())
 
 
+def test_read_trailing_newline_does_not_inflate_total_lines():
+    """A trailing '\\n' must not count as an extra line (small-file path).
+
+    ``line1\\nline2\\nline3\\n`` is 3 lines, matching both the large-file
+    path (line-by-line iteration) and the indexer's chunker. Before the fix,
+    ``content.split("\\n")`` counted the trailing empty element too, so the
+    boundary message reported 4 and start_line=4 (one past real EOF) was
+    silently accepted instead of rejected.
+    """
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            _seed_md(Path(tmp), "Short.md", "line1\nline2\nline3\n")
+            store = await _make_store()
+
+            resp = await _read(store, path="Short.md", start_line=99)
+            assert resp.success is False
+            assert "exceeds file length (3 lines)" in str(resp.answer)
+
+            past_eof = await _read(store, path="Short.md", start_line=4)
+            assert past_eof.success is False
+            assert "exceeds file length (3 lines)" in str(past_eof.answer)
+
+            in_range = await _read(store, path="Short.md", start_line=3)
+            assert in_range.success is True
+            assert str(in_range.answer).strip() == "line3"
+
+            await store.close()
+        print("✓ test_read_trailing_newline_does_not_inflate_total_lines passed")
+
+    _run(run())
+
+
 def test_read_truncation():
     """A file larger than DEFAULT_MAX_BYTES triggers truncation with a continuation notice."""
 
@@ -1175,6 +1208,7 @@ if __name__ == "__main__":
     test_read_missing_file()
     test_read_start_after_end()
     test_read_start_line_exceeds_total()
+    test_read_trailing_newline_does_not_inflate_total_lines()
     test_read_truncation()
     test_read_empty_path_rejected()
     print("\n=== crud_md (write/edit) E2E tests ===")


### PR DESCRIPTION
`ReadStep`'s small-file path computes the line count with `content.split("\n")`, whose
length includes a trailing empty element whenever the file ends in a newline
(`read.py:114`). That inflates `total` by 1 for every well-formed text file, so
`_resolve_range` accepts `start_line = <real_total> + 1`, one line past the actual end
of the file, and returns an empty excerpt with `success=True` instead of rejecting it.

The other two line-counting paths over identical content already get this right:
`read_file_lines_safe` (large-file path, iterates the file object line by line) and
`default_file_chunker` (`default_file_chunker.py:129-131`, decrements `end_line` when
the last byte is a newline). This fix mirrors the same correction in `ReadStep`: drop
the trailing empty element from `split("\n")` when the content ends in `\n`, so the
count agrees with both.

Verified in Docker (`python:3.11-slim`, editable install) against the real production
`ReadStep`/`LocalFileStore`, no mocks: with content `"line1\nline2\nline3\n"` (3 real
lines), `start_line=99` reported `"exceeds file length (4 lines)"` on main and
`"exceeds file length (3 lines)"` on this branch; `start_line=4` (one past real EOF)
returned `success=True, answer=''` on main and is correctly rejected on this branch.
`tests/unit/test_read_trailing_newline_does_not_inflate_total_lines` (new) fails on
main and passes here. Full `tests/unit` suite: 747 passed, 1 pre-existing failure
(`test_stat_indexed_file`, a MIME-type lookup gap in the slim Docker image, reproduces
identically on unpatched main and is unrelated to this change). `pre-commit run
--files` clean on both changed files.

Not verified: behavior on Windows/other filesystems with different newline
conventions, since the fix operates on the already-decoded string content.

Fixes #388
