### PR TITLE
fix(stat): return text/markdown for .md files regardless of OS mime registry

### DIFF
--- a/reme/steps/file_io/stat.py
+++ b/reme/steps/file_io/stat.py
@@ -64,8 +64,11 @@ class StatStep(BaseStep):
         }
         if target.is_file():
             payload["size"] = st.st_size
-            payload["mime"] = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
-            if target.suffix == ".md":
+            is_md = target.suffix.lower() == ".md"
+            payload["mime"] = (
+                "text/markdown" if is_md else (mimetypes.guess_type(target.name)[0] or "application/octet-stream")
+            )
+            if is_md:
                 try:
                     meta = dict(frontmatter.loads(target.read_text(encoding="utf-8")).metadata)
                 except Exception:


### PR DESCRIPTION
## Description

### Problem

On macOS, `mimetypes.guess_type()` may not recognize `.md` files, causing `StatStep` to report `application/octet-stream` instead of a `text/` mime type. This breaks `tests/unit/test_crud_steps.py::test_stat_indexed_file` when the test is run in isolation on macOS.

### Environment

- OS: macOS 14.6.1
- Python: 3.11.10
- ReMe: `main` branch at the time of testing
- Shell: zsh

### Reproduction

On macOS, run the test in isolation:

```bash
cd /Users/lichen/my_reme/ReMe
pytest tests/unit/test_crud_steps.py::test_stat_indexed_file -v
```

Observed failure:

```text
E   AssertionError: assert False
E    +  where False = <built-in method startswith of str object at 0x...>('text/')
E    +    where <built-in method startswith of str object at 0x...> = 'application/octet-stream'.startswith
```

The `stat` step logs:

```text
[StatStep] path=topics/n.md type=file size=20 mime=application/octet-stream
```

When the full unit suite is run, the test happens to pass because other tests initialize `mimetypes` as a side effect. Running the test in isolation reproduces the issue reliably.

### Root Cause

`reme/steps/file_io/stat.py` relied solely on `mimetypes.guess_type(target.name)` to determine the mime type. The system-level mime registry on some platforms (notably macOS) does not map `.md` to `text/markdown`, so the fallback `application/octet-stream` was used.

### Changes

- In `StatStep`, explicitly map `.md` files to `text/markdown`.
- Reuse the `is_md` flag for both mime type and frontmatter parsing to avoid redundant suffix checks.

### Files Changed

- `reme/steps/file_io/stat.py`

## Tests

- Added regression coverage: existing `test_stat_indexed_file` now passes when run in isolation on macOS.
- Ran focused tests:

```bash
pytest tests/unit/test_crud_steps.py -v
# 49 passed
```

- Ran the previously failing test in isolation:

```bash
pytest tests/unit/test_crud_steps.py::test_stat_indexed_file -v
# passed
```

- Ran pre-submit checks:

```bash
pre-commit run --all-files
# all hooks passed
```

## Checklist

- [x] Bug fix with regression test passing
- [x] `pre-commit run --all-files` passes
- [x] Conventional commit / PR title format followed
- [ ] Documentation updated (not required; no user-facing behavior change)
