### PR TITLE
fix(file-io): offload move copy from event loop

### DIFF
--- a/reme/steps/file_io/move.py
+++ b/reme/steps/file_io/move.py
@@ -29,6 +29,7 @@ want to leave references stale (e.g. moving aside before delete) — the
 original is still removed in that case (move semantics, not copy).
 """
 
+import asyncio
 import shutil
 from pathlib import Path
 
@@ -82,7 +83,7 @@ class MoveStep(BaseStep):
 
         # Step 1 — copy. Wikilinks use workspace-relative paths, so outgoing
         # targets do not change when their containing document moves.
-        shutil.copyfile(str(src_abs), str(dst_abs))
+        await asyncio.to_thread(shutil.copyfile, str(src_abs), str(dst_abs))
         payload: dict = {"src_path": src_path, "dst_path": dst_path, "size": dst_abs.stat().st_size}
 
         # Step 2 — retarget. workspace_dir stays consistent throughout: refs still

--- a/tests/unit/test_crud_steps.py
+++ b/tests/unit/test_crud_steps.py
@@ -29,6 +29,7 @@ outside the workspace are rejected.
 import asyncio
 import os
 import tempfile
+import threading
 import warnings
 from pathlib import Path, PureWindowsPath
 
@@ -248,6 +249,44 @@ def test_move_relocates_within_workspace():
             assert (Path(tmp) / "knowledge/foo/foo.md").read_text(encoding="utf-8") == "draft"
             await store.close()
         print("✓ test_move_relocates_within_workspace passed")
+
+    asyncio.run(run())
+
+
+def test_move_copy_does_not_block_event_loop(monkeypatch):
+    """A slow file copy must not prevent unrelated async work from running."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            store = await _make_store({"daily/source.md": "draft"})
+            step = crud_move.MoveStep(file_store=store)
+            copy_started = threading.Event()
+            release_copy = threading.Event()
+            original_copyfile = crud_move.shutil.copyfile
+
+            def blocking_copyfile(src, dst):
+                copy_started.set()
+                assert release_copy.wait(timeout=1)
+                return original_copyfile(src, dst)
+
+            monkeypatch.setattr(crud_move.shutil, "copyfile", blocking_copyfile)
+            release_timer = threading.Timer(0.2, release_copy.set)
+            release_timer.start()
+            try:
+                move_task = asyncio.create_task(
+                    step(src_path="daily/source.md", dst_path="knowledge/source.md", retarget=False),
+                )
+                await asyncio.sleep(0.02)
+
+                assert copy_started.is_set()
+                assert not release_copy.is_set(), "synchronous copyfile blocked the event loop"
+
+                release_copy.set()
+                await move_task
+            finally:
+                release_copy.set()
+                release_timer.join()
+                await store.close()
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary

Offload `MoveStep`'s potentially large `shutil.copyfile` operation so a file move does not block unrelated async service work.

## Changes

- Run the copy phase with `asyncio.to_thread`.
- Keep the existing copy -> retarget links -> unlink ordering unchanged.
- Add a regression test with a controlled slow copy that verifies the event loop remains responsive.

## Evidence

Before the fix:

```text
FAILED test_move_copy_does_not_block_event_loop
AssertionError: synchronous copyfile blocked the event loop
```

After the fix:

```text
1 passed, 48 deselected
49 passed
```

Validation:

```text
pytest tests/unit/test_crud_steps.py -q
pre-commit run --files reme/steps/file_io/move.py tests/unit/test_crud_steps.py
```

All checks pass.

## Scope

This does not change path validation, overwrite behavior, wikilink retargeting, or source cleanup semantics.
