### PR TITLE
fix(component): roll back failed startup

### DIFF
--- a/reme/components/base_component.py
+++ b/reme/components/base_component.py
@@ -210,10 +210,28 @@ class BaseComponent(ComponentMixin, ABC):
             if self._is_started:
                 return
             await self._resolve_bindings()
-            for owned in self._owned:
-                await owned.start()
-            await self._start()
-            self._is_started = True
+            started_owned: list[BaseComponent] = []
+            parent_start_attempted = False
+            try:
+                for owned in self._owned:
+                    await owned.start()
+                    started_owned.append(owned)
+                parent_start_attempted = True
+                await self._start()
+                self._is_started = True
+            except BaseException:
+                if parent_start_attempted:
+                    try:
+                        await self._close()
+                    except BaseException as exc:
+                        self.logger.exception(f"Failed to roll back component {self.name}: {exc}")
+                for owned in reversed(started_owned):
+                    try:
+                        await owned.close()
+                    except BaseException as exc:
+                        self.logger.exception(f"Failed to roll back owned component {owned.name}: {exc}")
+                self._is_started = False
+                raise
 
     async def close(self) -> None:
         """Close the component once: run _close → close owned in reverse order."""

--- a/tests/unit/test_base_component.py
+++ b/tests/unit/test_base_component.py
@@ -43,6 +43,12 @@ class FailCloseComponent(StubComponent):
         raise RuntimeError("close failed")
 
 
+class FailStartComponent(StubComponent):
+    async def _start(self):
+        await super()._start()
+        raise RuntimeError("start failed")
+
+
 # -- Dependency ---------------------------------------------------------------
 
 
@@ -172,6 +178,32 @@ def test_close_closes_owned_when_parent_close_fails():
         assert owned.is_started is False
         assert owned.close_count == 1
         assert parent.is_started is False
+
+    asyncio.run(run())
+
+
+def test_start_failure_rolls_back_parent_and_owned_components():
+    async def run():
+        owned = StubComponent(name="owned")
+        parent = FailStartComponent(name="parent")
+        parent.dep = BaseComponent.bind(
+            "sub",
+            StubComponent,
+            default_factory=lambda: owned,
+        )
+
+        with pytest.raises(RuntimeError, match="start failed"):
+            await parent.start()
+
+        assert parent.is_started is False
+        assert parent.close_count == 1
+        assert owned.is_started is False
+        assert owned.close_count == 1
+
+        # A caller may still defensively close after failed startup.
+        await parent.close()
+        assert parent.close_count == 1
+        assert owned.close_count == 1
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary

Roll back partially started component lifecycles when `BaseComponent.start()` fails.

## Problem

`start()` currently starts owned dependencies before invoking the parent's `_start()`. If the parent hook raises, the parent remains marked as not started, so a later `close()` returns immediately while the owned components remain running.

This can leak clients, tasks, or other resources created by default-factory dependencies.

## Changes

- Track owned components that successfully started during the current attempt.
- If parent startup fails, invoke its cleanup hook and close started owned components in reverse order.
- Preserve the original startup exception even if rollback cleanup also fails.
- Add a regression test covering failed parent startup and defensive follow-up close.

## Evidence

Before the fix:

```text
FAILED test_start_failure_rolls_back_parent_and_owned_components
assert parent.close_count == 1
E assert 0 == 1
```

After the fix:

```text
pytest tests/unit/test_base_component.py -q
25 passed

pytest tests/unit/test_job.py -q
21 passed
```

All relevant pre-commit hooks pass.

## Scope

Successful startup and normal idempotent close behavior are unchanged.
