### PR TITLE
fix: align startup banner URL defaults with actual service defaults

### DIFF
--- a/reme/utils/logo_utils.py
+++ b/reme/utils/logo_utils.py
@@ -10,6 +10,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from ..constants import REME_DEFAULT_HOST, REME_DEFAULT_PORT
+
 if TYPE_CHECKING:
     from ..schema import ApplicationConfig
 
@@ -73,16 +75,16 @@ def print_logo(app_config: "ApplicationConfig"):
 
     match backend:
         case "http":
-            host = extra.get("host", "localhost")
-            port = extra.get("port", 8000)
+            host = extra.get("host", REME_DEFAULT_HOST)
+            port = extra.get("port", REME_DEFAULT_PORT)
             info_table.add_row("🔗", "URL:", f"http://{host}:{port}")
             info_table.add_row("📚", "FastAPI:", Text(get_version("fastapi"), style="dim"))
         case "mcp":
             transport = extra.get("transport", "stdio")
             info_table.add_row("🚌", "Transport:", transport)
             if transport != "stdio":
-                host = extra.get("host", "localhost")
-                port = extra.get("port", 8000)
+                host = extra.get("host", REME_DEFAULT_HOST)
+                port = extra.get("port", REME_DEFAULT_PORT)
                 url = f"http://{host}:{port}"
                 if transport == "sse":
                     url += "/sse"


### PR DESCRIPTION
## Summary

The startup banner in `reme/utils/logo_utils.py` was using hard-coded defaults (`localhost`, `8000`) when rendering the service URL for `http` and `mcp` (non-stdio) backends. These defaults did not match the actual service defaults defined in `reme/constants.py` (`REME_DEFAULT_HOST`, `REME_DEFAULT_PORT`), so the banner could display a misleading URL when the user relied on the default configuration.

This PR aligns the banner URL defaults with the real service defaults by importing `REME_DEFAULT_HOST` and `REME_DEFAULT_PORT` from `reme.constants`.

## Changes

- `reme/utils/logo_utils.py`:
  - Import `REME_DEFAULT_HOST` and `REME_DEFAULT_PORT`.
  - Use them as fallbacks for `host` and `port` in both `http` and `mcp` (non-stdio) branches.

## Motivation

When starting the ReMe HTTP service without explicitly setting `host`/`port`, the banner previously showed `http://localhost:8000` even though the actual listening address might default to a different host/port (as defined in `reme.constants`). This can confuse users who copy the URL from the banner.
