### PR TITLE
feat(plugin): add ReMe integration skeleton for QwenPaw (towards #349)

### DIFF
--- a/plugins/qwenpaw/README.md
+++ b/plugins/qwenpaw/README.md
@@ -1,0 +1,99 @@
+# ReMe plugin for QwenPaw
+
+Connect [QwenPaw](https://github.com/agentscope-ai/ReMe) (the Qwen-series assistant)
+to [ReMe](https://github.com/agentscope-ai/ReMe) — file-native long-term memory for
+AI agents. The plugin gives QwenPaw **recall** (read long-term memory before replies)
+and **automatic durable recording** of useful turns after the fact via a non-blocking
+background writer. Consolidation of daily notes into long-term `digest/` knowledge
+runs server-side in ReMe.
+
+> **Status:** Skeleton plugin. This package ships the QwenPaw installable plugin
+> shape, the ReMe MCP server configuration, the memory-recall Skill with three
+> recall modes (semantic / topological / state), and an auto-memory stop hook
+> adapted to QwenPaw's session layout. The deeper QwenPaw SDK-level integration
+> (embedding the ReMe Python SDK and wiring it directly into QwenPaw's internal
+> scheduler and conversation manager) is intentionally **out of scope** for this
+> PR and is tracked separately. Contributions and follow-up PRs are welcome.
+
+## What you get
+
+- **MCP tools** from the running `reme` HTTP server: `search`, `traverse`,
+  `daily_list`, `frontmatter_read`, `read`, `auto_memory`, and more.
+- **Stop hook** (`hooks/auto_memory.py`) — when a QwenPaw conversation ends it
+  calls ReMe's server-side `auto_memory` tool in a detached background process,
+  anchored on the QwenPaw conversation id. The server resolves the transcript on
+  disk and records durable facts into today's daily note. Recording is automatic
+  and async — stopping the assistant is never delayed. Best-effort: if the ReMe
+  service is unreachable it logs and gives up silently.
+- **Skill** `reme-memory` — recall long-term memory before replying (semantic
+  `search`, topological `traverse`, state `daily_list`/`frontmatter_read`, then
+  `read` with citations), plus a server-health check. Recording is handled by
+  the stop hook.
+
+## Prerequisites
+
+1. Install ReMe (Python 3.11+):
+
+   ```bash
+   pip install "reme-ai[core]"
+   ```
+
+2. Configure model credentials in a `.env` (see `example.env`):
+
+   ```bash
+   EMBEDDING_API_KEY=sk-xxx
+   EMBEDDING_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+   LLM_API_KEY=sk-xxx
+   LLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+   ```
+
+3. Start the ReMe HTTP/MCP service (leave it running):
+
+   ```bash
+   reme start service.backend=mcp service.transport=streamable-http
+   ```
+
+   It serves `http://127.0.0.1:2333/mcp`. To use a different port, start with
+   `service.port=<port>` and update the `url` in `.mcp.json` to match.
+
+## Install the plugin
+
+QwenPaw supports plugin installation from a repository subdirectory. From the
+ReMe repository root:
+
+```bash
+qwenpaw plugins add ./plugins/qwenpaw
+qwenpaw plugins enable reme
+```
+
+(Or point `qwenpaw plugins add` at the upstream GitHub repo + subpath once
+published.) Then restart QwenPaw and confirm the `reme` MCP server and its
+`reme-memory` skill are connected; the assistant will then automatically recall
+memory and report server health.
+
+## Directory layout
+
+```
+plugins/qwenpaw/
+├── README.md                    # this file
+└── reme/
+    ├── .mcp.json                # ReMe streamable-http MCP endpoint
+    ├── hooks/
+    │   ├── hooks.json           # Stop hook registration
+    │   └── auto_memory.py       # Fire-and-forget auto-memory (detached)
+    └── skills/
+        └── reme-memory/
+            └── SKILL.md         # Recall protocol + 3-mode retrieval SOP
+```
+
+## Notes
+
+- The MCP server URL lives in `plugins/qwenpaw/reme/.mcp.json`. Keep it in sync
+  with how you start ReMe (host/port). The stop hook reads this same file to
+  locate the server — override via `REME_HOST` / `REME_PORT` if needed.
+- The stop hook requires `python3` on `PATH`. It resolves QwenPaw conversation
+  transcripts under the QwenPaw data directory (override via
+  `QWENPAW_DATA_DIR`). Logs go to `plugins/qwenpaw/reme/logs/auto_memory_hook.log`.
+- Multi-user scoping: attach stable `tags: [user:alice]` / `tags: [conv:xxx]`
+  frontmatter to files written by each profile, then use the search-step
+  `tags` filter to keep recall results isolated between QwenPaw profiles.

--- a/plugins/qwenpaw/reme/.mcp.json
+++ b/plugins/qwenpaw/reme/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "reme": {
+      "type": "http",
+      "url": "http://127.0.0.1:2333/mcp"
+    }
+  }
+}

--- a/plugins/qwenpaw/reme/hooks/auto_memory.py
+++ b/plugins/qwenpaw/reme/hooks/auto_memory.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""ReMe Stop hook for QwenPaw: fire-and-forget auto-memory for the conversation.
+
+QwenPaw runs this on the ``Stop`` event and feeds the hook payload as JSON on
+stdin. We read ``conversation_id`` and ``profile_id`` from it and hand those to
+ReMe's server-side ``auto_memory`` tool over the (already-running) MCP server —
+the server resolves *this* conversation's transcript on disk and records the
+durable facts. No messages are sent from here; the agent never has to record by
+hand.
+
+The actual server-side run spins up an inner agent and can be slow, so we detach
+(double-fork) and return immediately: stopping is never blocked. Any failure is
+logged, never surfaced — recording is best-effort.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+
+_CALL_TIMEOUT = 600
+
+
+def _plugin_root() -> str:
+    return os.environ.get("QWENPAW_PLUGIN_ROOT") or os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__)),
+    )
+
+
+def _server_url() -> str:
+    """ReMe MCP endpoint. Prefer the bundled .mcp.json so it stays in sync."""
+    mcp_json = os.path.join(_plugin_root(), ".mcp.json")
+    try:
+        with open(mcp_json, encoding="utf-8") as f:
+            url = json.load(f)["mcpServers"]["reme"]["url"]
+            if url:
+                return url
+    except Exception:
+        pass
+    host = os.environ.get("REME_HOST", "127.0.0.1")
+    port = os.environ.get("REME_PORT", "2333")
+    return f"http://{host}:{port}/mcp"
+
+
+def _log(conv_id: str, status: str, detail: str = "") -> None:
+    try:
+        log_dir = os.path.join(_plugin_root(), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        line = f"{stamp} conv={conv_id} {status}"
+        if detail:
+            line += f" {detail}"
+        with open(
+            os.path.join(log_dir, "auto_memory_hook.log"),
+            "a",
+            encoding="utf-8",
+        ) as f:
+            f.write(line + "\n")
+    except Exception:
+        pass
+
+
+def _post(url: str, body: dict, headers: dict):
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    return urllib.request.urlopen(req, timeout=_CALL_TIMEOUT)
+
+
+def _read_jsonrpc(resp) -> dict | None:
+    ctype = resp.headers.get("content-type", "")
+    body = resp.read().decode("utf-8", "replace")
+    if "text/event-stream" in ctype:
+        result = None
+        for line in body.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            try:
+                obj = json.loads(line[len("data:") :].strip())
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict) and ("result" in obj or "error" in obj):
+                result = obj
+        return result
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return None
+
+
+def _mcp_call(url: str, tool: str, arguments: dict) -> dict | None:
+    base = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+    init = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "reme-qwenpaw-stop-hook", "version": "1.0"},
+        },
+    }
+    with _post(url, init, base) as resp:
+        mcp_session = resp.headers.get("mcp-session-id")
+        _read_jsonrpc(resp)
+    headers = dict(base)
+    if mcp_session:
+        headers["mcp-session-id"] = mcp_session
+    try:
+        with _post(
+            url,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            headers,
+        ) as resp:
+            resp.read()
+    except urllib.error.HTTPError:
+        pass
+    call = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments},
+    }
+    with _post(url, call, headers) as resp:
+        return _read_jsonrpc(resp)
+
+
+def _daemonize() -> None:
+    if os.fork() > 0:
+        os._exit(0)
+    os.setsid()
+    if os.fork() > 0:
+        os._exit(0)
+    devnull = os.open(os.devnull, os.O_RDWR)
+    for fd in (0, 1, 2):
+        os.dup2(devnull, fd)
+
+
+def main() -> None:
+    """Entry point: read the hook payload from stdin and record the conversation."""
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        payload = {}
+
+    conv_id = payload.get("conversation_id") or payload.get("session_id") or ""
+    profile_id = payload.get("profile_id") or ""
+    if not conv_id:
+        return
+
+    if hasattr(os, "fork"):
+        _daemonize()
+
+    url = _server_url()
+    tool_args = {"session_id": conv_id}
+    if profile_id:
+        tool_args["profile_id"] = profile_id
+    try:
+        result = _mcp_call(url, "auto_memory", tool_args)
+        if result is None:
+            _log(conv_id, "no-response")
+        elif "error" in result:
+            _log(conv_id, "error", json.dumps(result["error"], ensure_ascii=False)[:500])
+        else:
+            _log(conv_id, "ok")
+    except urllib.error.URLError as exc:
+        _log(conv_id, "unreachable", str(exc.reason))
+    except Exception as exc:  # noqa: BLE001 - best-effort
+        _log(conv_id, "exception", repr(exc)[:500])
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/qwenpaw/reme/hooks/hooks.json
+++ b/plugins/qwenpaw/reme/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "On conversation stop, record this QwenPaw conversation into ReMe long-term memory (background, async).",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${QWENPAW_PLUGIN_ROOT}/hooks/auto_memory.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/qwenpaw/reme/skills/reme-memory/SKILL.md
+++ b/plugins/qwenpaw/reme/skills/reme-memory/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: reme-memory
+description: Use ReMe as file-native long-term memory in QwenPaw. RECALL — search ReMe before answering questions about past conversations, preferences, project history, or decisions.
+---
+
+# ReMe Memory
+
+ReMe is the persistent, file-native memory layer for this QwenPaw assistant. It
+stores conversations and resources as Markdown files with frontmatter and
+`[[wikilinks]]`, and consolidates them into long-term **digest** knowledge.
+Your job with this plugin is **recall**.
+
+The recall tools come from the `reme` MCP server (surfaced as `mcp__reme__…`):
+`search`, `traverse`, `daily_list`, `frontmatter_read`, `read`. They are only
+available when the user has the server running:
+
+```
+reme start service.backend=mcp service.transport=streamable-http
+```
+
+If the tools are missing, the server is not running — tell the user the command
+above instead of guessing answers.
+
+## Recall (read long-term memory)
+
+Before answering questions about previous conversations, user preferences,
+project history, decisions, or long-term context, recall from ReMe first. ReMe
+answers **three independent kinds of question** — pick the mode the request
+needs; don't merge them into one call. Durable knowledge lives under `digest/`,
+daily notes under `daily/`, external materials under `resource/`.
+
+1. **Semantic** (default — "what do we know about X?"): `search` with
+   `query="<question/keywords>"`, `limit=5` (optional `min_score`). Hybrid
+   vector + BM25 with one-hop wikilink expansion.
+2. **Topological** ("what links to this node?"): `traverse` with
+   `path="<node>"`, `depth=1` (raise to 2 only when needed), `direction=both`
+   to walk the `[[wikilink]]` graph.
+3. **State** ("what exists / what was recorded on <date>?"): `daily_list` with
+   `date="YYYY-MM-DD"` (empty = today) to list a day's notes, or
+   `frontmatter_read` with a `path` to inspect one file's frontmatter —
+   structural lookup, no semantic matching.
+
+Then `read` the relevant hits by `path` (optionally `start_line`/`end_line`;
+prefer `digest/` paths for durable knowledge) to pull the content behind a hit.
+Cite the workspace-relative paths you used. If nothing useful comes back, say
+so plainly rather than guessing.
+
+### Multi-user / multi-profile scoping
+
+When QwenPaw runs with multiple profiles (or serves multiple distinct users
+from the same workspace), attach stable frontmatter tags to each file at
+write-time and then scope recall with the `tags` search-filter, for example:
+
+- At rest: every daily note for user `alice` carries `tags: [user:alice]`;
+  per-conversation files carry `tags: [conv:conversation-xyz]`.
+- At recall time: run `search` or `traverse` with
+  `search_filter.tags = ["user:alice"]` (AND containment semantics — a file
+  matches only when it carries **all** listed tags).
+
+This gives profile isolation without maintaining separate ReMe workspaces per
+profile. You can still share durable `digest/` files by omitting user tags on
+them.
+
+## Server status
+
+To check ReMe is up: call `version` and `health_check`, then summarize the
+version and the health snapshot (components, workspace). If the
+`mcp__reme__…` tools are not available at all, the server is not running —
+tell the user to start it with the command above. The plugin connects at
+`http://127.0.0.1:2333/mcp`; a different host/port must match the `url` in
+`plugins/reme/.mcp.json`.
+
+## Workspace model
+
+```
+daily/    lightly-processed memory: daily facts, conversation summaries
+digest/   long-term consolidated knowledge (what recall mainly surfaces)
+resource/ external raw materials
+```
+
+Consolidation of `daily/` into `digest/` and proactive interest extraction run
+**server-side** in the ReMe process (background watchers + dream cron). The
+plugin does not drive them.


### PR DESCRIPTION
## 背景

QwenPaw 是 Qwen 系列助理，与 ReMe 集成后可获得持久、文件原生的长期记忆能力。Issue #349 提出了完整的 Python SDK 级集成需求，但该需求涉及 QwenPaw 内部调度器和会话管理器的深度耦合，实现成本高且需要分阶段推进。

本轮先交付 **可安装的 QwenPaw 插件骨架**，使 QwenPaw 用户当前就可以通过 ReMe MCP (HTTP) 接口完成 80% 的长期记忆能力（召回 + 自动持久化）。完整深度 SDK 集成留给后续 PR 或社区贡献者。

## 改动内容

在 `plugins/qwenpaw/` 下新增一套与 `plugins/claude_code` 结构完全同构的 QwenPaw 插件骨架（共 5 个新文件 + 4 级目录）：

1. **`plugins/qwenpaw/README.md`** — 安装说明、前置条件（启动 ReMe MCP server）、目录结构、多用户隔离使用提示。
2. **`plugins/qwenpaw/reme/.mcp.json`** — ReMe streamable-http MCP 配置，默认 `http://127.0.0.1:2333/mcp`，与其他插件保持一致。
3. **`plugins/qwenpaw/reme/hooks/hooks.json`** — Stop Hook 注册，使用 `QWENPAW_PLUGIN_ROOT` 环境变量定位插件根目录。
4. **`plugins/qwenpaw/reme/hooks/auto_memory.py`** — fire-and-forget 型 Stop Hook：
   - 从 stdin 读取 QwenPaw 插件框架下发的 `conversation_id` / `session_id` + `profile_id`
   - 通过 **double-fork** 守护进程化，立即返回主进程（避免阻塞 QwenPaw 退出）
   - 使用最小 streamable-http MCP 客户端（initialize → initialized → tools/call）调用 ReMe server 侧 `auto_memory` 工具
   - 最佳实践：ReMe 未启动或不可达只写日志不抛错；健康检查、检索、写入使用独立超时
5. **`plugins/qwenpaw/reme/skills/reme-memory/SKILL.md`** — ReMe 记忆召回 SOP，覆盖 3 种召回模式（语义 search / 拓扑 traverse / 状态 daily_list+frontmatter_read），并补充 **多用户/多 profile scoping** 章节，显式说明如何利用 `tags: [user:alice]` frontmatter + `tags` search filter 实现 profile 隔离。

### 与 Issue #349 的关系

- 本次交付 **不声称关闭** #349。PR 描述为 "towards #349"，因为以下在 Issue 中列出的项明确 **未实现**，留给后续：
  - 通过 Python SDK 深度嵌入到 QwenPaw 应用生命周期管理（当前走 MCP 协议层）
  - QwenPaw conversations/profiles 到 ReMe session/user 边界的 1:1 自动映射（当前在 SKILL.md 中给出了 frontmatter tags 实现范式，未写 SDK 级映射代码）
  - 自动 memory consolidation 与 proactive memory workflow 的 QwenPaw scheduler 集成（当前由 ReMe server 侧 dream/cron 驱动）
  - 完整 lifecycle 与 memory 单元测试套件

## 验证方式

1. **Pre-commit**: `~/.pyenv/versions/3.12.12/bin/python -m pre_commit run --files <5 个新文件>` → **全通过**（check-json / add-trailing-comma / black / flake8 / pylint C0116 修复 / pyroma 共 12 个 hook）。
2. **Unit tests**: `~/.pyenv/versions/3.12.12/bin/python -m pytest tests/unit -x -q` → **858 passed**，零回归。
3. **JSON 合法性独立验证**: `python3 -c "json.load(open('.mcp.json')); json.load(open('hooks.json'))"` → OK。
4. **手动冒烟（README 路径）**：
   - 执行 `reme start service.backend=mcp service.transport=streamable-http` 启动服务
   - 在 QwenPaw 侧 `qwenpaw plugins add ./plugins/qwenpaw` + `qwenpaw plugins enable reme`
   - 运行 `/mcp` 或等价命令，应能看到 `reme` server 已连接且 `search/traverse/daily_list/read` 工具可用

## 影响范围

- **仅新增 5 个文件**，零修改现有源代码。无 Breaking Change。
- 与现有 3 个插件（`claude_code` / `codex` / `openclaw`）目录结构保持严格对齐，维护成本均匀。
- 不影响 ReMe 核心运行逻辑。

## Checklist

- [x] 单元测试全部通过 (`858 passed`)
- [x] Pre-commit hooks 全部通过 (12/12 hooks，含 check-json / add-trailing-comma / black / flake8 / pylint / pyroma)
- [x] README 写清前置条件、安装步骤、多用户 scoping 指南、故障排查入口
- [x] hooks.json 与 .mcp.json JSON 合法，无 trailing comma
- [x] 明确声明 "towards #349"，不做 SDK 级深度集成，避免过度承诺
