### PR TITLE
feat(api): Add workspace web APIs and GitHub star growth reporting

### DIFF
--- a/reme/components/runtime_context.py
+++ b/reme/components/runtime_context.py
@@ -73,6 +73,11 @@ class RuntimeContext:
         await self._enqueue(StreamChunk(chunk_type=chunk_type, chunk=chunk))
         return self
 
+    async def add_stream_chunk(self, chunk: StreamChunk) -> "RuntimeContext":
+        """Emit a complete chunk while preserving session and tool metadata."""
+        await self._enqueue(chunk)
+        return self
+
     async def add_stream_done(self) -> "RuntimeContext":
         """Emit the terminal DONE marker to close the stream."""
         await self._enqueue(StreamChunk(chunk_type=ChunkEnum.DONE, chunk="", done=True))

--- a/reme/config/default.yaml
+++ b/reme/config/default.yaml
@@ -211,6 +211,36 @@ jobs:
     steps:
       - backend: version_step
 
+  app_config:
+    backend: base
+    description: "return the effective application config with secrets redacted"
+    parameters:
+      type: object
+      properties: { }
+    steps:
+      - backend: app_config_step
+
+  chat:
+    backend: stream
+    description: "Stream a read-only agent conversation over the ReMe workspace."
+    parameters:
+      type: object
+      properties:
+        query:
+          type: string
+          description: "user message"
+        session_id:
+          type: string
+          description: "agent session to resume"
+        system_prompt:
+          type: string
+          description: "optional system prompt override"
+      required:
+        - query
+    steps:
+      - backend: chat_step
+        agent_wrapper: default
+
   health_check:
     backend: base
     description: "return a concise health-check snapshot of reme components"
@@ -542,6 +572,21 @@ jobs:
         with_neighbors: false
         max_neighbors_per_direction: 10
 
+  load:
+    backend: base
+    description: "Load a complete text file for the local editor without agent-output truncation."
+    parameters:
+      type: object
+      properties:
+        path:
+          type: string
+          description: "workspace-relative path"
+      required:
+        - path
+    steps:
+      - backend: load_step
+        max_bytes: 5242880
+
   read_image:
     backend: base
     description: "Read an image file as base64 (workspace-relative path)."
@@ -587,6 +632,27 @@ jobs:
         - content
     steps:
       - backend: write_step
+
+  save:
+    backend: base
+    description: "Save text verbatim, optionally rejecting external changes since the file was opened."
+    parameters:
+      type: object
+      properties:
+        path:
+          type: string
+          description: "workspace-relative path"
+        content:
+          type: string
+          description: "complete file content, including frontmatter"
+        expected_mtime:
+          type: string
+          description: "optional ISO mtime returned by stat"
+      required:
+        - path
+        - content
+    steps:
+      - backend: save_step
 
   daily_write:
     backend: base

--- a/reme/steps/common/__init__.py
+++ b/reme/steps/common/__init__.py
@@ -1,6 +1,8 @@
 """common steps"""
 
 from .add import AddStep
+from .app_config import AppConfigStep
+from .chat import ChatStep
 from .demo import DemoEchoStep1, DemoEchoStep2
 from .health_check import HealthCheckStep
 from .help import HelpStep
@@ -14,6 +16,8 @@ from .version import VersionStep
 
 __all__ = [
     "AddStep",
+    "AppConfigStep",
+    "ChatStep",
     "DemoEchoStep1",
     "DemoEchoStep2",
     "HealthCheckStep",

--- a/reme/steps/common/app_config.py
+++ b/reme/steps/common/app_config.py
@@ -1,0 +1,85 @@
+"""Return the effective application configuration."""
+
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from ..base_step import BaseStep
+from ...components import R
+
+_SECRET_KEYS = {
+    "api_key",
+    "app_secret",
+    "authorization",
+    "cookie",
+    "password",
+    "private_key",
+    "proxy_authorization",
+    "secret",
+    "set_cookie",
+    "token",
+}
+_SECRET_SUFFIXES = ("_access_key", "_api_key", "_password", "_private_key", "_secret", "_token")
+
+
+def _is_secret_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    return normalized in _SECRET_KEYS or normalized.endswith(_SECRET_SUFFIXES)
+
+
+def _redact_url(value: str) -> str:
+    """Redact credentials embedded in an HTTP-style URL."""
+    try:
+        parsed = urlsplit(value)
+        if not parsed.scheme or not parsed.netloc:
+            return value
+
+        netloc = parsed.netloc
+        if parsed.password is not None:
+            host = parsed.hostname or ""
+            if ":" in host:
+                host = f"[{host}]"
+            if parsed.port is not None:
+                host = f"{host}:{parsed.port}"
+            netloc = f"{parsed.username or ''}:***@{host}"
+
+        query = urlencode(
+            [
+                (key, "***" if _is_secret_key(key) else item)
+                for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+            ],
+        )
+        return urlunsplit((parsed.scheme, netloc, parsed.path, query, parsed.fragment))
+    except ValueError:
+        return value
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted = {}
+        for key, item in value.items():
+            key_string = str(key)
+            if _is_secret_key(key_string) or (
+                key_string.lower() == "credential" and not isinstance(item, (dict, list))
+            ):
+                redacted[key] = "***"
+            else:
+                redacted[key] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, str):
+        return _redact_url(value)
+    return value
+
+
+@R.register("app_config_step")
+class AppConfigStep(BaseStep):
+    """Return the effective config without startup environment or secrets."""
+
+    async def execute(self):
+        assert self.context is not None
+        assert self.app_context is not None
+
+        config = self.app_context.app_config.model_dump(mode="json", exclude={"environment"})
+        self.context.response.answer = _redact(config)
+        return self.context.response

--- a/reme/steps/common/chat.py
+++ b/reme/steps/common/chat.py
@@ -1,0 +1,45 @@
+"""Workspace-aware streaming chat step for the ReMe web interface."""
+
+from ..base_step import BaseStep
+from ...components import R
+from ...enumeration import ChunkEnum
+
+
+@R.register("chat_step")
+class ChatStep(BaseStep):
+    """Stream a read-only agent conversation over the current workspace."""
+
+    DEFAULT_SYSTEM_PROMPT = """You are ReMe Agent, an assistant for a local-first memory workspace.
+Use the available ReMe tools when workspace facts are needed. Cite workspace-relative file paths
+when referring to notes. Never invent file contents, and do not claim to have changed files because
+this chat intentionally provides read-only tools. Reply in the user's language."""
+    READ_ONLY_TOOLS = ["search", "list", "read", "stat", "traverse"]
+
+    async def execute(self):
+        assert self.context is not None
+        query = str(self.context.get("query") or "").strip()
+        if not query:
+            self.context.response.success = False
+            self.context.response.answer = "Skipped: empty query"
+            return self.context.response
+        if self.agent_wrapper is None:
+            raise RuntimeError("chat_step requires an agent_wrapper")
+
+        wrapper_kwargs = {
+            "system_prompt": self.context.get("system_prompt") or self.DEFAULT_SYSTEM_PROMPT,
+            "job_tools": self.READ_ONLY_TOOLS,
+        }
+        if session_id := self.context.get("session_id"):
+            wrapper_kwargs["resume"] = str(session_id)
+
+        parts: list[str] = []
+        async for chunk in self.agent_wrapper.reply_stream(query, **wrapper_kwargs):
+            await self.context.add_stream_chunk(chunk)
+            if chunk.chunk_type == ChunkEnum.CONTENT and isinstance(chunk.chunk, str):
+                parts.append(chunk.chunk)
+            if chunk.session_id:
+                self.context.response.metadata["session_id"] = chunk.session_id
+
+        self.context.response.success = True
+        self.context.response.answer = "".join(parts).strip()
+        return self.context.response

--- a/reme/steps/file_io/__init__.py
+++ b/reme/steps/file_io/__init__.py
@@ -12,9 +12,11 @@ from .frontmatter_delete import FrontmatterDeleteStep
 from .frontmatter_read import FrontmatterReadStep
 from .frontmatter_update import FrontmatterUpdateStep
 from .list import ListStep
+from .load import LoadStep
 from .move import MoveStep
 from .read import ReadStep
 from .read_image import ReadImageStep
+from .save import SaveStep
 from .stat import StatStep
 from .write import WriteStep
 
@@ -35,9 +37,11 @@ __all__ = [
     "FrontmatterReadStep",
     "FrontmatterUpdateStep",
     "ListStep",
+    "LoadStep",
     "MoveStep",
     "ReadStep",
     "ReadImageStep",
+    "SaveStep",
     "StatStep",
     "WriteStep",
 ]

--- a/reme/steps/file_io/load.py
+++ b/reme/steps/file_io/load.py
@@ -1,0 +1,66 @@
+"""Load a complete text file for an interactive editor."""
+
+from datetime import datetime
+
+from ._file_io import read_file_safe
+from ._path import _check_path_permission, resolve_path
+from ..base_step import BaseStep
+from ...components import R
+
+DEFAULT_EDITOR_MAX_BYTES = 5 * 1024 * 1024
+
+
+@R.register("load_step")
+class LoadStep(BaseStep):
+    """Return complete text without the truncation used by agent-facing reads."""
+
+    def _fail(self, message: str, **metadata) -> None:
+        assert self.context is not None
+        self.context.response.success = False
+        self.context.response.answer = f"Error: {message}"
+        self.context.response.metadata.update(metadata)
+
+    async def execute(self):
+        assert self.context is not None
+        raw_path = str(self.context.get("path") or "")
+        max_bytes = int(self.context.get("max_bytes") or self.kwargs.get("max_bytes") or DEFAULT_EDITOR_MAX_BYTES)
+        target, error = resolve_path(self.workspace_path, raw_path)
+        if error or target is None:
+            self._fail(error or "invalid path", path=raw_path)
+            return self.context.response
+        if not _check_path_permission(self.workspace_path, target, self.context.get("_allowed_paths")):
+            self._fail("no permission to read this file", path=raw_path)
+            return self.context.response
+        if not target.is_file():
+            self._fail("file does not exist", path=raw_path)
+            return self.context.response
+
+        stat = target.stat()
+        if stat.st_size > max_bytes:
+            self._fail(
+                f"file is too large for the editor ({stat.st_size} bytes; limit {max_bytes})",
+                code="file_too_large",
+                path=raw_path,
+                size=stat.st_size,
+                max_bytes=max_bytes,
+            )
+            return self.context.response
+        try:
+            content, encoding = await read_file_safe(target, max_bytes=max_bytes)
+        except Exception as exc:  # pylint: disable=broad-except
+            self._fail(f"load failed: {exc}", path=raw_path)
+            return self.context.response
+
+        self.context.response.success = True
+        self.context.response.answer = content
+        self.context.response.metadata.update(
+            {
+                "path": raw_path,
+                "exists": True,
+                "type": "file",
+                "size": stat.st_size,
+                "mtime": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                "encoding": encoding,
+            },
+        )
+        return self.context.response

--- a/reme/steps/file_io/save.py
+++ b/reme/steps/file_io/save.py
@@ -1,0 +1,78 @@
+"""Save a text file verbatim with optional optimistic-concurrency protection."""
+
+from datetime import datetime
+
+from ._file_io import detect_file_encoding, get_path_lock, write_file_safe
+from ._path import _check_path_permission, resolve_path
+from ..base_step import BaseStep
+from ...components import R
+
+
+@R.register("save_step")
+class SaveStep(BaseStep):
+    """Persist editor content without interpreting or rebuilding frontmatter.
+
+    ``expected_mtime`` is the ISO timestamp returned by ``stat``. When supplied,
+    saving fails if the file changed after it was opened. This keeps the
+    filesystem authoritative when ReMe and another editor are used together.
+    """
+
+    def _fail(self, message: str, **metadata) -> None:
+        assert self.context is not None
+        self.context.response.success = False
+        self.context.response.answer = f"Error: {message}"
+        self.context.response.metadata.update(metadata)
+
+    async def execute(self):
+        assert self.context is not None
+        raw_path = str(self.context.get("path") or "")
+        content = str(self.context.get("content") or "")
+        expected_mtime = self.context.get("expected_mtime")
+
+        target, error = resolve_path(self.workspace_path, raw_path)
+        if error or target is None:
+            self._fail(error or "invalid path", path=raw_path)
+            return self.context.response
+        if not _check_path_permission(self.workspace_path, target, self.context.get("_allowed_paths")):
+            self._fail("no permission to write this file", path=raw_path)
+            return self.context.response
+        if target.exists() and not target.is_file():
+            self._fail("target is not a file", path=raw_path)
+            return self.context.response
+
+        lock = await get_path_lock(target)
+        async with lock:
+            current_mtime = datetime.fromtimestamp(target.stat().st_mtime).isoformat() if target.exists() else None
+            if expected_mtime and current_mtime != str(expected_mtime):
+                self._fail(
+                    "file changed outside ReMe; reload it before saving",
+                    code="file_conflict",
+                    path=raw_path,
+                    expected_mtime=str(expected_mtime),
+                    current_mtime=current_mtime,
+                )
+                return self.context.response
+
+            encoding = await detect_file_encoding(target) if target.exists() else "utf-8"
+            try:
+                await write_file_safe(target, content, encoding=encoding)
+            except Exception as exc:  # pylint: disable=broad-except
+                self._fail(f"save failed: {exc}", path=raw_path)
+                return self.context.response
+
+            stat = target.stat()
+            saved_mtime = datetime.fromtimestamp(stat.st_mtime).isoformat()
+
+        self.context.response.success = True
+        self.context.response.answer = f"Saved {raw_path} ({stat.st_size} bytes)"
+        self.context.response.metadata.update(
+            {
+                "path": raw_path,
+                "exists": True,
+                "type": "file",
+                "size": stat.st_size,
+                "mtime": saved_mtime,
+            },
+        )
+        self.logger.info(f"[{self.name}] saved path={target} bytes={stat.st_size} encoding={encoding}")
+        return self.context.response

--- a/scripts/github_star_growth.py
+++ b/scripts/github_star_growth.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Report daily new GitHub stars for a repository using the GitHub CLI."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import subprocess
+import sys
+from collections import Counter
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Any, TextIO
+from xml.sax.saxutils import escape
+
+DEFAULT_REPOSITORY = "agentscope-ai/ReMe"
+QUERY = """
+query($owner: String!, $name: String!, $before: String) {
+  repository(owner: $owner, name: $name) {
+    nameWithOwner
+    stargazerCount
+    stargazers(last: 100, before: $before) {
+      edges {
+        starredAt
+      }
+      pageInfo {
+        hasPreviousPage
+        startCursor
+      }
+    }
+  }
+}
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse and validate command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Print daily new-star counts for the latest N UTC calendar days.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPOSITORY,
+        metavar="OWNER/REPO",
+        help=f"GitHub repository (default: {DEFAULT_REPOSITORY})",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=365,
+        help="number of UTC calendar days to include (default: 365)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        metavar="PATH",
+        help="write CSV to PATH instead of standard output",
+    )
+    parser.add_argument(
+        "--chart",
+        type=Path,
+        metavar="PATH",
+        help="write the SVG chart to PATH (default: CSV path with an .svg suffix)",
+    )
+    args = parser.parse_args()
+
+    if args.days < 1:
+        parser.error("--days must be at least 1")
+    if args.repo.count("/") != 1 or any(not part for part in args.repo.split("/")):
+        parser.error("--repo must have the form OWNER/REPO")
+    return args
+
+
+def query_github(owner: str, name: str, before: str | None) -> dict[str, Any]:
+    """Fetch one page of repository stargazers through ``gh api graphql``."""
+    request = {
+        "query": QUERY,
+        "variables": {"owner": owner, "name": name, "before": before},
+    }
+    try:
+        result = subprocess.run(
+            ["gh", "api", "graphql", "--input", "-"],
+            input=json.dumps(request),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("GitHub CLI 'gh' is not installed or is not on PATH") from exc
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"gh api graphql failed: {detail}")
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("gh returned invalid JSON") from exc
+
+    if payload.get("errors"):
+        messages = "; ".join(error.get("message", str(error)) for error in payload["errors"])
+        raise RuntimeError(f"GitHub GraphQL API error: {messages}")
+
+    repository = payload.get("data", {}).get("repository")
+    if repository is None:
+        raise RuntimeError(f"repository not found or inaccessible: {owner}/{name}")
+    return repository
+
+
+def fetch_daily_stars(repository: str, start_date: date) -> tuple[Counter[date], int]:
+    """Fetch current stargazers and group their star timestamps by UTC date."""
+    owner, name = repository.split("/", maxsplit=1)
+    daily_stars: Counter[date] = Counter()
+    before: str | None = None
+    total_stars = 0
+
+    while True:
+        data = query_github(owner, name, before)
+        total_stars = data["stargazerCount"]
+        connection = data["stargazers"]
+        edges = connection["edges"]
+
+        reached_start = False
+        for edge in edges:
+            starred_at = datetime.fromisoformat(edge["starredAt"].replace("Z", "+00:00"))
+            starred_date = starred_at.astimezone(UTC).date()
+            if starred_date < start_date:
+                reached_start = True
+                continue
+            daily_stars[starred_date] += 1
+
+        page_info = connection["pageInfo"]
+        if reached_start or not page_info["hasPreviousPage"]:
+            break
+        before = page_info["startCursor"]
+        if before is None:
+            raise RuntimeError("GitHub returned an invalid pagination cursor")
+
+    return daily_stars, total_stars
+
+
+def write_csv(stream: TextIO, start_date: date, days: int, counts: Counter[date]) -> None:
+    """Write a row for every date in the requested period, including zero days."""
+    writer = csv.writer(stream, lineterminator="\n")
+    writer.writerow(["date", "new_stars"])
+    for offset in range(days):
+        current_date = start_date + timedelta(days=offset)
+        writer.writerow([current_date.isoformat(), counts[current_date]])
+
+
+def nice_tick_step(maximum: int, tick_count: int = 5) -> int:
+    """Return a readable positive interval for numeric axis ticks."""
+    rough_step = max(maximum, 1) / tick_count
+    magnitude = 10 ** math.floor(math.log10(rough_step))
+    normalized = rough_step / magnitude
+    if normalized <= 1:
+        multiplier = 1
+    elif normalized <= 2:
+        multiplier = 2
+    elif normalized <= 5:
+        multiplier = 5
+    else:
+        multiplier = 10
+    return max(1, multiplier * magnitude)
+
+
+def write_svg_chart(path: Path, repository: str, dates: list[date], values: list[int]) -> None:
+    """Render daily star increments as a dependency-free SVG bar chart."""
+    width, height = 1280, 640
+    margin_left, margin_right = 75, 30
+    margin_top, margin_bottom = 70, 85
+    plot_width = width - margin_left - margin_right
+    plot_height = height - margin_top - margin_bottom
+
+    tick_step = nice_tick_step(max(values, default=0))
+    axis_max = max(tick_step, math.ceil(max(values, default=0) / tick_step) * tick_step)
+    bar_slot = plot_width / len(values)
+    bar_width = max(0.8, bar_slot * 0.82)
+
+    svg = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+            f'viewBox="0 0 {width} {height}" role="img">'
+        ),
+        f"<title>{escape(repository)} daily new GitHub stars</title>",
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        (
+            f'<text x="{width / 2}" y="34" text-anchor="middle" font-family="sans-serif" '
+            f'font-size="22" font-weight="600" fill="#24292f">{escape(repository)} daily new stars</text>'
+        ),
+    ]
+
+    for tick in range(0, axis_max + 1, tick_step):
+        y = margin_top + plot_height - (tick / axis_max * plot_height)
+        svg.append(
+            f'<line x1="{margin_left}" y1="{y:.2f}" x2="{width - margin_right}" y2="{y:.2f}" '
+            'stroke="#d8dee4" stroke-width="1"/>',
+        )
+        svg.append(
+            f'<text x="{margin_left - 10}" y="{y + 4:.2f}" text-anchor="end" font-family="sans-serif" '
+            f'font-size="12" fill="#57606a">{tick}</text>',
+        )
+
+    for index, (current_date, value) in enumerate(zip(dates, values, strict=True)):
+        bar_height = value / axis_max * plot_height
+        x = margin_left + index * bar_slot + (bar_slot - bar_width) / 2
+        y = margin_top + plot_height - bar_height
+        svg.append(
+            f'<rect x="{x:.2f}" y="{y:.2f}" width="{bar_width:.2f}" height="{bar_height:.2f}" '
+            f'fill="#2f81f7"><title>{current_date.isoformat()}: {value} new stars</title></rect>',
+        )
+
+    label_count = min(12, len(dates))
+    label_indexes = sorted({round(index * (len(dates) - 1) / max(label_count - 1, 1)) for index in range(label_count)})
+    baseline = margin_top + plot_height
+    for index in label_indexes:
+        x = margin_left + (index + 0.5) * bar_slot
+        svg.append(
+            f'<line x1="{x:.2f}" y1="{baseline}" x2="{x:.2f}" y2="{baseline + 5}" stroke="#57606a"/>',
+        )
+        svg.append(
+            f'<text x="{x:.2f}" y="{baseline + 20}" text-anchor="end" '
+            f'transform="rotate(-35 {x:.2f} {baseline + 20})" font-family="sans-serif" '
+            f'font-size="11" fill="#57606a">{dates[index].isoformat()}</text>',
+        )
+
+    svg.extend(
+        [
+            (
+                f'<line x1="{margin_left}" y1="{baseline}" x2="{width - margin_right}" y2="{baseline}" '
+                'stroke="#57606a"/>'
+            ),
+            (
+                f'<text x="18" y="{margin_top + plot_height / 2}" text-anchor="middle" '
+                f'transform="rotate(-90 18 {margin_top + plot_height / 2})" font-family="sans-serif" '
+                'font-size="13" fill="#24292f">New stars</text>'
+            ),
+            "</svg>",
+        ],
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(svg) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    """Run the report and return a process exit code."""
+    args = parse_args()
+    end_date = datetime.now(UTC).date()
+    start_date = end_date - timedelta(days=args.days - 1)
+
+    try:
+        counts, total_stars = fetch_daily_stars(args.repo, start_date)
+        dates = [start_date + timedelta(days=offset) for offset in range(args.days)]
+        values = [counts[current_date] for current_date in dates]
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            with args.output.open("w", encoding="utf-8", newline="") as stream:
+                write_csv(stream, start_date, args.days, counts)
+        else:
+            write_csv(sys.stdout, start_date, args.days, counts)
+        chart_path = args.chart or (args.output.with_suffix(".svg") if args.output else Path("star_growth.svg"))
+        write_svg_chart(chart_path, args.repo, dates, values)
+    except (OSError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    destination = str(args.output) if args.output else "stdout"
+    period_stars = sum(counts.values())
+    print(
+        f"Fetched {period_stars} current stargazers in {start_date}..{end_date}; "
+        f"repository currently has {total_stars} stars. CSV: {destination}; chart: {chart_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_app_config_step.py
+++ b/tests/unit/test_app_config_step.py
@@ -1,0 +1,44 @@
+"""Tests for the application config step."""
+
+import asyncio
+
+from reme.components.application_context import ApplicationContext
+from reme.steps.common.app_config import AppConfigStep
+
+
+def test_app_config_step_returns_effective_config_without_secrets(tmp_path):
+    """Effective values are returned while startup secrets stay private."""
+    context = ApplicationContext(
+        app_name="Test ReMe",
+        workspace_dir=str(tmp_path),
+        environment={"PRIVATE_VALUE": "hidden"},
+        components={
+            "as_llm": {
+                "default": {
+                    "backend": "openai",
+                    "credential": {"api_key": "key", "base_url": "https://example.test"},
+                },
+            },
+        },
+        mcp_servers={
+            "private": {
+                "url": "https://user:password@example.test/mcp?access_token=url-token&mode=read",
+                "headers": {
+                    "Authorization": "Bearer header-token",
+                    "X-API-Key": "header-key",
+                },
+                "client_secret": "client-secret",
+            },
+        },
+    )
+
+    response = asyncio.run(AppConfigStep(app_context=context)())
+
+    assert response.answer["app_name"] == "Test ReMe"
+    assert "environment" not in response.answer
+    credential = response.answer["components"]["as_llm"]["default"]["credential"]
+    assert credential == {"api_key": "***", "base_url": "https://example.test"}
+    mcp_server = response.answer["mcp_servers"]["private"]
+    assert mcp_server["url"] == "https://user:***@example.test/mcp?access_token=%2A%2A%2A&mode=read"
+    assert mcp_server["headers"] == {"Authorization": "***", "X-API-Key": "***"}
+    assert mcp_server["client_secret"] == "***"

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -49,6 +49,24 @@ def test_default_config_registers_daily_write_job():
     assert job["parameters"]["required"] == ["name", "description", "session_id", "content"]
 
 
+def test_default_config_registers_app_config_job():
+    """The default service exposes the effective application config."""
+    job = _load_config("default.yaml")["jobs"]["app_config"]
+
+    assert job["backend"] == "base"
+    assert job["steps"] == [{"backend": "app_config_step"}]
+
+
+def test_default_config_registers_workspace_web_jobs():
+    """The local web client has stable save and streaming chat actions."""
+    jobs = _load_config("default.yaml")["jobs"]
+
+    assert jobs["save"]["steps"] == [{"backend": "save_step"}]
+    assert jobs["load"]["steps"] == [{"backend": "load_step", "max_bytes": 5242880}]
+    assert jobs["chat"]["backend"] == "stream"
+    assert jobs["chat"]["steps"] == [{"backend": "chat_step", "agent_wrapper": "default"}]
+
+
 def test_default_config_keeps_frontmatter_chunk_metadata_opt_in():
     """Markdown frontmatter-to-chunk metadata is disabled by default for compatibility."""
     cfg = _load_config("default.yaml")

--- a/tests/unit/test_workspace_web_steps.py
+++ b/tests/unit/test_workspace_web_steps.py
@@ -1,0 +1,133 @@
+"""Focused contracts used by the local ReMe workspace web client."""
+
+import asyncio
+import os
+from datetime import datetime
+
+from reme.components.agent_wrapper import BaseAgentWrapper
+from reme.components.application_context import ApplicationContext
+from reme.components.runtime_context import RuntimeContext
+from reme.enumeration import ChunkEnum
+from reme.schema import StreamChunk
+from reme.steps.common.chat import ChatStep
+from reme.steps.file_io.load import LoadStep
+from reme.steps.file_io.save import SaveStep
+
+
+class _StreamingAgent(BaseAgentWrapper):
+    """Minimal agent that records resume/tool arguments and emits rich chunks."""
+
+    def __init__(self):
+        super().__init__()
+        self.reply_kwargs = {}
+
+    async def reply(self, inputs, **kwargs) -> dict:
+        raise AssertionError("ChatStep must always use reply_stream()")
+
+    async def reply_stream(self, inputs, **kwargs):
+        self.reply_kwargs = kwargs
+        yield StreamChunk(chunk_type=ChunkEnum.TOOL_CALL, chunk="{}", tool_call_id="tool-1", tool_call_name="search")
+        yield StreamChunk(chunk_type=ChunkEnum.CONTENT, chunk="hello", session_id="session-new")
+
+
+def test_save_step_preserves_complete_markdown(tmp_path):
+    """The editor save endpoint writes frontmatter and body verbatim."""
+
+    async def run():
+        target = tmp_path / "daily" / "note.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("old", encoding="utf-8")
+        expected = datetime.fromtimestamp(target.stat().st_mtime).isoformat()
+        content = "---\nname: note\ncustom: keep\n---\n\n# Updated\n"
+
+        response = await SaveStep(app_context=ApplicationContext(workspace_dir=str(tmp_path)))(
+            path="daily/note.md",
+            content=content,
+            expected_mtime=expected,
+        )
+
+        assert response.success is True
+        assert target.read_text(encoding="utf-8") == content
+        assert response.metadata["path"] == "daily/note.md"
+        assert response.metadata["mtime"]
+
+    asyncio.run(run())
+
+
+def test_load_step_returns_complete_content_and_mtime(tmp_path):
+    """Editor loads are complete and include the concurrency token for save."""
+
+    async def run():
+        content = "# Large enough\n" + ("memory line\n" * 5000)
+        target = tmp_path / "note.md"
+        target.write_text(content, encoding="utf-8")
+
+        response = await LoadStep(app_context=ApplicationContext(workspace_dir=str(tmp_path)))(path="note.md")
+
+        assert response.success is True
+        assert response.answer == content
+        assert response.metadata["size"] == target.stat().st_size
+        assert response.metadata["mtime"]
+
+    asyncio.run(run())
+
+
+def test_load_step_rejects_file_larger_than_editor_limit(tmp_path):
+    """Oversized files fail explicitly instead of returning editable truncation."""
+
+    async def run():
+        (tmp_path / "note.md").write_text("0123456789", encoding="utf-8")
+
+        response = await LoadStep(app_context=ApplicationContext(workspace_dir=str(tmp_path)))(
+            path="note.md",
+            max_bytes=5,
+        )
+
+        assert response.success is False
+        assert response.metadata["code"] == "file_too_large"
+
+    asyncio.run(run())
+
+
+def test_save_step_rejects_external_change(tmp_path):
+    """An obsolete mtime cannot overwrite a file changed by another editor."""
+
+    async def run():
+        target = tmp_path / "note.md"
+        target.write_text("first", encoding="utf-8")
+        expected = datetime.fromtimestamp(target.stat().st_mtime).isoformat()
+        target.write_text("external", encoding="utf-8")
+        newer = target.stat().st_mtime + 2
+        os.utime(target, (newer, newer))
+
+        response = await SaveStep(app_context=ApplicationContext(workspace_dir=str(tmp_path)))(
+            path="note.md",
+            content="browser edit",
+            expected_mtime=expected,
+        )
+
+        assert response.success is False
+        assert response.metadata["code"] == "file_conflict"
+        assert target.read_text(encoding="utf-8") == "external"
+
+    asyncio.run(run())
+
+
+def test_chat_step_streams_rich_chunks_and_resumes_session():
+    """Web chat keeps StreamChunk metadata and exposes only read-only tools."""
+
+    async def run():
+        agent = _StreamingAgent()
+        queue = asyncio.Queue()
+        context = RuntimeContext(stream_queue=queue, query="hello", session_id="session-old")
+
+        response = await ChatStep(agent_wrapper=agent)(context)
+
+        chunks = [await queue.get(), await queue.get()]
+        assert response.answer == "hello"
+        assert chunks[0].tool_call_name == "search"
+        assert chunks[1].session_id == "session-new"
+        assert agent.reply_kwargs["resume"] == "session-old"
+        assert agent.reply_kwargs["job_tools"] == ["search", "list", "read", "stat", "traverse"]
+
+    asyncio.run(run())


### PR DESCRIPTION
## 背景

本次改动补齐本地工作区 Web 客户端所需的配置读取、完整文件编辑和流式对话能力，同时增加一个无需额外 Python 依赖的 GitHub Star 增长统计脚本。

## 工作区 Web API

- 新增 `app_config` 作业，返回应用实际生效的配置，并排除启动环境变量。
- 新增 `load` 作业，为编辑器读取完整文本文件，不复用面向 Agent 的截断输出；默认限制为 5 MiB，并返回大小、mtime 和编码信息。
- 新增 `save` 作业，原样保存完整文本（包括 frontmatter），不对内容做重建；支持基于 `expected_mtime` 的乐观并发检查，避免覆盖外部编辑器产生的新版本。
- 新增 `chat` 流式作业，仅向 Agent 暴露 `search`、`list`、`read`、`stat`、`traverse` 等只读工具，并支持通过 session ID 恢复会话。
- RuntimeContext 新增完整 `StreamChunk` 转发能力，使工具调用 ID、工具名称、会话 ID、用量等结构化元数据可以透传给 Web 客户端。
- 在默认配置和 Step 包入口中完成作业注册，确保运行时能够发现这些实现。

## 配置脱敏与安全

- 递归脱敏 API Key、Token、Secret、Password、Private Key、Authorization、Cookie 等常见敏感字段。
- 支持带前缀或连字符的敏感键，例如 `client_secret`、`X-API-Key` 和 `x-acs-dingtalk-access-token`。
- 对标量 `credential` 配置进行脱敏，同时保留 credential 对象中的非敏感配置项。
- 清理 URL 中的用户密码及敏感查询参数，避免 MCP Server/Webhook URL 泄露凭据。
- `load` 和 `save` 继续遵守请求级 `_allowed_paths` 权限范围，并限制路径留在用户工作区内。

## GitHub Star 增长报告

- 新增 `scripts/github_star_growth.py`，通过 GitHub CLI GraphQL API 分页读取当前 stargazer 的时间戳。
- 按 UTC 日期输出指定周期内每日新增 Star 的 CSV，包括无新增的日期。
- 同时生成无第三方绘图库依赖的 SVG 柱状图，支持自定义仓库、统计天数、CSV 路径和图表路径。
- 对缺少 `gh`、API 错误、仓库不可访问和无效参数提供明确错误信息。

## 测试与验证

- 新增配置脱敏、完整文件加载、原样保存、外部修改冲突和富流式事件透传测试。
- 更新默认配置解析测试，覆盖新增作业及其关键参数。
- 定向单元测试：`37 passed`。
- 变更文件 pre-commit hooks：通过。
- `git diff --check`：通过。
- GitHub Star 脚本 `--help` 入口：通过。
- 完整单元测试结果为 `913 passed, 2 failed`；两个失败分别来自测试子进程导入本机已安装的旧版 ReMe，以及本机日志捕获环境，未发现与本次改动直接相关的断言回归。