### PR TITLE
docs: link ExpG news to toolmemory README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ memory, then continuously indexes, links, and consolidates that memory for futur
 
 ## 📰 News
 
-- [2026.08] - Experience-driven enhancement of agent tool-use execution built on ReMe is available on
-  [arXiv:2608.03403](https://arxiv.org/abs/2608.03403).
+- [2026.08] - [Experience-driven enhancement method](benchmark/toolmemory/README.md) of agent tool-use
+  execution built on ReMe is available on [arXiv:2608.03403](https://arxiv.org/abs/2608.03403).
 - [2026.07] - Introduced optional Cookbooks: [Daily Paper](cookbook/daily_paper/README.md) for paper discovery and
   analysis, and [Auto Fin](cookbook/auto-fin/README.md) for file-native ETF event research based on CLS news and
   historical market reactions.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -52,7 +52,8 @@ Agent 能够可靠召回。
 
 ## 📰 新闻
 
-- [2026.08] - 基于 ReMe 的智能体工具使用执行增强工作见
+- [2026.08] - 基于 ReMe 的智能体工具使用
+  [经验驱动增强方法](benchmark/toolmemory/README_ZH.md)已发布，见
   [arXiv:2608.03403](https://arxiv.org/abs/2608.03403)。
 - [2026.07] - 新增可选 Cookbook 工作流：[每日论文](cookbook/daily_paper/README_ZH.md)用于论文发现与解析，
   [Auto Fin](cookbook/auto-fin/README_ZH.md)用于结合财联社新闻和历史行情开展文件化 ETF 事件研究。


### PR DESCRIPTION
## Summary
- Link the News phrase “Experience-driven enhancement method” to `benchmark/toolmemory/README.md`
- Mirror the change in `README_ZH.md` with a relative link to `README_ZH.md`
- Keep the existing arXiv link

## Test plan
- [ ] Confirm News links resolve to `benchmark/toolmemory` READMEs on GitHub
- [ ] Confirm arXiv link still works

Made with [Cursor](https://cursor.com)