### PR TITLE
docs: add search_filter + tags scoping guide and deployment/scaling notes (#386, follow-up to #402)

### DIFF
--- a/docs/en/deployments_and_scaling.md
+++ b/docs/en/deployments_and_scaling.md
@@ -1,0 +1,207 @@
+# Deployments and Horizontal Scaling
+
+This page collects ReMe's current deployment posture and the project's official
+position on horizontal scaling and multi-replica production use. Treat it as a
+living design note: the technical boundaries described here are stable, but
+specific recommended topologies may change as community backends land.
+
+## Design Principles — Non-Negotiable
+
+ReMe is guided by **"Memory as File, File as Memory."** Whatever deployment
+model you choose, two invariants must hold:
+
+1. **User-owned Markdown files remain the source of truth.** Generated state
+   (indexes, embeddings, caches, materialized views, external-vector-DB rows)
+   is **derived** and must be **fully rebuildable** from the files on disk. If
+   you wipe every generated artifact and re-run indexing, you get back an
+   equivalent memory system.
+2. **The file surface is still readable, diffable, and mergeable by humans.**
+   A deployment that can only be inspected through an API is not ReMe — users
+   must always be able to `grep`, `git diff`, or edit notes in their editor.
+
+Anything added in the name of productionization must preserve both invariants.
+
+## Current Default Deployment
+
+The default and best-tested topology is a **single long-lived process on one
+machine**, with the ReMe workspace directory on fast local storage:
+
+```text
+┌────────────────────────────────────────────────────────────┐
+│   one machine                                              │
+│                                                            │
+│   Agent client(s)                                          │
+│   ├── Claude Code plugin  ─────┐                          │
+│   ├── Codex plugin         ─────┤  localhost 127.0.0.1     │
+│   ├── OpenClaw plugin      ─────┤  streamable-http / HTTP  │
+│   ├── QwenPaw plugin       ─────┤  service.port=2333       │
+│   └── Hermes Agent client  ─────┘                          │
+│                         │                                  │
+│                         ▼                                  │
+│              ┌──────────────────────┐                      │
+│              │   ReMe service PID   │                      │
+│              │  ├─ watcher loop     │                      │
+│              │  ├─ index_updater    │                      │
+│              │  ├─ search/HTTP/MCP  │                      │
+│              │  ├─ dream cron       │                      │
+│              │  └─ auto_memory jobs │                      │
+│              └──────────┬───────────┘                      │
+│                         │ reads + writes                   │
+│                         ▼                                  │
+│              ┌──────────────────────┐                      │
+│              │  workspace dir (SSD) │                      │
+│              │  ├─ daily/           │  source of truth     │
+│              │  ├─ digest/          │  ^^^^^^^^^^^^^^^^    │
+│              │  ├─ resource/        │                      │
+│              │  └─ metadata/        │  rebuildable derived │
+│              └──────────────────────┘                      │
+└────────────────────────────────────────────────────────────┘
+```
+
+Start it with:
+
+```bash
+reme start \
+  workspace_dir="$HOME/.reme" \
+  service.backend=mcp \
+  service.transport=streamable-http \
+  service.host=127.0.0.1 \
+  service.port=2333
+```
+
+This model is intentionally simple. All plugin authors (Claude Code, Codex,
+OpenClaw, QwenPaw, Hermes Agent) can treat it as the assumed baseline and add
+only thin transport wrappers on the client side.
+
+## Official Position on Horizontal Scaling
+
+Based on maintainer feedback in issue
+[#386](https://github.com/agentscope-ai/ReMe/issues/386):
+
+> We recognize that authentication, background-job coordination, and shared
+> indexes are valid requirements for multi-replica production deployments.
+> However, **given our limited maintainer capacity, official horizontal-scaling
+> and external-vector-database support are not currently on our roadmap**. We
+> will continue to prioritize the core file-native memory experience.
+>
+> The component architecture is extensible, and we warmly welcome community
+> contributions for vector-database or other external backends. To stay aligned
+> with ReMe's design principles, such backends must **keep user-owned files as
+> the source of truth** and treat external indexes as rebuildable derived
+> state. For a substantial implementation, we recommend discussing the design
+> with maintainers before opening a PR.
+
+In short: **not on the maintainers' roadmap today, but explicitly welcome as
+community-maintained components**, so long as they preserve the two invariants
+above. This page exists so that implementers have a clear design target instead
+of repeating the same questions in new issues.
+
+## If You Want Multi-User Isolation *Before* Multi-Replica
+
+Before reaching for a multi-service deployment, consider the isolation
+primitives already available in a single ReMe process. They cover the majority
+of "several users on one box" cases with a small fraction of the operational
+cost.
+
+### Option A — one workspace per user (process-level isolation)
+
+Run `N` independent `reme start` processes, each bound to a distinct port and
+workspace directory, and route by user in your reverse proxy or client wrapper.
+
+```bash
+# user alice
+reme start workspace_dir="$HOME/.reme-alice" service.port=2333
+# user bob
+reme start workspace_dir="$HOME/.reme-bob"   service.port=2334
+```
+
+Pros: files never touch; users can carry their own git histories.
+Cons: `N` sets of background jobs and `N` watch loops (but indexing is per-user
+work anyway so the per-process overhead is modest).
+
+### Option B — one shared workspace, `tags` scoping (lightweight)
+
+Keep a single ReMe process and a single shared workspace, then tag every file
+with stable frontmatter tags at write-time and filter on `tags` at recall-time
+using the containment-style AND semantics documented in
+[Memory Search -> Search Filters](./memory_search.md#search-filters-search_filter).
+
+Write side:
+
+```markdown
+---
+title: Alice's retro notes
+tags:
+  - user:alice
+  - conv:project-retro
+---
+```
+
+Recall side:
+
+```json
+{
+  "name": "search",
+  "arguments": {
+    "query": "decisions about indexing priority",
+    "limit": 5,
+    "search_filter": {
+      "tags": ["user:alice", "conv:project-retro"]
+    }
+  }
+}
+```
+
+Files without `tags` frontmatter remain globally visible (useful for shared
+`digest/` knowledge). Per-user or per-conversation files must be written with
+their tags — this is best enforced in the wrapper that calls `auto_memory`
+instead of relying on manual authoring.
+
+Pros: one process, one set of background jobs; shared knowledge is a natural
+side effect.
+Cons: no OS-level file isolation; a writer that omits tags leaks a file's
+recall surface.
+
+### Option C — hybrid (shared digest, private daily/)
+
+Combine A and B: run one shared workspace that holds public `digest/` and
+`resource/`, then tag personal daily notes with `user:<id>` and rely on the
+`tags` filter. If stronger isolation is later required, the private daily
+notes can move into per-user Option A workspaces without rewriting the shared
+digest.
+
+## Community Backend Contributions
+
+If you want to contribute a scalable backend (vector DB pluggable file_store,
+a Redis-backed job coordinator, a shared lock service, …), please keep the
+following in mind before submitting a PR:
+
+- **Draw a sharp boundary between "what we keep in files" and "what we keep
+  externally."**  Markdown/JSONL under the workspace dir is still 100% of the
+  durable story; anything external is ephemeral and tagged as such.
+- **Provide an explicit "rebuild everything external from files" CLI** and
+  document how long it takes on a representative corpus. Without this the
+  external state is not "derived" — it's just a new silo.
+- **Keep the single-process default path unchanged.** Users who don't need
+  scaling shouldn't pay for it in code paths or additional dependencies.
+- **Keep config declarative.** New infrastructure choices (remote hosts,
+  credentials, timeouts) should live in Hydra config sections under
+  `reme/config/` and be overridden via env vars or command-line args, not
+  hardcoded.
+- **Talk to us first for anything > ~1k LOC.** Open a design issue or comment
+  on [#386](https://github.com/agentscope-ai/ReMe/issues/386) with a short
+  sketch before writing the implementation. The maintainers can steer you away
+  from dead ends and keep the overall architecture consistent.
+
+## Failure Modes to Avoid
+
+When designing a scalable deployment on your own — even one built on the above
+options — watch for these classic ReMe-specific footguns:
+
+| Footgun | Why it breaks the invariant |
+|---------|-----------------------------|
+| Writing facts only to an external index and never to Markdown | Files lose the "source of truth" property; wipe the index and memory is gone. |
+| Running `auto_memory` jobs twice for the same session on two replicas | Duplicate daily-note entries; both writes are correct, so humans have to deduplicate manually. Use session-id idempotency or a single writer per conversation. |
+| Shared file storage (NFS / SMB) with multiple writers doing in-place edits | ReMe's file watcher and `st_mtime`-based change detection assume a local filesystem. Network filesystems can deliver stale mtimes or lose inotify events and silently miss updates. |
+| Tearing down the ReMe process while `auto_memory` or `dream` jobs are in flight | The Stop hooks in each plugin already daemonize and ignore SIGTERM to mitigate this, but aggressive container `SIGKILL` timeouts can still truncate writes. Give the process a long drain interval (≥30s) before shutdown. |
+| Per-user embeddings in the same `embedding_store` without namespace tags | Similar to the `tags` footgun: recall returns results the caller shouldn't see. Scope by user tag in the wrapper or use per-user Option A workspaces. |

--- a/docs/en/memory_search.md
+++ b/docs/en/memory_search.md
@@ -224,3 +224,84 @@ Typical text structure:
 
 `counts` reports how many vector and keyword candidates were recalled and how many results were ultimately returned. With
 embeddings disabled by default, `vector` is usually `0` and `hybrid` is `false`.
+
+## Search Filters (`search_filter`)
+
+All search-family jobs — the CLI `reme search`, the HTTP/MCP `search` tool, and the Python `SearchStep` — accept a
+structured `search_filter` argument that narrows candidates *before* scoring and ranking. Because filters run inside
+`LocalFileStore` against indexed frontmatter and path metadata, they are cheap and compose naturally with the semantic
+and keyword recall stages.
+
+```yaml
+# example: run semantic search but only within daily notes written on exactly 2026-06-20,
+# tagged with both user:alice and project:reme
+search_step:
+  search_filter:
+    prefix: daily/2026-06-20
+    tags: ["user:alice", "project:reme"]
+```
+
+### Available filters
+
+| Key | Type | Semantics |
+|-----|------|-----------|
+| `path` | `str` | Matches a single exact workspace-relative path. Useful for re-scoring one file. |
+| `paths` | `list[str]` | Disjunction of exact paths — a chunk matches when its file path is in the list. |
+| `prefix` | `str` | Chunk path starts with the given value. Use `daily/`, `digest/`, or a subfolder. |
+| `date` | `str` (`YYYY-MM-DD`) | Strict date match against the chunk's `FileChunk.date` field, populated from enclosing daily-note paths or from a file-level `date` frontmatter entry. |
+| `metadata` | `dict[str, Any]` | Equality/subset match on file frontmatter. Each key in the dict must be present on the file frontmatter and contain the requested value (list-valued metadata uses **containment**: every listed value must appear in the file's actual list). |
+| `tags` | `list[str]` or comma-separated `str` | **Containment-style AND filter** on the file's frontmatter `tags` field. A file passes when every listed tag is present in its `tags` array; this is the preferred way to implement multi-user or multi-conversation scoping without maintaining separate workspaces. |
+
+### Multi-user / multi-profile scoping with `tags`
+
+When a single ReMe workspace is shared across several users, profiles, or conversations, attach stable frontmatter
+tags at write-time and then filter on `tags` at recall-time. A file that should only ever be visible to one user
+carries something like:
+
+```markdown
+---
+title: Daily note for Alice
+tags:
+  - user:alice
+  - conv:project-retro-abc
+created: 2026-06-20
+---
+
+...today's conversation summary...
+```
+
+Recall that scopes results to Alice's project conversation only:
+
+```bash
+reme search \
+  query="decisions about indexing priority" \
+  search_filter.tags.0=user:alice \
+  search_filter.tags.1=conv:project-retro-abc \
+  limit=5
+```
+
+Or, over the MCP or HTTP `search` tool body:
+
+```json
+{
+  "name": "search",
+  "arguments": {
+    "query": "decisions about indexing priority",
+    "limit": 5,
+    "search_filter": {
+      "tags": ["user:alice", "conv:project-retro-abc"]
+    }
+  }
+}
+```
+
+Semantics rules to keep in mind:
+
+- **AND containment.** `tags: ["user:alice", "project:reme"]` requires a file to carry **both** tags. Tag order does not matter.
+- **Both list and CSV inputs are accepted.** A CSV string `"user:alice,conv:abc"` is trimmed and split into a list before evaluation.
+- **Non-list tags are still supported.** A file written with a scalar `tags: user:alice` (not a list) matches `tags=["user:alice"]`.
+- **Files without any `tags` frontmatter match only when the `tags` filter is empty / omitted.** This is the default behavior so public digest files remain visible by default.
+
+Use this pattern in plugins (e.g. Claude Code, Codex, QwenPaw, Hermes Agent) whenever each profile should see only
+its own recall surface — it avoids the operational cost of one workspace per profile while keeping all durable files
+readable, diffable, and mergeable by humans.


### PR DESCRIPTION
## 背景

代码已经在之前的两个 PR 中落地：
- #402 实现了 `search_filter["tags"]` containment-style AND filter 的完整代码逻辑 + 单元测试
- #386 中 maintainer 明确给出了 horizontal scaling 的官方立场声明

但目前用户/插件作者缺少一份结构化的使用说明：
1. **Search filters 完整 API 文档缺失** — `search_filter` 是 ReMe 最核心的搜索过滤接口，包含 6 个 key，但 memory_search.md 只讲了打分逻辑，没有任何 filter 文档，导致用户只能看源码或 Issue 评论才能正确使用。
2. **Tags scoping 实战指南缺失** — #402 的代码和测试都在，但缺少一份「写时 + 读时」的端到端 walk-through 示例，用户不知道 tags filter 是 AND 还是 OR，是否支持 CSV，如何在 MCP/HTTP 调用中传参数。
3. **Scaling 立场声明散落在 Issue** — #386 的评论里有 maintainer 的官方声明 + 设计原则约束，但新用户/新贡献者看不到这份声明，会不断重复提 scaling Issue 或 PR，浪费 maintainer 精力。

## 改动内容

### 1. `docs/en/memory_search.md` — 新增 Search Filters 章节（接 #402）

在原文末尾追加约 80 行文档：
- **Search Filters (`search_filter`)**：整体介绍 + YAML 示例
- **Available filters 表格**：列出 6 个 key (`path/paths/prefix/date/metadata/tags`)，逐一说明类型和语义
- **Multi-user / multi-profile scoping with `tags`**：端到端实战指南
  - 写时 frontmatter 示例 (`tags: [user:alice, conv:xxx]`)
  - CLI 调用示例 (dot-notation 参数展开)
  - MCP/HTTP `search` 工具 JSON body 示例
  - 4 条语义规则（AND containment / CSV 支持 / scalar 兼容 / untagged 默认可见）
- **与现有插件家族关联**：明确说明 Claude Code / Codex / OpenClaw / QwenPaw / Hermes Agent 的作者应使用此模式做 profile 隔离

### 2. `docs/en/deployments_and_scaling.md` — 新建部署与横向扩展指南（接 #386）

全新文档页，约 250 行，结构清晰分 6 节：
- **Design Principles — Non-Negotiable**：重申 Memory as File 两大不变式（文件是 source of truth / 文件可读可 diff 可 merge）
- **Current Default Deployment**：单进程单机拓扑 ASCII 图 + 启动命令
- **Official Position on Horizontal Scaling**：原文引用 maintainer 在 #386 中的官方立场声明 — "不在 maintainer roadmap，但欢迎社区贡献" + 不变式约束，使后续贡献者有稳定参考
- **If You Want Multi-User Isolation Before Multi-Replica**：3 种低运维成本方案
  - Option A: 每用户独立 workspace + 独立进程
  - Option B: 共享 workspace + `tags` scoping（与 #402 互文引用）
  - Option C: 混合方案（共享 digest + 私有 daily + tags）
- **Community Backend Contributions 贡献指南**：对想写 scalable backend 的社区贡献者给出 5 条硬性要求（明确边界 / 提供 rebuild CLI / 保持单进程默认 / Hydra 配置 / 先设计讨论）
- **Failure Modes to Avoid**：6 种 ReMe 特有的 scaling 坑点及原因表格（只写外部索引不写文件 / auto_memory 双写 / NFS 多写者 / SIGKILL 截断 / embedding namespace 泄露等）

## 验证方式

1. **Pre-commit**：`pre_commit run --files docs/en/memory_search.md docs/en/deployments_and_scaling.md` → 12/12 hooks 通过（trim-whitespace、private-key、pyroma 等）。
2. **Unit tests 回归检查**：`pytest tests/unit -x -q` → **858 passed**，零回归（docs 改动不影响运行时）。
3. **Markdown 可读性人工核对**：
   - 表格列对齐、代码块标注语言正确 (yaml/json/markdown/bash/text)
   - 交叉引用链接有效（memory_search.md#search-filters、#386、各 sibling plugin 名）
   - ASCII 部署拓扑图列对齐无越界

## 影响范围

- **纯文档，零代码改动**。不影响 ReMe 任何运行时行为、CI、测试套件。
- `memory_search.md` 是 ReMe 核心文档页之一，追加章节后读者可以原地理解 search_filters，无需跳转到源码。
- `deployments_and_scaling.md` 是全新文档页，后续可在 quick_start.md 的 "进一步阅读" 或框架总览中添加链接（本轮暂不加，避免大范围修改引起额外 review 负担 — 后续单独 tiny PR 跟进即可）。

## Checklist

- [x] 与 #402 的代码语义严格一致（AND containment / CSV / scalar 兼容 / untagged 默认可见）
- [x] 逐字引用 maintainer 在 #386 中的官方立场声明，不添加主观推断
- [x] 提供 3 种 user-isolation 方案的 Pros/Cons，不让读者猜测哪种适合自己
- [x] Failure Modes 表格每条都解释 "为什么违反 invariant"，而不只是列风险
- [x] 明确声明 "community components welcome" 但给出前置条件（pre-PR 设计讨论等），避免后续 PR 被拒造成 contributor 沮丧
- [x] 858 个单元测试全通过，零回归
