### PR TITLE
refactor: derive dialog paths from session_dir

### DIFF
--- a/reme/config/beam.yaml
+++ b/reme/config/beam.yaml
@@ -64,7 +64,7 @@ jobs:
   index_update:
     backend: base
     description: "Manually trigger incremental index update for watched dirs."
-    watch_dirs: [daily_dir, digest_dir, dialog_dir]
+    watch_dirs: [daily_dir, digest_dir, session_dir/dialog]
     watch_suffixes: [md, jsonl]
     parameters:
       type: object

--- a/reme/config/lme.yaml
+++ b/reme/config/lme.yaml
@@ -62,7 +62,7 @@ jobs:
   index_update:
     backend: base
     description: "Manually trigger incremental index update for watched dirs."
-    watch_dirs: [daily_dir, digest_dir, dialog_dir]
+    watch_dirs: [daily_dir, digest_dir, session_dir/dialog]
     watch_suffixes: [md, jsonl]
     parameters:
       type: object

--- a/reme/schema/application_config.py
+++ b/reme/schema/application_config.py
@@ -1,8 +1,9 @@
 """Application configuration models."""
 
 import os
+from pathlib import PurePosixPath, PureWindowsPath
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ..enumeration import ComponentEnum
 
@@ -53,3 +54,12 @@ class ApplicationConfig(BaseModel):
         default_factory=dict,
         description="Component registry keyed by type then name",
     )
+
+    @field_validator("session_dir")
+    @classmethod
+    def validate_session_dir(cls, value: str) -> str:
+        """Keep standard session storage inside the configured workspace."""
+        path = value.strip()
+        if PurePosixPath(path.replace("\\", "/")).is_absolute() or PureWindowsPath(path).anchor:
+            raise ValueError("session_dir must be a workspace-relative path")
+        return value

--- a/reme/schema/application_config.py
+++ b/reme/schema/application_config.py
@@ -35,6 +35,7 @@ class ApplicationConfig(BaseModel):
     workspace_dir: str = Field(default=".reme", description="Workspace root directory for runtime files")
     metadata_dir: str = Field(default="metadata", description="Subdirectory for ReMe persistent state")
     session_dir: str = Field(default="session", description="Subdirectory for persisted agent sessions")
+    # dialog_dir was removed; standard transcripts are always derived as ``{session_dir}/dialog``.
     mem_session_dir: str = Field(default="mem_session", description="Subdirectory for persisted agent sessions")
     resource_dir: str = Field(default="resource", description="Subdirectory for external assets")
     daily_dir: str = Field(default="daily", description="Subdirectory for daily memory")

--- a/reme/schema/application_config.py
+++ b/reme/schema/application_config.py
@@ -39,7 +39,6 @@ class ApplicationConfig(BaseModel):
     resource_dir: str = Field(default="resource", description="Subdirectory for external assets")
     daily_dir: str = Field(default="daily", description="Subdirectory for daily memory")
     digest_dir: str = Field(default="digest", description="Subdirectory for digest memory")
-    dialog_dir: str = Field(default="session/dialog", description="Subdirectory for dialog session transcripts")
     enable_logo: bool = Field(default=True, description="Show ASCII logo on startup")
     timezone: str | None = Field(default="Asia/Shanghai", description="IANA timezone; None uses local time")
     language: str = Field(default="", description="Default language for LLM interactions")

--- a/reme/steps/evolve/auto_memory.py
+++ b/reme/steps/evolve/auto_memory.py
@@ -10,6 +10,7 @@ from ._evolve import agent_reply_result_text, format_history, now
 from ..base_step import BaseStep
 from ..file_io import extract_daily_date, parse_daily_date, refresh_day_index
 from ..file_io import validate_filename_component, validate_session_id
+from ..index import normalize_posix_path
 from ...components import R
 
 _SESSION_ID_KEY = "session_id"
@@ -66,13 +67,13 @@ class AutoMemoryStep(BaseStep):
         self.update_tools: list[str] = ["read", "edit", "frontmatter_update", "write"]
 
     def _session_dir(self) -> str:
-        return str(self.config_value("session_dir")).strip("/")
+        return normalize_posix_path(str(self.config_value("session_dir")))
 
     def _session_path(self, session_id: str) -> Path:
         return self.file_store.workspace_path / self._session_dir() / "dialog" / f"{session_id}.jsonl"
 
     def _session_source_path(self, session_id: str) -> str:
-        return f"{self._session_dir()}/dialog/{session_id}.jsonl"
+        return normalize_posix_path(f"{self._session_dir()}/dialog/{session_id}.jsonl")
 
     def _session_link(self, session_id: str) -> str:
         return f"[[{self._session_source_path(session_id)}]]"

--- a/reme/steps/evolve/auto_memory_cc.py
+++ b/reme/steps/evolve/auto_memory_cc.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from .auto_memory import AutoMemoryStep
+from ..index import normalize_posix_path
 from ...components import R
 from ...components.agent_wrapper import CcFileSessionStore
 
@@ -73,7 +74,8 @@ class AutoMemoryCCStep(AutoMemoryStep):
         return
 
     def _session_link(self, session_id: str) -> str:
-        return f"[[{self._session_dir()}/{self._CC_STORE_SUBDIR}/{session_id}.jsonl]]"
+        path = normalize_posix_path(f"{self._session_dir()}/{self._CC_STORE_SUBDIR}/{session_id}.jsonl")
+        return f"[[{path}]]"
 
     # ----- session: Claude Code side <-> ReMe CC SessionStore ----------------
 

--- a/reme/steps/file_io/daily_write.py
+++ b/reme/steps/file_io/daily_write.py
@@ -3,6 +3,7 @@
 from ._daily_index import parse_daily_date, refresh_day_index, validate_session_id
 from ._path import validate_filename_component
 from ..base_step import BaseStep
+from ..index import normalize_posix_path
 from ...components import R
 from ...steps.evolve import now
 
@@ -21,10 +22,11 @@ class DailyWriteStep(BaseStep):
             self.context.response.metadata.update(meta)
 
     def _session_dir(self) -> str:
-        return str(self.config_value("session_dir")).strip("/")
+        return normalize_posix_path(str(self.config_value("session_dir")))
 
     def _session_link(self, session_id: str) -> str:
-        return f"[[{self._session_dir()}/dialog/{session_id}.jsonl]]"
+        path = normalize_posix_path(f"{self._session_dir()}/dialog/{session_id}.jsonl")
+        return f"[[{path}]]"
 
     def _collect_required(self) -> tuple[str, str, str, str] | None:
         assert self.context is not None

--- a/reme/steps/file_io/read.py
+++ b/reme/steps/file_io/read.py
@@ -114,8 +114,8 @@ class ReadStep(BaseStep):
             self.logger.info(f"[{self.name}] skip session format: path outside workspace_path path={target}")
             return truncate_text_output(excerpt, start_line=start_line, total_lines=total, file_path=str(target))
 
-        dialog_dir = self.config_value("dialog_dir")
-        if not is_session_path(rel_path, dialog_dir):
+        session_dir = self.config_value("session_dir")
+        if not is_session_path(rel_path, session_dir):
             return truncate_text_output(excerpt, start_line=start_line, total_lines=total, file_path=str(target))
 
         return truncate_session_output(

--- a/reme/steps/file_io/read.py
+++ b/reme/steps/file_io/read.py
@@ -109,7 +109,7 @@ class ReadStep(BaseStep):
         the workspace or is not a raw session transcript.
         """
         try:
-            rel_path = str(target.relative_to(self.workspace_path))
+            rel_path = target.relative_to(self.workspace_path).as_posix()
         except ValueError:
             self.logger.info(f"[{self.name}] skip session format: path outside workspace_path path={target}")
             return truncate_text_output(excerpt, start_line=start_line, total_lines=total, file_path=str(target))

--- a/reme/steps/index/__init__.py
+++ b/reme/steps/index/__init__.py
@@ -1,5 +1,6 @@
 """Index steps."""
 
+from ._source_format import normalize_posix_path
 from .bm25_search import Bm25SearchStep
 from .clear_paths import ClearPathsStep
 from .clear_store import ClearStoreStep
@@ -35,6 +36,7 @@ __all__ = [
     "InitChangesStep",
     "LogChangesStep",
     "NodeSearchStep",
+    "normalize_posix_path",
     "ReadAllDraftStep",
     "OptimizeIndexStep",
     "SearchStep",

--- a/reme/steps/index/_source_format.py
+++ b/reme/steps/index/_source_format.py
@@ -38,21 +38,21 @@ ALL_RETURNED_MESSAGE: Final[str] = (
 NO_RESULTS_MESSAGE: Final[str] = "No relevant information was found for the given query."
 
 
-def is_session_path(path: str, dialog_dir: str) -> bool:
-    """True if the path points at a raw session transcript (a jsonl file under the dialog dir)."""
+def is_session_path(path: str, session_dir: str) -> bool:
+    """True if the path points at a raw transcript under ``{session_dir}/dialog``."""
     path = (path or "").strip().strip("/")
     if not path.endswith(".jsonl"):
         return False
-    dialog_dir = (dialog_dir or "").strip("/")
-    return path == dialog_dir or path.startswith(f"{dialog_dir}/")
+    session_dialog_dir = f"{(session_dir or '').strip('/')}/dialog"
+    return path == session_dialog_dir or path.startswith(f"{session_dialog_dir}/")
 
 
-def is_session_chunk(chunk: FileChunk, dialog_dir: str) -> bool:
+def is_session_chunk(chunk: FileChunk, session_dir: str) -> bool:
     """True if the chunk comes from a raw session transcript (a jsonl file under the dialog dir)."""
-    return is_session_path(chunk.path, dialog_dir)
+    return is_session_path(chunk.path, session_dir)
 
 
-def render_chunk_body(chunk: FileChunk, dialog_dir: str) -> str:
+def render_chunk_body(chunk: FileChunk, session_dir: str) -> str:
     """Render a chunk's body; raw session transcripts render one message per line.
 
     Session chunks are jsonl where each line is a serialized ``Msg``. They
@@ -61,7 +61,7 @@ def render_chunk_body(chunk: FileChunk, dialog_dir: str) -> str:
     share the same single-line-per-message format. All other chunks keep
     their raw ``text``.
     """
-    if not is_session_chunk(chunk, dialog_dir):
+    if not is_session_chunk(chunk, session_dir):
         return chunk.text
     return "\n".join(render_session_chunk_lines(chunk))
 
@@ -123,7 +123,7 @@ def _build_union_chunk(group: list[FileChunk]) -> FileChunk:
     )
 
 
-def merge_session_chunk_intervals(chunks: list[FileChunk], dialog_dir: str) -> list[FileChunk]:
+def merge_session_chunk_intervals(chunks: list[FileChunk], session_dir: str) -> list[FileChunk]:
     """Merge raw session chunks from the same file into their line-range union.
 
     Only chunks recognized as raw session transcripts (see
@@ -148,7 +148,7 @@ def merge_session_chunk_intervals(chunks: list[FileChunk], dialog_dir: str) -> l
     # non-session chunks use their own rank and thus keep their position.
     ordered: list[tuple[int, int, FileChunk]] = []
     for idx, c in enumerate(chunks):
-        if is_session_chunk(c, dialog_dir):
+        if is_session_chunk(c, session_dir):
             session_by_path.setdefault(c.path, []).append((idx, c))
         else:
             ordered.append((idx, c.start_line, c))
@@ -183,7 +183,7 @@ def _finalize_group(group: list[FileChunk]) -> FileChunk:
 
 def render_chunk_entries(
     chunks: list[FileChunk],
-    dialog_dir: str,
+    session_dir: str,
     *,
     include_source: bool = True,
     score_fn: Callable[[FileChunk], str] | None = None,
@@ -207,7 +207,7 @@ def render_chunk_entries(
     expansion lines (used by hybrid search).
     """
     if not include_source:
-        return [{"body": render_chunk_body(c, dialog_dir)} for c in chunks]
+        return [{"body": render_chunk_body(c, session_dir)} for c in chunks]
 
     fmt = score_fn or (lambda c: f"score={c.score:.4f}")
     entries: list[dict[str, str]] = []
@@ -218,7 +218,7 @@ def render_chunk_entries(
                 "start_line": str(c.start_line),
                 "end_line": str(c.end_line),
                 "score": fmt(c),
-                "body": render_chunk_body(c, dialog_dir),
+                "body": render_chunk_body(c, session_dir),
                 "link": "\n".join(render_expansion_lines((link_expansion or {}).get(c.path, {}))),
             },
         )

--- a/reme/steps/index/_source_format.py
+++ b/reme/steps/index/_source_format.py
@@ -20,6 +20,7 @@ removes every previously-returned result. :data:`NO_RESULTS_MESSAGE` is the
 English notice shown when the search returned no results at all.
 """
 
+import posixpath
 from typing import Callable, Final
 
 from agentscope.message import Msg
@@ -38,12 +39,19 @@ ALL_RETURNED_MESSAGE: Final[str] = (
 NO_RESULTS_MESSAGE: Final[str] = "No relevant information was found for the given query."
 
 
+def normalize_posix_path(path: str) -> str:
+    """Return a normalized, workspace-relative POSIX path string."""
+    normalized = posixpath.normpath((path or "").strip().replace("\\", "/").strip("/"))
+    return "" if normalized == "." else normalized
+
+
 def is_session_path(path: str, session_dir: str) -> bool:
     """True if the path points at a raw transcript under ``{session_dir}/dialog``."""
-    path = (path or "").strip().strip("/")
+    path = normalize_posix_path(path)
     if not path.endswith(".jsonl"):
         return False
-    session_dialog_dir = f"{(session_dir or '').strip('/')}/dialog"
+    session_root = normalize_posix_path(session_dir)
+    session_dialog_dir = posixpath.join(session_root, "dialog")
     return path == session_dialog_dir or path.startswith(f"{session_dialog_dir}/")
 
 

--- a/reme/steps/index/_watch_rules.py
+++ b/reme/steps/index/_watch_rules.py
@@ -27,11 +27,16 @@ def build_watch_rules(
     """Build watch rules from application config fields and suffix whitelist."""
     rules: list[WatchRule] = []
     for dir_field in watch_dirs:
-        config_field, separator, child_path = dir_field.partition("/")
-        dir_name = getattr(app_config, config_field, config_field)
-        if separator:
-            dir_name = str(Path(dir_name) / child_path)
-        rules.append(WatchRule(path=workspace_path / dir_name, suffixes=list(watch_suffixes)))
+        literal_path = Path(dir_field)
+        if literal_path.is_absolute():
+            rule_path = literal_path
+        else:
+            config_field, separator, child_path = dir_field.partition("/")
+            dir_name = Path(getattr(app_config, config_field, config_field))
+            if separator:
+                dir_name /= child_path
+            rule_path = dir_name if dir_name.is_absolute() else workspace_path / dir_name
+        rules.append(WatchRule(path=rule_path, suffixes=list(watch_suffixes)))
     return rules
 
 

--- a/reme/steps/index/_watch_rules.py
+++ b/reme/steps/index/_watch_rules.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ._source_format import normalize_posix_path
+
 if TYPE_CHECKING:
     from ...schema import ApplicationConfig
     from ...components.runtime_context import RuntimeContext
@@ -32,9 +34,12 @@ def build_watch_rules(
             rule_path = literal_path
         else:
             config_field, separator, child_path = dir_field.partition("/")
-            dir_name = Path(getattr(app_config, config_field, config_field))
+            dir_value = getattr(app_config, config_field, config_field)
+            if hasattr(app_config, config_field) and dir_value in (None, ""):
+                dir_value = getattr(type(app_config)(), config_field)
             if separator:
-                dir_name /= child_path
+                dir_value = normalize_posix_path(f"{dir_value}/{child_path}")
+            dir_name = Path(dir_value)
             rule_path = dir_name if dir_name.is_absolute() else workspace_path / dir_name
         rules.append(WatchRule(path=rule_path, suffixes=list(watch_suffixes)))
     return rules

--- a/reme/steps/index/_watch_rules.py
+++ b/reme/steps/index/_watch_rules.py
@@ -27,7 +27,10 @@ def build_watch_rules(
     """Build watch rules from application config fields and suffix whitelist."""
     rules: list[WatchRule] = []
     for dir_field in watch_dirs:
-        dir_name = getattr(app_config, dir_field, dir_field)
+        config_field, separator, child_path = dir_field.partition("/")
+        dir_name = getattr(app_config, config_field, config_field)
+        if separator:
+            dir_name = str(Path(dir_name) / child_path)
         rules.append(WatchRule(path=workspace_path / dir_name, suffixes=list(watch_suffixes)))
     return rules
 

--- a/reme/steps/index/bm25_search.py
+++ b/reme/steps/index/bm25_search.py
@@ -48,10 +48,10 @@ class Bm25SearchStep(_ToolContextDedupMixin, BaseStep):
         else:
             results = results[:limit]
 
-        dialog_dir = self.config_value("dialog_dir")
+        session_dir = self.config_value("session_dir")
         entries = render_chunk_entries(
-            merge_session_chunk_intervals(results, dialog_dir),
-            dialog_dir,
+            merge_session_chunk_intervals(results, session_dir),
+            session_dir,
             include_source=self.include_source,
         )
         self.context.response.answer = join_chunk_entries(entries)

--- a/reme/steps/index/search_v2.py
+++ b/reme/steps/index/search_v2.py
@@ -213,15 +213,15 @@ class SearchV2Step(_ToolContextDedupMixin, BaseStep):
             await expand_links(self.file_store, unique_paths, max_links_per_direction) if expand_links_enabled else {}
         )
 
-        dialog_dir = self.config_value("dialog_dir")
+        session_dir = self.config_value("session_dir")
         entries = render_chunk_entries(
-            merge_session_chunk_intervals(fused, dialog_dir),
-            dialog_dir,
+            merge_session_chunk_intervals(fused, session_dir),
+            session_dir,
             score_fn=lambda c: self._format_scores(c.scores, hybrid),
             link_expansion=link_expansion,
         )
         if self._session_compress_enabled():
-            await self._compress_session_entries(entries, query, dialog_dir)
+            await self._compress_session_entries(entries, query, session_dir)
         self.context.response.answer = join_chunk_entries(entries)
         if not fused:
             self.context.response.answer = ALL_RETURNED_MESSAGE if pre_dedup_count > 0 else NO_RESULTS_MESSAGE
@@ -246,7 +246,7 @@ class SearchV2Step(_ToolContextDedupMixin, BaseStep):
         value = (search_cfg.get("_compress") or {}).get("session")
         return value is True or str(value).strip().lower() == "true"
 
-    async def _compress_session_entries(self, entries: list[dict[str, str]], query: str, dialog_dir: str) -> None:
+    async def _compress_session_entries(self, entries: list[dict[str, str]], query: str, session_dir: str) -> None:
         """Compress session-transcript entry bodies in place via the ``compressor`` job.
 
         Only entries whose ``path`` points at a raw session transcript are
@@ -323,7 +323,7 @@ class SearchV2Step(_ToolContextDedupMixin, BaseStep):
                 return
             entry["body"] = f"compressed session chunk:\n{compressed}"
 
-        targets = [e for e in entries if is_session_path(e.get("path", ""), dialog_dir)]
+        targets = [e for e in entries if is_session_path(e.get("path", ""), session_dir)]
         if not targets:
             return
         self.logger.info(f"[{self.name}] compressing {len(targets)} session entries with {len(queries)} queries")

--- a/reme/steps/index/vector_search.py
+++ b/reme/steps/index/vector_search.py
@@ -48,10 +48,10 @@ class VectorSearchStep(_ToolContextDedupMixin, BaseStep):
         else:
             results = results[:limit]
 
-        dialog_dir = self.config_value("dialog_dir")
+        session_dir = self.config_value("session_dir")
         entries = render_chunk_entries(
-            merge_session_chunk_intervals(results, dialog_dir),
-            dialog_dir,
+            merge_session_chunk_intervals(results, session_dir),
+            session_dir,
             include_source=self.include_source,
         )
         self.context.response.answer = join_chunk_entries(entries)

--- a/tests/unit/test_application_config.py
+++ b/tests/unit/test_application_config.py
@@ -39,6 +39,21 @@ def test_dialog_watch_rule_follows_custom_session_dir(tmp_path):
     assert rules[0].suffixes == ["jsonl"]
 
 
+def test_absolute_watch_rule_stays_outside_workspace(tmp_path):
+    """Absolute literal watch directories retain their original location."""
+    config = ApplicationConfig()
+    absolute_dir = tmp_path.parent / "reme-dialogs"
+
+    rules = build_watch_rules(
+        config,
+        tmp_path,
+        watch_dirs=[str(absolute_dir)],
+        watch_suffixes=["jsonl"],
+    )
+
+    assert rules[0].path == absolute_dir
+
+
 def test_standard_session_paths_and_links_follow_custom_session_dir(tmp_path):
     """Writers derive transcript paths and links from session_dir."""
     app_context = ApplicationContext(session_dir="sessions")
@@ -52,11 +67,38 @@ def test_standard_session_paths_and_links_follow_custom_session_dir(tmp_path):
     assert daily_write._session_link("s1") == "[[sessions/dialog/s1.jsonl]]"
 
 
+def test_session_paths_and_links_normalize_custom_session_dir(tmp_path):
+    """Writers and source links use the same normalized POSIX session root."""
+    for configured, expected in (
+        ("./sessions", "sessions"),
+        (".", ""),
+        ("parent//../sessions", "sessions"),
+    ):
+        app_context = ApplicationContext(session_dir=configured)
+        auto_memory = AutoMemoryStep(app_context=app_context)
+        auto_memory.file_store = SimpleNamespace(workspace_path=tmp_path)
+        daily_write = DailyWriteStep(app_context=app_context)
+        source_path = f"{expected + '/' if expected else ''}dialog/s1.jsonl"
+
+        assert auto_memory._session_path("s1") == tmp_path / source_path
+        assert auto_memory._session_source_path("s1") == source_path
+        assert auto_memory._session_link("s1") == f"[[{source_path}]]"
+        assert daily_write._session_link("s1") == f"[[{source_path}]]"
+
+
 def test_dialog_classification_excludes_other_session_stores():
     """Only jsonl files below the dialog child directory are transcripts."""
     assert is_session_path("sessions/dialog/s1.jsonl", "sessions")
     assert not is_session_path("sessions/claude_code/s1.jsonl", "sessions")
     assert not is_session_path("session/dialog/s1.jsonl", "sessions")
+
+
+def test_dialog_classification_normalizes_paths():
+    """Session recognition compares normalized path representations."""
+    assert is_session_path("sessions/dialog/s1.jsonl", "./sessions")
+    assert is_session_path("./sessions//dialog/s1.jsonl", "sessions")
+    assert is_session_path("dialog/s1.jsonl", ".")
+    assert is_session_path("sessions/dialog/s1.jsonl", "parent/../sessions")
 
 
 def test_session_rendering_follows_custom_session_dir():

--- a/tests/unit/test_application_config.py
+++ b/tests/unit/test_application_config.py
@@ -4,8 +4,11 @@
 
 from types import SimpleNamespace
 
+import pytest
 from agentscope.message import Msg
+from pydantic import ValidationError
 
+from reme.application import Application
 from reme.components import ApplicationContext
 from reme.schema import ApplicationConfig, FileChunk
 from reme.steps.evolve.auto_memory import AutoMemoryStep
@@ -21,6 +24,17 @@ def test_dialog_dir_is_not_an_application_config_field():
     assert not hasattr(custom, "dialog_dir")
     assert "dialog_dir" not in custom.model_dump()
     assert "dialog_dir" not in ApplicationConfig.model_json_schema()["properties"]
+
+
+@pytest.mark.parametrize("session_dir", ["/tmp/sessions", "C:\\sessions", "\\\\server\\share\\sessions"])
+def test_application_rejects_absolute_session_dir_before_workspace_setup(tmp_path, session_dir):
+    """Application initialization rejects session directories outside the workspace."""
+    workspace = tmp_path / "workspace"
+
+    with pytest.raises(ValidationError, match="session_dir must be a workspace-relative path"):
+        Application(workspace_dir=str(workspace), session_dir=session_dir)
+
+    assert not workspace.exists()
 
 
 def test_dialog_watch_rule_follows_custom_session_dir(tmp_path):
@@ -41,7 +55,7 @@ def test_dialog_watch_rule_follows_custom_session_dir(tmp_path):
 
 def test_dialog_watch_rule_matches_writer_for_normalized_session_dirs(tmp_path):
     """Nested watch rules use the same defaults and normalization as transcript writers."""
-    for configured in ("", "parent//../sessions", str(tmp_path.parent / "external-sessions")):
+    for configured in ("", "parent//../sessions"):
         app_context = ApplicationContext(session_dir=configured)
         auto_memory = AutoMemoryStep(app_context=app_context)
         auto_memory.file_store = SimpleNamespace(workspace_path=tmp_path)

--- a/tests/unit/test_application_config.py
+++ b/tests/unit/test_application_config.py
@@ -1,0 +1,75 @@
+"""Application path configuration contracts."""
+
+# pylint: disable=protected-access
+
+from types import SimpleNamespace
+
+from agentscope.message import Msg
+
+from reme.components import ApplicationContext
+from reme.schema import ApplicationConfig, FileChunk
+from reme.steps.evolve.auto_memory import AutoMemoryStep
+from reme.steps.file_io.daily_write import DailyWriteStep
+from reme.steps.index._source_format import is_session_path, render_chunk_body
+from reme.steps.index._watch_rules import build_watch_rules
+
+
+def test_dialog_dir_is_not_an_application_config_field():
+    """The removed option is absent from schemas and ignored when supplied."""
+    custom = ApplicationConfig(session_dir="sessions/", dialog_dir="somewhere/else")
+
+    assert not hasattr(custom, "dialog_dir")
+    assert "dialog_dir" not in custom.model_dump()
+    assert "dialog_dir" not in ApplicationConfig.model_json_schema()["properties"]
+
+
+def test_dialog_watch_rule_follows_custom_session_dir(tmp_path):
+    """Nested watch rules resolve the dialog directory below session_dir."""
+    config = ApplicationConfig(session_dir="sessions")
+
+    rules = build_watch_rules(
+        config,
+        tmp_path,
+        watch_dirs=["session_dir/dialog"],
+        watch_suffixes=["jsonl"],
+    )
+
+    assert len(rules) == 1
+    assert rules[0].path == tmp_path / "sessions" / "dialog"
+    assert rules[0].suffixes == ["jsonl"]
+
+
+def test_standard_session_paths_and_links_follow_custom_session_dir(tmp_path):
+    """Writers derive transcript paths and links from session_dir."""
+    app_context = ApplicationContext(session_dir="sessions")
+    auto_memory = AutoMemoryStep(app_context=app_context)
+    auto_memory.file_store = SimpleNamespace(workspace_path=tmp_path)
+    daily_write = DailyWriteStep(app_context=app_context)
+
+    assert auto_memory._session_path("s1") == tmp_path / "sessions" / "dialog" / "s1.jsonl"
+    assert auto_memory._session_source_path("s1") == "sessions/dialog/s1.jsonl"
+    assert auto_memory._session_link("s1") == "[[sessions/dialog/s1.jsonl]]"
+    assert daily_write._session_link("s1") == "[[sessions/dialog/s1.jsonl]]"
+
+
+def test_dialog_classification_excludes_other_session_stores():
+    """Only jsonl files below the dialog child directory are transcripts."""
+    assert is_session_path("sessions/dialog/s1.jsonl", "sessions")
+    assert not is_session_path("sessions/claude_code/s1.jsonl", "sessions")
+    assert not is_session_path("session/dialog/s1.jsonl", "sessions")
+
+
+def test_session_rendering_follows_custom_session_dir():
+    """Session-aware rendering recognizes a custom session root."""
+    message = Msg(name="user", role="user", content=[{"type": "text", "text": "hello"}])
+    chunk = FileChunk(
+        path="sessions/dialog/s1.jsonl",
+        start_line=1,
+        end_line=1,
+        text=message.model_dump_json(),
+    )
+
+    rendered = render_chunk_body(chunk, "sessions")
+
+    assert rendered.startswith("[user @")
+    assert rendered.endswith("] hello")

--- a/tests/unit/test_application_config.py
+++ b/tests/unit/test_application_config.py
@@ -39,6 +39,23 @@ def test_dialog_watch_rule_follows_custom_session_dir(tmp_path):
     assert rules[0].suffixes == ["jsonl"]
 
 
+def test_dialog_watch_rule_matches_writer_for_normalized_session_dirs(tmp_path):
+    """Nested watch rules use the same defaults and normalization as transcript writers."""
+    for configured in ("", "parent//../sessions", str(tmp_path.parent / "external-sessions")):
+        app_context = ApplicationContext(session_dir=configured)
+        auto_memory = AutoMemoryStep(app_context=app_context)
+        auto_memory.file_store = SimpleNamespace(workspace_path=tmp_path)
+
+        rules = build_watch_rules(
+            app_context.app_config,
+            tmp_path,
+            watch_dirs=["session_dir/dialog"],
+            watch_suffixes=["jsonl"],
+        )
+
+        assert rules[0].path == auto_memory._session_path("s1").parent
+
+
 def test_absolute_watch_rule_stays_outside_workspace(tmp_path):
     """Absolute literal watch directories retain their original location."""
     config = ApplicationConfig()

--- a/tests/unit/test_crud_steps.py
+++ b/tests/unit/test_crud_steps.py
@@ -31,7 +31,9 @@ import os
 import tempfile
 import warnings
 from pathlib import Path, PureWindowsPath
+from types import SimpleNamespace
 
+from reme.components import ApplicationContext
 from reme.components.file_store import LocalFileStore
 from reme.schema import FileNode
 from reme.steps.file_io import (
@@ -807,6 +809,31 @@ def test_read_format_session_injected_false_disables_yaml_true():
 
             await store.close()
         print("✓ test_read_format_session_injected_false_disables_yaml_true passed")
+
+    _run(run())
+
+
+def test_read_format_session_with_non_normalized_session_dir():
+    """Session formatting recognizes a normalized target when config contains ``./``."""
+
+    async def run():
+        from agentscope.message import Msg
+
+        m = Msg(name="user", role="user", content=[{"type": "text", "text": "hello world"}])
+        jsonl_body = m.model_dump_json() + "\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            session_path = workspace / "sessions" / "dialog" / "s.jsonl"
+            session_path.parent.mkdir(parents=True, exist_ok=True)
+            session_path.write_text(jsonl_body, encoding="utf-8")
+
+            app_context = ApplicationContext(workspace_dir=str(workspace.resolve()), session_dir="./sessions")
+            step = crud_read.ReadStep(app_context=app_context, read_step_format_session=True)
+            step.file_store = SimpleNamespace(workspace_path=workspace)
+            await step(path="sessions/dialog/s.jsonl")
+
+            assert "[user @" in str(step.context.response.answer)
 
     _run(run())
 

--- a/tests/unit/test_source_format_merge.py
+++ b/tests/unit/test_source_format_merge.py
@@ -11,17 +11,17 @@ assert the union content and line order directly.
 from reme.schema import FileChunk
 from reme.steps.index._source_format import join_chunk_entries, merge_session_chunk_intervals, render_chunk_entries
 
-_DIALOG_DIR = "session"
+_SESSION_DIR = "session"
 
 
-def _render(chunks: list[FileChunk], dialog_dir: str, **kwargs) -> str:
+def _render(chunks: list[FileChunk], session_dir: str, **kwargs) -> str:
     """Merge session chunks, render entries, then join — mirroring the search steps."""
     return join_chunk_entries(
-        render_chunk_entries(merge_session_chunk_intervals(chunks, dialog_dir), dialog_dir, **kwargs),
+        render_chunk_entries(merge_session_chunk_intervals(chunks, session_dir), session_dir, **kwargs),
     )
 
 
-def _chunk(start: int, end: int, text: str, score: float = 1.0, path: str = "session/s1.jsonl") -> FileChunk:
+def _chunk(start: int, end: int, text: str, score: float = 1.0, path: str = "session/dialog/s1.jsonl") -> FileChunk:
     return FileChunk(path=path, start_line=start, end_line=end, text=text, scores={"score": score})
 
 
@@ -30,7 +30,7 @@ def test_overlapping_session_chunks_merge_into_union_without_duplicates():
     a = _chunk(1, 3, "m1\nm2\nm3\n")
     b = _chunk(3, 5, "m3\nm4\nm5\n")
 
-    answer = _render([a, b], _DIALOG_DIR, include_source=False)
+    answer = _render([a, b], _SESSION_DIR, include_source=False)
 
     assert answer == "m1\nm2\nm3\nm4\nm5"
 
@@ -40,7 +40,7 @@ def test_contained_session_chunk_is_absorbed_by_the_larger_range():
     big = _chunk(1, 5, "m1\nm2\nm3\nm4\nm5\n")
     small = _chunk(2, 4, "m2\nm3\nm4\n")
 
-    answer = _render([big, small], _DIALOG_DIR, include_source=False)
+    answer = _render([big, small], _SESSION_DIR, include_source=False)
 
     assert answer == "m1\nm2\nm3\nm4\nm5"
 
@@ -50,7 +50,7 @@ def test_adjacent_session_chunks_merge_end_plus_one_equals_next_start():
     a = _chunk(1, 3, "m1\nm2\nm3\n")
     b = _chunk(4, 6, "m4\nm5\nm6\n")
 
-    answer = _render([a, b], _DIALOG_DIR, include_source=False)
+    answer = _render([a, b], _SESSION_DIR, include_source=False)
 
     assert answer == "m1\nm2\nm3\nm4\nm5\nm6"
 
@@ -60,17 +60,17 @@ def test_session_chunks_with_a_gap_are_not_merged():
     a = _chunk(1, 3, "m1\nm2\nm3\n")
     b = _chunk(5, 6, "m5\nm6\n")  # line 4 missing -> not adjacent
 
-    answer = _render([a, b], _DIALOG_DIR, include_source=False)
+    answer = _render([a, b], _SESSION_DIR, include_source=False)
 
     assert answer == "m1\nm2\nm3\n\nm5\nm6"
 
 
 def test_session_chunks_from_different_files_are_not_merged():
     """Overlapping ranges in different session files must stay separate."""
-    a = _chunk(1, 3, "A1\nA2\nA3\n", path="session/s1.jsonl")
-    b = _chunk(2, 4, "B2\nB3\nB4\n", path="session/s2.jsonl")
+    a = _chunk(1, 3, "A1\nA2\nA3\n", path="session/dialog/s1.jsonl")
+    b = _chunk(2, 4, "B2\nB3\nB4\n", path="session/dialog/s2.jsonl")
 
-    answer = _render([a, b], _DIALOG_DIR, include_source=False)
+    answer = _render([a, b], _SESSION_DIR, include_source=False)
 
     assert answer == "A1\nA2\nA3\n\nB2\nB3\nB4"
 
@@ -80,7 +80,7 @@ def test_non_session_chunks_are_never_merged():
     a = _chunk(1, 3, "M1\nM2\nM3\n", path="daily/a.md")
     b = _chunk(2, 4, "M2\nM3\nM4\n", path="daily/a.md")
 
-    answer = _render([a, b], _DIALOG_DIR, include_source=False)
+    answer = _render([a, b], _SESSION_DIR, include_source=False)
 
     assert answer == "M1\nM2\nM3\n\nM2\nM3\nM4"
 
@@ -91,7 +91,7 @@ def test_merge_preserves_line_order_regardless_of_input_rank_order():
     earlier = _chunk(1, 3, "m1\nm2\nm3\n", score=1.0)
 
     # Higher-scored later-range chunk is listed first (as a ranker would).
-    answer = _render([later, earlier], _DIALOG_DIR, include_source=False)
+    answer = _render([later, earlier], _SESSION_DIR, include_source=False)
 
     assert answer == "m1\nm2\nm3\nm4\nm5"
 
@@ -101,10 +101,10 @@ def test_merged_header_spans_the_union_range_and_keeps_best_score():
     a = _chunk(1, 3, "m1\nm2\nm3\n", score=2.0)
     b = _chunk(3, 5, "m3\nm4\nm5\n", score=7.0)
 
-    answer = _render([a, b], _DIALOG_DIR, include_source=True)
+    answer = _render([a, b], _SESSION_DIR, include_source=True)
 
     assert answer.count("==========") == 2  # exactly one header (open + close markers)
-    assert "session/s1.jsonl:1-5" in answer
+    assert "session/dialog/s1.jsonl:1-5" in answer
     assert "score=7.0000" in answer
 
 
@@ -114,7 +114,7 @@ def test_separate_intervals_in_same_file_stay_separate():
     b = _chunk(3, 4, "m3\nm4\n")  # adjacent to a -> merges with a into 1-4
     c = _chunk(10, 11, "m10\nm11\n")  # far away -> separate
 
-    answer = _render([a, b, c], _DIALOG_DIR, include_source=False)
+    answer = _render([a, b, c], _SESSION_DIR, include_source=False)
 
     assert answer == "m1\nm2\nm3\nm4\n\nm10\nm11"
 
@@ -123,12 +123,12 @@ def test_same_file_units_stay_adjacent_and_sorted_even_when_interleaved_by_rank(
     """Two disjoint units of one session file are grouped together and ordered by
     ``start_line``, even when a different file is ranked between them and the
     lower interval was ranked last."""
-    s1_high = _chunk(10, 12, "S1x\nS1y\nS1z\n", score=9.0, path="session/s1.jsonl")
-    s2_mid = _chunk(1, 3, "S2a\nS2b\nS2c\n", score=5.0, path="session/s2.jsonl")
-    s1_low = _chunk(1, 3, "S1a\nS1b\nS1c\n", score=1.0, path="session/s1.jsonl")
+    s1_high = _chunk(10, 12, "S1x\nS1y\nS1z\n", score=9.0, path="session/dialog/s1.jsonl")
+    s2_mid = _chunk(1, 3, "S2a\nS2b\nS2c\n", score=5.0, path="session/dialog/s2.jsonl")
+    s1_low = _chunk(1, 3, "S1a\nS1b\nS1c\n", score=1.0, path="session/dialog/s1.jsonl")
 
     # Rank order (as a ranker would emit, by score desc): s1[10-12], s2[1-3], s1[1-3].
-    answer = _render([s1_high, s2_mid, s1_low], _DIALOG_DIR, include_source=False)
+    answer = _render([s1_high, s2_mid, s1_low], _SESSION_DIR, include_source=False)
 
     # s1's two units are adjacent and sorted by start_line (1-3 before 10-12),
     # placed at s1's earliest rank (0), so the whole s1 block precedes s2.
@@ -137,13 +137,13 @@ def test_same_file_units_stay_adjacent_and_sorted_even_when_interleaved_by_rank(
 
 def test_same_file_units_adjacency_with_source_headers():
     """Header view: same-file units are contiguous and ascending; other files follow."""
-    s1_high = _chunk(10, 12, "S1x\nS1y\nS1z\n", score=9.0, path="session/s1.jsonl")
-    s2_mid = _chunk(1, 3, "S2a\nS2b\nS2c\n", score=5.0, path="session/s2.jsonl")
-    s1_low = _chunk(1, 3, "S1a\nS1b\nS1c\n", score=1.0, path="session/s1.jsonl")
+    s1_high = _chunk(10, 12, "S1x\nS1y\nS1z\n", score=9.0, path="session/dialog/s1.jsonl")
+    s2_mid = _chunk(1, 3, "S2a\nS2b\nS2c\n", score=5.0, path="session/dialog/s2.jsonl")
+    s1_low = _chunk(1, 3, "S1a\nS1b\nS1c\n", score=1.0, path="session/dialog/s1.jsonl")
 
-    answer = _render([s1_high, s2_mid, s1_low], _DIALOG_DIR, include_source=True)
+    answer = _render([s1_high, s2_mid, s1_low], _SESSION_DIR, include_source=True)
 
     headers = [line for line in answer.splitlines() if line.startswith("==========")]
-    assert headers[0].split(" [")[0] == "========== session/s1.jsonl:1-3"
-    assert headers[1].split(" [")[0] == "========== session/s1.jsonl:10-12"
-    assert headers[2].split(" [")[0] == "========== session/s2.jsonl:1-3"
+    assert headers[0].split(" [")[0] == "========== session/dialog/s1.jsonl:1-3"
+    assert headers[1].split(" [")[0] == "========== session/dialog/s1.jsonl:10-12"
+    assert headers[2].split(" [")[0] == "========== session/dialog/s2.jsonl:1-3"


### PR DESCRIPTION
## 背景

标准对话记录在代码中已经按 `{session_dir}/dialog` 写入，但搜索、读取和部分 benchmark 配置仍通过独立的 `dialog_dir` 配置识别该目录。这会让同一个路径契约存在两个配置来源：修改 `session_dir` 后，还需要同步维护 `dialog_dir`，否则写入路径与读取、索引路径可能不一致。

本 PR 将标准对话目录收敛为单一规则：

```text
{workspace_dir}/{session_dir}/dialog
```

`session_dir` 是唯一配置来源，`dialog` 是固定子目录。

## 主要改动

### 1. 删除 `dialog_dir` 配置字段

- 从 `ApplicationConfig` 中删除 `dialog_dir`。
- 不增加兼容字段、迁移校验或弃用警告。
- 旧配置中传入的 `dialog_dir` 会遵循当前 Pydantic extra 字段策略被忽略，不再影响运行时路径。

### 2. 统一标准对话路径识别

以下代码不再读取 `config_value("dialog_dir")`，统一读取 `session_dir` 并识别 `{session_dir}/dialog/**/*.jsonl`：

- vector search
- BM25 search
- hybrid search / session compression
- read step 的 session JSONL 格式化
- session chunk 渲染与区间合并

这也确保 `{session_dir}/claude_code` 等其他 session store 不会被误认为标准对话记录。

### 3. 统一 session 路径表示

- 新增 workspace-relative POSIX 路径归一化，统一处理 `./`、重复分隔符和可折叠路径段。
- AutoMemory、AutoMemoryCC 和 DailyWrite 生成一致的 transcript 路径及 source link。
- ReadStep 使用 POSIX 相对路径识别 transcript，避免 Windows 路径分隔符导致匹配失败。
- 支持 `session_dir: "."`，此时标准对话目录为 workspace 下的 `dialog`。

### 4. 支持嵌套和绝对 watch path

`build_watch_rules` 现在支持 `session_dir/dialog`：首段按 `ApplicationConfig` 字段解析，后续部分作为固定子路径拼接。绝对字面路径及解析后为绝对路径的配置值会保持原位置，不再错误拼接到 workspace 下。

BEAM 和 LME 的手动索引配置相应从：

```yaml
watch_dirs: [daily_dir, digest_dir, dialog_dir]
```

调整为：

```yaml
watch_dirs: [daily_dir, digest_dir, session_dir/dialog]
```

因此自定义 `session_dir` 时，watcher 会自动跟随对应的 dialog 子目录。

### 5. 补充和调整测试

覆盖以下路径契约：

- `dialog_dir` 不再出现在 schema 和序列化结果中；
- 传入旧 `dialog_dir` 不会改变路径；
- 自定义及非规范化 `session_dir` 下 watcher、写入路径、source link、读取格式化和搜索渲染保持一致；
- `{session_dir}/claude_code` 不会被识别为标准 dialog transcript；
- 绝对 watch path 保持 workspace 外的原始位置；
- session chunk merge 测试数据与真实目录 `{session_dir}/dialog` 一致。

## 行为变化

此前：

```yaml
session_dir: sessions
dialog_dir: another/path
```

两个配置可以表达相互冲突的路径。

现在：

```yaml
session_dir: sessions
```

标准对话目录固定为 `sessions/dialog`。即使旧配置仍包含 `dialog_dir: another/path`，该值也会被忽略。

`mem_session_dir` 及 Agent Wrapper 自身的会话目录不在本次改动范围内。

## 验证

本次最新提交已通过：

- `PYTHONPATH=. pytest -q tests/unit/test_application_config.py tests/unit/test_crud_steps.py tests/unit/test_background_steps.py`：`119 passed`
- 修改文件的 `pre-commit run --files ...`：全部通过
- `git diff --check`：通过

远程 CI 已由最新提交触发。