### PR TITLE
fix(prompt): default omitted conditional flags to false

### DIFF
--- a/reme/components/prompt_handler.py
+++ b/reme/components/prompt_handler.py
@@ -116,8 +116,7 @@ class PromptHandler:
         flags = {k: v for k, v in kwargs.items() if isinstance(v, bool)}
         formats = {k: v for k, v in kwargs.items() if not isinstance(v, bool)}
 
-        if flags:
-            prompt = self._apply_flag_filter(prompt, flags)
+        prompt = self._apply_flag_filter(prompt, flags)
 
         return prompt.format(**formats).strip() if formats else prompt
 

--- a/tests/unit/test_prompt_handler.py
+++ b/tests/unit/test_prompt_handler.py
@@ -182,11 +182,16 @@ def test_flag_filter_removes_non_matching():
 def test_flag_filter_default_false():
     ph = PromptHandler()
     ph.load_prompt_dict({"p": "[debug] debug info\nbase"})
-    # When no flags are passed at all, _apply_flag_filter is not called,
-    # so flagged lines are kept as-is (including the tag text after regex sub).
-    result = ph.prompt_format("p", debug=False)
+    result = ph.prompt_format("p")
     assert "debug info" not in result
     assert "base" in result
+
+
+def test_flag_filter_defaults_false_with_format_variables():
+    ph = PromptHandler()
+    ph.load_prompt_dict({"p": "[debug] debug {name}\nhello {name}"})
+    result = ph.prompt_format("p", name="Alice")
+    assert result == "hello Alice"
 
 
 def test_flag_filter_unflagged_lines_always_kept():


### PR DESCRIPTION
## Summary

- Always apply conditional-line filtering so `[flag]` lines are omitted unless the corresponding boolean flag is explicitly true.
- Add regression coverage for omitted flags, including templates that also interpolate format variables.

## Problem

`PromptHandler` documents conditional lines as opt-in, but `prompt_format()` skipped filtering when no boolean kwargs were supplied. A template such as `[debug] secret detail` therefore leaked the raw tagged line into the rendered prompt by default.

## Verification

- Before: `PromptHandler(p="[debug] secret detail\nbase").prompt_format("p")` returned `"[debug] secret detail\nbase"`.
- After: the same reproduction returns `"base"`.
- `pytest tests/unit/test_prompt_handler.py -q` -> `32 passed`.
- `pre-commit run --files reme/components/prompt_handler.py tests/unit/test_prompt_handler.py` -> all hooks passed.

## Scope

- No prompt syntax or public method signatures change.
- Explicit `flag=True` behavior is unchanged.
- Unflagged lines and normal format variables are unchanged.