### PR TITLE
fix(auto_fin): harden news reference resolution and fallback handling

### DIFF
--- a/reme/steps/cookbook/auto_fin/history_search.py
+++ b/reme/steps/cookbook/auto_fin/history_search.py
@@ -44,66 +44,106 @@ class AutoFinHistorySearchStep(AutoFinStep):
             return None
         return number if number > 0 else None
 
+    def _historical_source_candidates(self, source_path_value: str, news_id: str) -> list[Path]:
+        """Return the declared source and a date-derived fallback within the workspace."""
+        workspace = self.workspace_path.resolve()
+        relative_path = Path(source_path_value)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError(f"Historical source path must be workspace-relative: {source_path_value}")
+        source_path = (workspace / relative_path).resolve()
+        try:
+            source_path.relative_to(workspace)
+        except ValueError as exc:
+            raise ValueError(f"Historical source path is outside the workspace: {source_path_value}") from exc
+        if source_path.name != "auto_fin_news_data.jsonl":
+            raise ValueError(f"Historical source must be an Auto Fin news file: {source_path_value}")
+
+        candidates = [source_path]
+        news_date = news_id.partition("_")[0][:8]
+        try:
+            parsed_date = datetime.strptime(news_date, "%Y%m%d").date()
+        except ValueError:
+            parsed_date = None
+        if parsed_date is not None:
+            inferred_path = workspace / "daily" / parsed_date.isoformat() / "auto_fin_news_data.jsonl"
+            if inferred_path not in candidates:
+                candidates.append(inferred_path)
+        return candidates
+
+    async def _resolve_historical_event(
+        self,
+        reference: AutoFinHistoricalEventReference,
+        current_news_ids: set[str],
+        window_start: datetime,
+        rows_by_path: dict[Path, list[dict[str, Any]]],
+    ) -> AutoFinHistoricalEvent:
+        """Resolve one Agent-selected identity from user-owned source files."""
+        workspace = self.workspace_path.resolve()
+        if reference.news_id in current_news_ids:
+            raise ValueError(f"History Agent returned a current news item: {reference.news_id}")
+
+        candidates = self._historical_source_candidates(reference.source_path, reference.news_id)
+        matches: list[tuple[Path, dict[str, Any]]] = []
+        for source_path in candidates:
+            if not source_path.is_file():
+                continue
+            rows = rows_by_path.get(source_path)
+            if rows is None:
+                rows = await self._read_jsonl(source_path)
+                rows_by_path[source_path] = rows
+            matches.extend((source_path, row) for row in rows if str(row.get("news_id") or "") == reference.news_id)
+        if len(matches) != 1:
+            raise ValueError(
+                f"Historical news_id must resolve exactly once from {reference.source_path} "
+                f"or its ID-derived daily file: {reference.news_id}",
+            )
+
+        source_path, row = matches[0]
+        event_time = self._published_at(row)
+        if event_time is None:
+            raise ValueError(f"Historical news has no valid publication time: {reference.news_id}")
+        if event_time >= window_start:
+            raise ValueError(f"History Agent returned an event inside the current news window: {reference.news_id}")
+        event_title = str(row.get("title") or "").strip()
+        event_content = _plain_text(str(row.get("content") or event_title))
+        if not event_title or not event_content:
+            raise ValueError(f"Historical news has no usable title or content: {reference.news_id}")
+
+        return AutoFinHistoricalEvent(
+            reason=reference.reason,
+            news_id=reference.news_id,
+            source_path=source_path.relative_to(workspace).as_posix(),
+            event_time=event_time,
+            event_title=event_title,
+            event_content=event_content,
+        )
+
     async def _resolve_historical_events(
         self,
         references: list[AutoFinHistoricalEventReference],
         current_news_ids: set[str],
         window_start: datetime,
-    ) -> list[AutoFinHistoricalEvent]:
-        """Resolve Agent-selected identities from user-owned source files."""
-        workspace = self.workspace_path.resolve()
+    ) -> tuple[list[AutoFinHistoricalEvent], list[str]]:
+        """Resolve valid references and report invalid ones without stopping the ETF."""
         rows_by_path: dict[Path, list[dict[str, Any]]] = {}
         events_by_news_id: dict[str, AutoFinHistoricalEvent] = {}
+        limitations = []
         for reference in references:
-            if reference.news_id in current_news_ids:
-                raise ValueError(f"History Agent returned a current news item: {reference.news_id}")
-
-            relative_path = Path(reference.source_path)
-            if relative_path.is_absolute() or ".." in relative_path.parts:
-                raise ValueError(f"Historical source path must be workspace-relative: {reference.source_path}")
-            source_path = (workspace / relative_path).resolve()
             try:
-                normalized_path = source_path.relative_to(workspace)
-            except ValueError as exc:
-                raise ValueError(f"Historical source path is outside the workspace: {reference.source_path}") from exc
-            if source_path.name != "auto_fin_news_data.jsonl":
-                raise ValueError(f"Historical source must be an Auto Fin news file: {reference.source_path}")
-            if not source_path.is_file():
-                raise ValueError(f"Historical source file does not exist: {reference.source_path}")
-
-            rows = rows_by_path.get(source_path)
-            if rows is None:
-                rows = await self._read_jsonl(source_path)
-                rows_by_path[source_path] = rows
-            matches = [row for row in rows if str(row.get("news_id") or "") == reference.news_id]
-            if len(matches) != 1:
-                raise ValueError(
-                    f"Historical news_id must resolve exactly once in {reference.source_path}: {reference.news_id}",
+                event = await self._resolve_historical_event(
+                    reference,
+                    current_news_ids,
+                    window_start,
+                    rows_by_path,
                 )
-
-            row = matches[0]
-            event_time = self._published_at(row)
-            if event_time is None:
-                raise ValueError(f"Historical news has no valid publication time: {reference.news_id}")
-            if event_time >= window_start:
-                raise ValueError(f"History Agent returned an event inside the current news window: {reference.news_id}")
-            event_title = str(row.get("title") or "").strip()
-            event_content = _plain_text(str(row.get("content") or event_title))
-            if not event_title or not event_content:
-                raise ValueError(f"Historical news has no usable title or content: {reference.news_id}")
-
-            events_by_news_id.setdefault(
-                reference.news_id,
-                AutoFinHistoricalEvent(
-                    reason=reference.reason,
-                    news_id=reference.news_id,
-                    source_path=normalized_path.as_posix(),
-                    event_time=event_time,
-                    event_title=event_title,
-                    event_content=event_content,
-                ),
-            )
-        return sorted(events_by_news_id.values(), key=lambda event: (event.event_time, event.news_id))
+            except (OSError, ValueError) as exc:
+                limitation = f"跳过无法解析的历史新闻 {reference.news_id}: {exc}"
+                self.logger.warning(f"[{self.name}] {limitation}")
+                limitations.append(limitation)
+                continue
+            events_by_news_id.setdefault(reference.news_id, event)
+        resolved = sorted(events_by_news_id.values(), key=lambda event: (event.event_time, event.news_id))
+        return resolved, limitations
 
     async def _calculate_samples(
         self,
@@ -249,7 +289,7 @@ class AutoFinHistorySearchStep(AutoFinStep):
                         self.app_context.metadata.pop(_ToolContextDedupMixin.TOOL_CONTEXTS_KEY, None)
         if (history.etf_code, history.etf_name) != (item.etf_code, item.etf_name):
             raise ValueError(f"History Agent changed ETF {label!r}")
-        resolved_events = await self._resolve_historical_events(
+        resolved_events, resolution_limitations = await self._resolve_historical_events(
             history.historical_events,
             {event.news_id for event in events},
             window_start,
@@ -272,7 +312,7 @@ class AutoFinHistorySearchStep(AutoFinStep):
             etf_code=history.etf_code,
             etf_name=history.etf_name,
             historical_events=enriched_events,
-            limitations=market_limitations,
+            limitations=list(dict.fromkeys([*resolution_limitations, *market_limitations])),
         )
         _write(
             history_path,

--- a/reme/steps/cookbook/auto_fin/history_search.yaml
+++ b/reme/steps/cookbook/auto_fin/history_search.yaml
@@ -16,7 +16,8 @@ history_search_user: |
   3. 当前事件时间线来自最近一次收盘后至本次分析时点，只能作为检索线索，不属于历史事件。
      即使搜索命中同一条当前新闻，也不得放入 historical_events。
   4. 每个 historical_events 项只需从原始 JSONL 逐字复制 news_id 和 workspace 相对
-     source_path，并用 reason 简洁说明它与当前事件相似的原因。不要返回时间、标题或正文。
+     source_path，并用 reason 简洁说明它与当前事件相似的原因。source_path 的 YYYY-MM-DD 必须
+     是实际文件所在日期，通常与 news_id 开头的日期一致。不要返回时间、标题或正文。
   5. 只选择原始记录中真实存在且带有 news_id 的新闻。程序会严格使用 source_path + news_id
      回查，找不到、重复命中、路径越界或不是 auto_fin_news_data.jsonl 都会失败；严禁编造。
   6. etf_code 和 etf_name 必须原样返回 `{etf_code}` 和 `{etf_name}`。不要读写或下载行情文件，

--- a/reme/steps/cookbook/auto_fin/market.py
+++ b/reme/steps/cookbook/auto_fin/market.py
@@ -115,16 +115,24 @@ class AutoFinMarketStep(AutoFinStep):
             f"- [{event.event_time.isoformat()}] {event.event_title or event.reason}: {event.event_content}"
             for event in events
         )
-        selection, selection_path = await self._reply(
-            "market_user",
-            f"auto_fin_market_{index:02d}_{item.etf_code}",
-            AutoFinMarketSelection,
-            etf_code=item.etf_code,
-            etf_name=item.etf_name,
-            events=event_lines,
-            history_path=str(self._required("auto_fin_current_history_resource")),
-            decision_at=str(self._required("auto_fin_decision_at")),
-        )
+        resource_name = f"auto_fin_market_{index:02d}_{item.etf_code}"
+        if history.historical_events:
+            selection, selection_path = await self._reply(
+                "market_user",
+                resource_name,
+                AutoFinMarketSelection,
+                etf_code=item.etf_code,
+                etf_name=item.etf_name,
+                events=event_lines,
+                history_path=str(self._required("auto_fin_current_history_resource")),
+                decision_at=str(self._required("auto_fin_decision_at")),
+            )
+        else:
+            selection = AutoFinMarketSelection()
+            selection_path = (
+                self.workspace_path / "resource" / str(self._required("auto_fin_date")) / f"{resource_name}_output.json"
+            )
+            self.logger.warning(f"[{self.name}] skip similarity Agent for {item.etf_code}: no valid history")
         analysis = self._calculate_analysis(item, history, selection)
         _write(
             selection_path,

--- a/reme/steps/cookbook/auto_fin/topic.py
+++ b/reme/steps/cookbook/auto_fin/topic.py
@@ -151,6 +151,33 @@ class AutoFinTopicStep(AutoFinStep):
         return selected
 
     @staticmethod
+    def _repair_news_ids(
+        output: AutoFinEtfsOutput,
+        news: list[dict[str, Any]],
+    ) -> tuple[AutoFinEtfsOutput, dict[str, str]]:
+        """Repair a mistyped timestamp only when the content hash is unambiguous."""
+        news_ids = {str(row["news_id"]) for row in news}
+        ids_by_suffix: dict[str, list[str]] = {}
+        for news_id in news_ids:
+            _, separator, suffix = news_id.rpartition("_")
+            if separator and suffix:
+                ids_by_suffix.setdefault(suffix, []).append(news_id)
+
+        data = output.model_dump(mode="json")
+        repairs: dict[str, str] = {}
+        for item in data["etfs"]:
+            for event in item["events"]:
+                news_id = event["news_id"]
+                if news_id in news_ids:
+                    continue
+                _, separator, suffix = news_id.rpartition("_")
+                candidates = ids_by_suffix.get(suffix, []) if separator else []
+                if len(candidates) == 1:
+                    event["news_id"] = candidates[0]
+                    repairs[news_id] = candidates[0]
+        return AutoFinEtfsOutput.model_validate(data), repairs
+
+    @staticmethod
     def _validate_selection(
         output: AutoFinEtfsOutput,
         news: list[dict[str, Any]],
@@ -166,6 +193,8 @@ class AutoFinTopicStep(AutoFinStep):
             unknown = set(selected_news_ids) - news_ids
             if unknown:
                 raise ValueError(f"Topic Agent returned unknown news IDs: {sorted(unknown)}")
+            if len(selected_news_ids) != len(set(selected_news_ids)):
+                raise ValueError(f"Topic Agent returned duplicate news IDs for ETF: {item.etf_code}")
             event_order = [news_order[news_id] for news_id in selected_news_ids]
             if event_order != sorted(event_order):
                 raise ValueError(f"Topic Agent returned unsorted news IDs for ETF: {item.etf_code}")
@@ -197,6 +226,10 @@ class AutoFinTopicStep(AutoFinStep):
             filtered_news_path=str(news_path),
             filtered_etf_path=str(etf_path),
         )
+        output, repairs = self._repair_news_ids(output, news)
+        if repairs:
+            self.logger.warning(f"[{self.name}] repaired mistyped news IDs: {repairs}")
+            _write_jsonl(output_path, output.model_dump(mode="json")["etfs"])
         self._validate_selection(output, news, etfs)
         self.context["auto_fin_window_start"] = window_start.isoformat()
         self.context["auto_fin_etfs"] = output.model_dump(mode="json")["etfs"]

--- a/reme/steps/cookbook/auto_fin/topic.yaml
+++ b/reme/steps/cookbook/auto_fin/topic.yaml
@@ -18,6 +18,7 @@ topic_user: |
   4. events 只填写与该 ETF 相关的事件对象，每项包含 reason 和 news_id；reason 简洁说明该条新闻
      与 ETF 所代表资产之间的直接传导关系。合并重复报道，并按新闻时间升序排列。
   5. etf_code、etf_name 必须逐字复制候选文件中的 code、name；无相关 ETF 时返回空 etfs。
+     news_id 也必须整段逐字复制，禁止把一条新闻的时间前缀与另一条新闻的哈希后缀拼接。
   6. reason 不得加入预测；同一 ETF 的不同新闻应分别说明关联理由。
   7. 最终生成一个对象，只包含 etfs；每只 ETF 只包含 etf_code、etf_name、events，每个 event
      只包含 reason 和 news_id。JSON 示例：

--- a/tests/unit/test_auto_fin.py
+++ b/tests/unit/test_auto_fin.py
@@ -20,6 +20,7 @@ from reme.schema import (
     AutoFinEtfSelection,
     AutoFinEtfsOutput,
     AutoFinHistoricalEvent,
+    AutoFinHistoricalEventReference,
     AutoFinMarketSelection,
     AutoFinMarketSample,
     AutoFinReportOutput,
@@ -68,6 +69,49 @@ def test_plain_news_text_removes_markup_images_and_hidden_content():
     content = '<p>甲&amp;乙</p><img src="https://example.com/large.png"><style>隐藏样式</style><p>丙</p>'
 
     assert _plain_text(content) == "甲&乙 丙"
+
+
+def test_topic_repairs_unknown_news_id_by_unique_content_hash():
+    output = AutoFinEtfsOutput.model_validate(
+        {
+            "etfs": [
+                {
+                    "etf_code": "159819.SZ",
+                    "etf_name": "人工智能ETF",
+                    "events": [{"reason": "穆迪警告AI投资风险", "news_id": "20260725061826_1c76"}],
+                },
+            ],
+        },
+    )
+    news = [
+        {"news_id": "20260725050638_1c76"},
+        {"news_id": "20260725061826_765a"},
+    ]
+
+    repaired, repairs = AutoFinTopicStep._repair_news_ids(output, news)
+
+    assert repaired.etfs[0].events[0].news_id == "20260725050638_1c76"
+    assert repairs == {"20260725061826_1c76": "20260725050638_1c76"}
+
+
+def test_topic_does_not_repair_ambiguous_content_hash():
+    output = AutoFinEtfsOutput.model_validate(
+        {
+            "etfs": [
+                {
+                    "etf_code": "159819.SZ",
+                    "etf_name": "人工智能ETF",
+                    "events": [{"reason": "相关事件", "news_id": "20260725061826_abcd"}],
+                },
+            ],
+        },
+    )
+    news = [{"news_id": "20260725050638_abcd"}, {"news_id": "20260725070000_abcd"}]
+
+    repaired, repairs = AutoFinTopicStep._repair_news_ids(output, news)
+
+    assert repaired.etfs[0].events[0].news_id == "20260725061826_abcd"
+    assert not repairs
 
 
 def test_published_time_is_normalized_once_to_shanghai_local_time():
@@ -648,6 +692,50 @@ def test_market_calculation_clamps_and_reverses_negative_similarity():
 
 
 @pytest.mark.asyncio
+async def test_market_skips_agent_when_all_historical_references_were_invalid(tmp_path: Path):
+    class _UnexpectedAgent(BaseAgentWrapper):
+        async def reply(self, inputs, **kwargs):
+            raise AssertionError((inputs, kwargs))
+
+    app_context = ApplicationContext(workspace_dir=str(tmp_path), timezone="Asia/Shanghai")
+    step = AutoFinMarketStep(app_context=app_context, agent_wrapper=_UnexpectedAgent(app_context=app_context))
+    step.logger = SimpleNamespace(warning=lambda _message: None)
+    step.context = RuntimeContext(
+        auto_fin_current_etf={
+            "etf_code": "159819.SZ",
+            "etf_name": "人工智能ETF",
+            "events": [{"reason": "AI事件", "news_id": "20260725050638_1c76"}],
+        },
+        auto_fin_current_events=[
+            {
+                "reason": "AI事件",
+                "news_id": "20260725050638_1c76",
+                "event_time": "2026-07-25T05:06:38",
+                "event_title": "当前新闻",
+                "event_content": "当前内容",
+            },
+        ],
+        auto_fin_current_history={
+            "etf_code": "159819.SZ",
+            "etf_name": "人工智能ETF",
+            "historical_events": [],
+            "limitations": ["跳过无法解析的历史新闻 20260427100000_dead"],
+        },
+        auto_fin_current_history_resource=str(tmp_path / "history.json"),
+        auto_fin_current_index=1,
+        auto_fin_date="2026-07-26",
+        auto_fin_decision_at="2026-07-26T18:00:00",
+    )
+
+    await step.execute()
+
+    analysis = step.context["auto_fin_current_analysis"]
+    assert not analysis["matched_historical_events"]
+    assert "没有匹配的历史事件" in analysis["limitations"]
+    assert (tmp_path / "resource" / "2026-07-26" / "auto_fin_market_01_159819.SZ_output.json").is_file()
+
+
+@pytest.mark.asyncio
 async def test_history_search_calculates_adjusted_returns_for_event_time_boundaries(tmp_path: Path):
     calls = []
 
@@ -707,6 +795,90 @@ async def test_history_search_calculates_adjusted_returns_for_event_time_boundar
     assert samples[3].future_returns[0].cumulative_return == pytest.approx(14 / 12 - 1)
     assert limitations
     assert [endpoint for endpoint, _ in calls] == ["fund_daily", "fund_adj"]
+
+
+@pytest.mark.asyncio
+async def test_history_search_recovers_source_path_from_news_id_date(tmp_path: Path):
+    actual_path = tmp_path / "daily" / "2026-04-26" / "auto_fin_news_data.jsonl"
+    actual_path.parent.mkdir(parents=True)
+    actual_path.write_text(
+        json.dumps(
+            {
+                "news_id": "20260426221449_de86",
+                "pub_time": "2026-04-26 22:14:49",
+                "title": "PCB厂商一季度业绩增长",
+                "content": "AI硬件需求带动PCB订单增长。",
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    step = AutoFinHistorySearchStep(
+        app_context=ApplicationContext(workspace_dir=str(tmp_path), timezone="Asia/Shanghai"),
+    )
+    references = [
+        AutoFinHistoricalEventReference(
+            reason="PCB订单增长的传导机制相同",
+            news_id="20260426221449_de86",
+            source_path="daily/2026-04-27/auto_fin_news_data.jsonl",
+        ),
+    ]
+
+    events, limitations = await step._resolve_historical_events(
+        references,
+        set(),
+        datetime.fromisoformat("2026-07-24T15:00:00"),
+    )
+
+    assert len(events) == 1
+    assert events[0].source_path == "daily/2026-04-26/auto_fin_news_data.jsonl"
+    assert not limitations
+
+
+@pytest.mark.asyncio
+async def test_history_search_skips_one_invalid_reference_and_continues(tmp_path: Path):
+    actual_path = tmp_path / "daily" / "2026-04-26" / "auto_fin_news_data.jsonl"
+    actual_path.parent.mkdir(parents=True)
+    actual_path.write_text(
+        json.dumps(
+            {
+                "news_id": "20260426221449_de86",
+                "pub_time": "2026-04-26 22:14:49",
+                "title": "有效历史新闻",
+                "content": "有效内容",
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    step = AutoFinHistorySearchStep(
+        app_context=ApplicationContext(workspace_dir=str(tmp_path), timezone="Asia/Shanghai"),
+    )
+    step.logger = SimpleNamespace(warning=lambda _message: None)
+    references = [
+        AutoFinHistoricalEventReference(
+            reason="有效引用",
+            news_id="20260426221449_de86",
+            source_path="daily/2026-04-26/auto_fin_news_data.jsonl",
+        ),
+        AutoFinHistoricalEventReference(
+            reason="无效引用",
+            news_id="20260427100000_dead",
+            source_path="daily/2026-04-27/auto_fin_news_data.jsonl",
+        ),
+    ]
+
+    events, limitations = await step._resolve_historical_events(
+        references,
+        set(),
+        datetime.fromisoformat("2026-07-24T15:00:00"),
+    )
+
+    assert [event.news_id for event in events] == ["20260426221449_de86"]
+    assert len(limitations) == 1
+    assert "20260427100000_dead" in limitations[0]
 
 
 def test_daily_cookbook_wires_enabled_auto_fin_steps_and_tushare_skill():


### PR DESCRIPTION
## 背景

Auto Fin 流程依赖 Agent 从用户自有的 JSONL 文件中返回新闻引用。实际运行中，Agent 可能返回日期目录有偏差的 `source_path`，或把正确的内容哈希后缀与错误的时间前缀组合成 `news_id`。此前这些问题会让历史事件解析整体失败；当全部历史引用均无效时，后续仍会调用相似度 Agent，产生无意义的请求。

本次改动增强新闻引用解析的容错能力，同时保留工作区边界、文件类型、唯一命中和时间窗口等严格校验，避免将模糊或不可信的引用静默接受。

## Topic 阶段：修复可唯一确认的 `news_id`

- 在 Topic Agent 返回未知 `news_id` 时，按下划线后的内容哈希后缀查找原始新闻。
- 仅当该哈希后缀在输入新闻中唯一命中时，修复错误的时间前缀；无法命中或存在多个候选时保持原值，并继续由既有校验明确报错。
- 修复后重新写入 Topic 输出文件，保证落盘结果与后续运行时数据一致。
- 增加同一 ETF 下重复 `news_id` 的校验，避免重复事件进入后续分析。
- 更新 Topic 提示词，要求完整逐字复制 `news_id`，禁止拼接不同新闻的时间前缀与哈希后缀。

## History Search 阶段：增强来源解析与局部容错

- 将历史来源候选路径计算与单条历史事件解析拆分，缩小职责范围。
- 优先检查 Agent 声明的 `source_path`；若文件缺失或未命中，则根据 `news_id` 的日期前缀推导对应的 `daily/YYYY-MM-DD/auto_fin_news_data.jsonl` 作为回退候选。
- 在全部候选文件中聚合匹配结果，并继续要求 `news_id` 恰好命中一次，防止重复或歧义数据被接受。
- 保留并强化安全约束：来源路径必须是工作区相对路径、不得包含路径穿越、解析后不得越出工作区，且文件名必须是 `auto_fin_news_data.jsonl`。
- 继续校验发布时间、当前新闻窗口、标题和正文等数据完整性。
- 改为逐条解析历史引用：单条引用无效时记录 warning 和 limitation，并继续处理同一 ETF 的其他有效引用，不再让整个 ETF 直接失败。
- 合并引用解析与行情计算产生的 limitations，并按首次出现顺序去重。
- 更新 History Search 提示词，强调 `source_path` 中的日期必须对应实际文件日期。

## Market 阶段：处理无有效历史事件的情况

- 当历史引用全部无效、没有可用历史事件时，跳过相似度 Agent 调用。
- 生成空的市场选择结果并继续执行分析，使输出仍包含明确的限制说明和可检查的资源文件。
- 保持存在有效历史事件时的原有相似度分析流程不变。

## 行为边界

- 回退只使用 `news_id` 中可解析的日期，并且只定位工作区内约定的 Auto Fin 日度新闻文件。
- 自动修复只针对哈希后缀唯一匹配的 `news_id`；任何歧义都不会被猜测性修复。
- 无效历史引用会被显式记录到 limitations，不会被静默丢弃。
- 用户自有 JSONL 文件仍是历史事件内容的唯一来源，不引入额外持久化状态。

## 测试覆盖

新增单元测试覆盖以下场景：

- 根据唯一内容哈希修复错误的 `news_id` 时间前缀。
- 哈希后缀存在歧义时不执行修复。
- 根据 `news_id` 日期从错误的来源日期目录恢复到实际 JSONL 文件。
- 单条历史引用无效时保留其他有效历史事件，并返回对应 limitation。
- 所有历史引用均无效时跳过 Market 相似度 Agent，同时正常生成分析输出。