### PR TITLE
docs: add standalone ReMe GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,64 @@
+name: Deploy ReMe documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "github-pages/**"
+      - "docs/**"
+      - "README.md"
+      - "README_ZH.md"
+      - "skills/reme_memory/SKILL.md"
+      - "AGENTS.md"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.13"
+          cache: npm
+          cache-dependency-path: github-pages/package-lock.json
+
+      - name: Install dependencies
+        working-directory: github-pages
+        run: npm ci
+
+      - name: Build documentation
+        working-directory: github-pages
+        run: npm run build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: github-pages/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://pepy.tech/project/reme-ai/"><img src="https://img.shields.io/pypi/dm/reme-ai" alt="PyPI Downloads"></a>
   <a href="https://github.com/agentscope-ai/ReMe"><img src="https://img.shields.io/github/commit-activity/m/agentscope-ai/ReMe?style=flat-square" alt="GitHub commit activity"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-black" alt="License"></a>
-  <a href="https://docs.agentscope.io/reme"><img src="https://img.shields.io/badge/docs-ReMe-blue" alt="Documentation"></a>
+  <a href="https://reme.agentscope.io"><img src="https://img.shields.io/badge/docs-ReMe-blue" alt="Documentation"></a>
   <a href="./README.md"><img src="https://img.shields.io/badge/English-Click-yellow" alt="English"></a>
   <a href="./README_ZH.md"><img src="https://img.shields.io/badge/简体中文-点击查看-orange" alt="简体中文"></a>
   <a href="https://github.com/agentscope-ai/ReMe"><img src="https://img.shields.io/github/stars/agentscope-ai/ReMe?style=social" alt="GitHub Stars"></a>
@@ -422,7 +422,7 @@ are mainly for maintenance, debugging, or advanced integration. Run `reme help` 
 - **Pre-submit checks**: Before submitting a PR, try to run `pre-commit run --all-files` and `pytest`. If tests that
   depend on LLMs, embeddings, or external services cannot run, explain that in the PR.
 - **Get help**: Use [GitHub Issues](https://github.com/agentscope-ai/ReMe/issues) for bugs and feature requests. Project
-  documentation is available at [https://docs.agentscope.io/reme](https://docs.agentscope.io/reme).
+  documentation is available at [https://reme.agentscope.io](https://reme.agentscope.io).
 
 ### Contributors
 
@@ -438,7 +438,7 @@ Thanks to everyone who has contributed to ReMe:
 @software{ReMe2026,
   title = {Remember me, Refine me: Memory Management Kit for Agents},
   author = {ReMe Team},
-  url = {https://docs.agentscope.io/reme},
+  url = {https://reme.agentscope.io},
   year = {2026}
 }
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,7 +8,7 @@
   <a href="https://pepy.tech/project/reme-ai/"><img src="https://img.shields.io/pypi/dm/reme-ai" alt="PyPI Downloads"></a>
   <a href="https://github.com/agentscope-ai/ReMe"><img src="https://img.shields.io/github/commit-activity/m/agentscope-ai/ReMe?style=flat-square" alt="GitHub commit activity"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-black" alt="License"></a>
-  <a href="https://docs.agentscope.io/reme"><img src="https://img.shields.io/badge/docs-ReMe-blue" alt="文档"></a>
+  <a href="https://reme.agentscope.io"><img src="https://img.shields.io/badge/docs-ReMe-blue" alt="文档"></a>
   <a href="./README.md"><img src="https://img.shields.io/badge/English-Click-yellow" alt="English"></a>
   <a href="./README_ZH.md"><img src="https://img.shields.io/badge/简体中文-点击查看-orange" alt="简体中文"></a>
   <a href="https://github.com/agentscope-ai/ReMe"><img src="https://img.shields.io/github/stars/agentscope-ai/ReMe?style=social" alt="GitHub Stars"></a>
@@ -398,7 +398,7 @@ frontmatter 和文件操作接口主要用于维护、调试或高级集成。�
 - **提交前检查**：提交 PR 前请尽量运行 `pre-commit run --all-files` 和 `pytest`；如有依赖 LLM、embedding 或外部服务的测试无法运行，请在
   PR 中说明。
 - **获取帮助**：如需反馈 Bug 或功能请求，请使用 [GitHub Issues](https://github.com/agentscope-ai/ReMe/issues)；项目文档见
-  [https://docs.agentscope.io/reme](https://docs.agentscope.io/reme)。
+  [https://reme.agentscope.io](https://reme.agentscope.io)。
 
 ### 贡献者
 
@@ -414,7 +414,7 @@ frontmatter 和文件操作接口主要用于维护、调试或高级集成。�
 @software{ReMe2026,
   title = {Remember me, Refine me: Memory Management Kit for Agents},
   author = {ReMe Team},
-  url = {https://docs.agentscope.io/reme},
+  url = {https://reme.agentscope.io},
   year = {2026}
 }
 ```

--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -218,7 +218,7 @@ Documentation should:
 
 - Bugs and feature requests: [GitHub Issues](https://github.com/agentscope-ai/ReMe/issues)
 - Project home: [GitHub Repository](https://github.com/agentscope-ai/ReMe)
-- Documentation site: [https://docs.agentscope.io/reme](https://docs.agentscope.io/reme)
+- Documentation site: [https://reme.agentscope.io](https://reme.agentscope.io)
 
 ---
 

--- a/docs/en/reme-blog.md
+++ b/docs/en/reme-blog.md
@@ -14,7 +14,7 @@ That is exactly what ReMe sets out to do.
 
 GitHub: [https://github.com/agentscope-ai/ReMe](https://github.com/agentscope-ai/ReMe)
 
-Documentation: [https://docs.agentscope.io/reme](https://docs.agentscope.io/reme)
+Documentation: [https://reme.agentscope.io](https://reme.agentscope.io)
 
 <p align="center">
   <img src="../figure/reme-blog/reme-blog-cover-benchmark.png" alt="ReMe self-evolving personal knowledge base and public benchmark results" width="100%">

--- a/docs/zh/contributing.md
+++ b/docs/zh/contributing.md
@@ -199,7 +199,7 @@ docs/
 
 - Bugs 和功能请求：[GitHub Issues](https://github.com/agentscope-ai/ReMe/issues)
 - 项目主页：[GitHub Repository](https://github.com/agentscope-ai/ReMe)
-- 文档站点：[https://docs.agentscope.io/reme](https://docs.agentscope.io/reme)
+- 文档站点：[https://reme.agentscope.io](https://reme.agentscope.io)
 
 ---
 

--- a/docs/zh/reme-blog.md
+++ b/docs/zh/reme-blog.md
@@ -15,7 +15,7 @@ Markdown 记忆，并从中提炼值得继续关注的线索。**
 
 项目地址：[https://github.com/agentscope-ai/ReMe](https://github.com/agentscope-ai/ReMe)
 
-项目文档：[https://docs.agentscope.io/reme](https://docs.agentscope.io/reme)
+项目文档：[https://reme.agentscope.io](https://reme.agentscope.io)
 
 <p align="center">
   <img src="../figure/reme-blog/reme-blog-cover-benchmark.png" alt="ReMe 自进化个人知识库与公开基准结果" width="100%">

--- a/github-pages/.gitignore
+++ b/github-pages/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.generated/

--- a/github-pages/README.md
+++ b/github-pages/README.md
@@ -1,0 +1,86 @@
+# ReMe GitHub Pages
+
+This directory contains the standalone Vite documentation site published at <https://reme.agentscope.io>. The
+GitHub Pages fallback is <https://agentscope-ai.github.io/ReMe/>. It does not depend on the ReMe Studio application in
+`website/`.
+
+## Requirements
+
+- Node.js 22.13 or newer
+- npm
+
+## Local development
+
+From the repository root:
+
+```bash
+cd github-pages
+npm install
+npm run dev
+```
+
+Open the URL printed by Vite, normally <http://localhost:5173/>. The development server watches the frontend source.
+When a repository Markdown file changes, restart the development command to regenerate the documentation content.
+
+For subsequent installs or CI-compatible dependency installation, use:
+
+```bash
+npm ci
+```
+
+## Preview the production build
+
+Build and start the preview server:
+
+```bash
+npm run build
+npm run preview
+```
+
+Open the URL printed by Vite, normally <http://localhost:4173/>. Production assets use relative paths so the same build
+works on both the custom domain and the GitHub Pages project path.
+
+The generated `dist/` and `.generated/` directories are disposable build output and are excluded from Git.
+
+## Documentation sources
+
+The build script reads the canonical repository files directly. Do not edit generated copies under `.generated/` or
+`dist/`.
+
+- `README.md` and `README_ZH.md`: project introductions
+- `docs/en/` and `docs/zh/`: English and Chinese guides
+- `docs/figure/`: documentation images
+- `skills/reme_memory/SKILL.md`: ReMe Memory skill guide
+- `AGENTS.md`: repository development guide
+
+To add or reorganize a document in the site navigation, update
+[`scripts/generate-content.mjs`](./scripts/generate-content.mjs). Presentation and interaction code lives in `src/`.
+
+## Project structure
+
+```text
+github-pages/
+├── index.html
+├── package.json
+├── scripts/
+│   └── generate-content.mjs
+├── src/
+│   ├── main.js
+│   └── styles.css
+└── vite.config.js
+```
+
+## Deployment
+
+The repository workflow `.github/workflows/pages.yml` builds this directory and publishes `dist/` to GitHub Pages.
+It runs after relevant documentation or site files change on `main`, and it can also be started manually from the
+GitHub Actions page.
+
+The repository's **Settings → Pages → Build and deployment → Source** must be set to **GitHub Actions**. Its custom
+domain must be set to `reme.agentscope.io`; `public/CNAME` preserves that domain in the published artifact.
+
+Useful links:
+
+- ReMe documentation: <https://reme.agentscope.io>
+- GitHub Pages fallback: <https://agentscope-ai.github.io/ReMe/>
+- ReMe repository: <https://github.com/agentscope-ai/ReMe>

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="ReMe documentation — a local-first, file-native memory system for agents."
+    />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
+    <title>ReMe Documentation</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/github-pages/package-lock.json
+++ b/github-pages/package-lock.json
@@ -1,0 +1,1157 @@
+{
+  "name": "reme-github-pages",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reme-github-pages",
+      "version": "0.1.0",
+      "dependencies": {
+        "dompurify": "^3.2.6",
+        "marked": "^16.2.1"
+      },
+      "devDependencies": {
+        "vite": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.anpm.alibaba-inc.com/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.anpm.alibaba-inc.com/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.anpm.alibaba-inc.com/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.anpm.alibaba-inc.com/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.anpm.alibaba-inc.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.anpm.alibaba-inc.com/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/github-pages/package.json
+++ b/github-pages/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "reme-github-pages",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "scripts": {
+    "dev": "node scripts/generate-content.mjs && vite",
+    "build": "node scripts/generate-content.mjs && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "dompurify": "^3.2.6",
+    "marked": "^16.2.1"
+  },
+  "devDependencies": {
+    "vite": "^7.1.1"
+  }
+}

--- a/github-pages/public/CNAME
+++ b/github-pages/public/CNAME
@@ -1,0 +1,1 @@
+reme.agentscope.io

--- a/github-pages/public/favicon.svg
+++ b/github-pages/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <title>ReMe Documentation</title>
+  <defs>
+    <linearGradient id="reme-gradient" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#19c9b0"/>
+      <stop offset="1" stop-color="#3156d9"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="19" fill="url(#reme-gradient)"/>
+  <text
+    x="32"
+    y="44"
+    fill="#ffffff"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="39"
+    font-weight="700"
+    text-anchor="middle"
+  >R</text>
+</svg>

--- a/github-pages/scripts/generate-content.mjs
+++ b/github-pages/scripts/generate-content.mjs
@@ -1,0 +1,147 @@
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const siteDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoDir = path.resolve(siteDir, "..");
+const outputDir = path.join(siteDir, ".generated", "content");
+
+const topicOrder = [
+  "quick_start",
+  "memory_as_file",
+  "memory_search",
+  "auto_memory",
+  "auto_resource",
+  "auto_link",
+  "auto_dream",
+  "proactive",
+  "reme_scene",
+  "framework",
+  "reme-blog",
+  "contributing",
+];
+
+const groups = {
+  quick_start: "start",
+  memory_as_file: "fundamentals",
+  memory_search: "fundamentals",
+  auto_memory: "automation",
+  auto_resource: "automation",
+  auto_link: "automation",
+  auto_dream: "automation",
+  proactive: "automation",
+  reme_scene: "concepts",
+  framework: "concepts",
+  "reme-blog": "concepts",
+  contributing: "development",
+};
+
+const localizedTitles = {
+  quick_start: { zh: "快速开始", en: "Quick Start" },
+  memory_as_file: { zh: "文件即记忆", en: "Memory as File" },
+  memory_search: { zh: "记忆检索", en: "Memory Search" },
+  auto_memory: { zh: "自动记忆", en: "Auto Memory" },
+  auto_resource: { zh: "自动资料整理", en: "Auto Resource" },
+  auto_link: { zh: "自动关联", en: "Auto Link" },
+  auto_dream: { zh: "自动沉淀", en: "Auto Dream" },
+  proactive: { zh: "主动发现", en: "Proactive" },
+  reme_scene: { zh: "ReMe 应用场景", en: "ReMe Application Scenarios" },
+  framework: { zh: "ReMe 代码框架", en: "ReMe Framework" },
+  "reme-blog": { zh: "ReMe 博客", en: "ReMe Blog" },
+  contributing: { zh: "开源与贡献", en: "Open Source and Contributing" },
+};
+
+const sharedDocuments = [
+  {
+    id: "reme-memory-skill",
+    path: "skills/reme_memory/SKILL.md",
+    sourcePath: "skills/reme_memory/SKILL.md",
+    titles: {
+      zh: "ReMe 记忆技能",
+      en: "ReMe Memory Skill",
+    },
+    description: "Bootstrap, retrieve, write, and consolidate memory from an agent.",
+    group: "integration",
+    language: "shared",
+  },
+  {
+    id: "agents-guide",
+    path: "AGENTS.md",
+    sourcePath: "AGENTS.md",
+    titles: {
+      zh: "Agent 开发指南",
+      en: "Agent Development Guide",
+    },
+    description: "Repository contracts, lifecycle rules, safety boundaries, and validation.",
+    group: "development",
+    language: "shared",
+  },
+];
+
+async function markdownTitle(filePath) {
+  const source = await readFile(filePath, "utf8");
+  return source.match(/^#\s+(.+)$/m)?.[1]?.replace(/[`*_]/g, "") || path.basename(filePath, ".md");
+}
+
+async function buildManifest() {
+  const documents = [
+    {
+      id: "readme-zh",
+      path: "README_ZH.md",
+      sourcePath: "README_ZH.md",
+      title: "ReMe 项目介绍",
+      description: "核心理念、快速开始、使用场景与社区入口。",
+      group: "overview",
+      language: "zh",
+    },
+    {
+      id: "readme-en",
+      path: "README.md",
+      sourcePath: "README.md",
+      title: "Introducing ReMe",
+      description: "Core ideas, quick start, use cases, and community resources.",
+      group: "overview",
+      language: "en",
+    },
+  ];
+
+  for (const language of ["zh", "en"]) {
+    for (const topic of topicOrder) {
+      const sourcePath = `docs/${language}/${topic}.md`;
+      documents.push({
+        id: `${language}-${topic}`,
+        path: sourcePath,
+        sourcePath,
+        title: localizedTitles[topic]?.[language] || (await markdownTitle(path.join(repoDir, sourcePath))),
+        description: "",
+        group: groups[topic],
+        language,
+      });
+    }
+  }
+
+  return [...documents, ...sharedDocuments];
+}
+
+await rm(path.join(siteDir, ".generated"), { recursive: true, force: true });
+await mkdir(outputDir, { recursive: true });
+await cp(path.join(siteDir, "public", "favicon.svg"), path.join(siteDir, ".generated", "favicon.svg"));
+await cp(path.join(siteDir, "public", "CNAME"), path.join(siteDir, ".generated", "CNAME"));
+
+for (const file of ["README.md", "README_ZH.md", "AGENTS.md"]) {
+  await cp(path.join(repoDir, file), path.join(outputDir, file));
+}
+await cp(path.join(repoDir, "docs"), path.join(outputDir, "docs"), {
+  recursive: true,
+  filter: (source) => path.basename(source) !== ".DS_Store",
+});
+await mkdir(path.join(outputDir, "skills", "reme_memory"), { recursive: true });
+await cp(
+  path.join(repoDir, "skills", "reme_memory", "SKILL.md"),
+  path.join(outputDir, "skills", "reme_memory", "SKILL.md"),
+);
+
+await writeFile(
+  path.join(outputDir, "manifest.json"),
+  `${JSON.stringify({ documents: await buildManifest() }, null, 2)}\n`,
+);

--- a/github-pages/src/main.js
+++ b/github-pages/src/main.js
@@ -1,0 +1,340 @@
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+import "./styles.css";
+
+const baseUrl = import.meta.env.BASE_URL;
+const repositoryUrl = "https://github.com/agentscope-ai/ReMe";
+const officialDocsUrl = "https://reme.agentscope.io";
+
+const copy = {
+  zh: {
+    docs: "文档",
+    search: "搜索文档…",
+    noResults: "没有找到匹配的文档",
+    menu: "打开导航",
+    toc: "本页目录",
+    edit: "在 GitHub 查看源文件",
+    officialDocs: "官方文档",
+    groups: {
+      overview: "项目介绍",
+      start: "开始使用",
+      fundamentals: "核心原理",
+      automation: "自动化能力",
+      concepts: "架构与场景",
+      integration: "Agent 集成",
+      development: "开发者规范",
+    },
+  },
+  en: {
+    docs: "Documentation",
+    search: "Search documentation…",
+    noResults: "No matching documents",
+    menu: "Open navigation",
+    toc: "On this page",
+    edit: "View source on GitHub",
+    officialDocs: "Official docs",
+    groups: {
+      overview: "Introduction",
+      start: "Get started",
+      fundamentals: "Fundamentals",
+      automation: "Automation",
+      concepts: "Architecture & scenarios",
+      integration: "Agent integration",
+      development: "Development",
+    },
+  },
+};
+
+const state = {
+  language: localStorage.getItem("reme-docs-language") || "zh",
+  documents: [],
+  activeDocument: null,
+  query: "",
+};
+
+const app = document.querySelector("#app");
+
+app.innerHTML = `
+  <header class="topbar">
+    <a class="brand" href="${baseUrl}" aria-label="ReMe documentation home">
+      <span class="brand-mark">R</span>
+      <span>ReMe</span>
+      <span class="brand-divider"></span>
+      <span class="brand-section" data-copy="docs"></span>
+    </a>
+    <nav class="top-actions" aria-label="Global navigation">
+      <div class="language-switch" role="group" aria-label="Language">
+        <button type="button" data-language="zh">中</button>
+        <button type="button" data-language="en">EN</button>
+      </div>
+      <a class="official-docs-link" href="${officialDocsUrl}" target="_blank" rel="noreferrer" data-copy="officialDocs"></a>
+      <a class="github-link" href="${repositoryUrl}" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <button class="menu-button" type="button" aria-expanded="false" data-action="menu"></button>
+    </nav>
+  </header>
+  <div class="docs-shell">
+    <aside class="sidebar" aria-label="Documentation navigation">
+      <label class="search-box">
+        <span aria-hidden="true">⌕</span>
+        <input type="search" autocomplete="off" />
+        <kbd>⌘K</kbd>
+      </label>
+      <nav class="document-nav"></nav>
+      <div class="sidebar-footer">
+        <span class="status-dot"></span>
+        Local-first · File-native
+      </div>
+    </aside>
+    <main class="article-wrap">
+      <article class="article"><div class="loading-line"></div></article>
+    </main>
+    <aside class="toc-panel"><nav class="toc"></nav></aside>
+  </div>
+  <button class="sidebar-backdrop" type="button" aria-label="Close navigation"></button>
+`;
+
+const sidebar = app.querySelector(".sidebar");
+const documentNav = app.querySelector(".document-nav");
+const article = app.querySelector(".article");
+const toc = app.querySelector(".toc");
+const searchInput = app.querySelector("input[type='search']");
+const menuButton = app.querySelector(".menu-button");
+const backdrop = app.querySelector(".sidebar-backdrop");
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^\p{Letter}\p{Number}]+/gu, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function resolveDocumentPath(currentPath, target) {
+  const cleanTarget = target.split("#")[0].split("?")[0];
+  const currentParts = currentPath.split("/");
+  currentParts.pop();
+  for (const part of cleanTarget.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") currentParts.pop();
+    else currentParts.push(part);
+  }
+  return currentParts.join("/");
+}
+
+function configureMarkdown(document) {
+  const renderer = new marked.Renderer();
+  const headingIds = new Map();
+
+  renderer.heading = ({ tokens, depth }) => {
+    const text = tokens.map((token) => token.text || token.raw || "").join("");
+    const baseSlug = slugify(text) || "section";
+    const count = headingIds.get(baseSlug) || 0;
+    headingIds.set(baseSlug, count + 1);
+    const id = count ? `${baseSlug}-${count + 1}` : baseSlug;
+    return `<h${depth} id="${id}">${text}</h${depth}>`;
+  };
+
+  renderer.image = ({ href, title, text }) => {
+    const url = /^(https?:|data:)/.test(href)
+      ? href
+      : `${baseUrl}content/${resolveDocumentPath(document.path, href)}`;
+    const titleAttribute = title ? ` title="${title}"` : "";
+    return `<img src="${url}" alt="${text}" loading="lazy"${titleAttribute}>`;
+  };
+
+  renderer.link = ({ href, title, tokens }) => {
+    const label = tokens.map((token) => token.text || token.raw || "").join("");
+    const titleAttribute = title ? ` title="${title}"` : "";
+    if (href.startsWith("#")) return `<a href="${href}"${titleAttribute}>${label}</a>`;
+    if (!/^(https?:|mailto:)/.test(href)) {
+      const resolved = resolveDocumentPath(document.path, href);
+      const localDocument = state.documents.find((item) => item.path === resolved);
+      if (localDocument) return `<a href="?doc=${localDocument.id}" data-doc="${localDocument.id}">${label}</a>`;
+      return `<a href="${repositoryUrl}/blob/main/${resolved}" target="_blank" rel="noreferrer">${label}</a>`;
+    }
+    return `<a href="${href}" target="_blank" rel="noreferrer"${titleAttribute}>${label}</a>`;
+  };
+
+  marked.use({ renderer, gfm: true, breaks: false });
+}
+
+function availableDocuments() {
+  return state.documents.filter(
+    (document) => document.language === state.language || document.language === "shared",
+  );
+}
+
+function documentTitle(document) {
+  return document.titles?.[state.language] || document.title;
+}
+
+function renderChrome() {
+  const labels = copy[state.language];
+  app.querySelector("[data-copy='docs']").textContent = labels.docs;
+  app.querySelector("[data-copy='officialDocs']").textContent = `${labels.officialDocs} ↗`;
+  searchInput.placeholder = labels.search;
+  menuButton.textContent = labels.menu;
+  document.documentElement.lang = state.language === "zh" ? "zh-CN" : "en";
+  app.querySelectorAll("[data-language]").forEach((button) => {
+    button.classList.toggle("active", button.dataset.language === state.language);
+  });
+}
+
+function renderNavigation() {
+  const labels = copy[state.language];
+  const query = state.query.trim().toLocaleLowerCase();
+  const filtered = availableDocuments().filter((document) =>
+    `${documentTitle(document)} ${document.title || ""} ${document.description}`.toLocaleLowerCase().includes(query),
+  );
+  const groups = [...new Set(filtered.map((document) => document.group))];
+
+  if (!filtered.length) {
+    documentNav.innerHTML = `<p class="empty-state">${labels.noResults}</p>`;
+    return;
+  }
+
+  documentNav.innerHTML = groups
+    .map(
+      (group) => `
+        <section class="nav-group">
+          <h2>${labels.groups[group]}</h2>
+          ${filtered
+            .filter((document) => document.group === group)
+            .map(
+              (document) => `
+                <a href="?doc=${document.id}" data-doc="${document.id}" class="${state.activeDocument?.id === document.id ? "active" : ""}">
+                  <span>${documentTitle(document)}</span>
+                </a>`,
+            )
+            .join("")}
+        </section>`,
+    )
+    .join("");
+}
+
+function renderToc() {
+  const headings = [...article.querySelectorAll("h2, h3")];
+  if (!headings.length) {
+    toc.innerHTML = "";
+    return;
+  }
+  toc.innerHTML = `
+    <h2>${copy[state.language].toc}</h2>
+    ${headings
+      .map(
+        (heading) => `<a class="toc-${heading.tagName.toLowerCase()}" href="#${heading.id}">${heading.childNodes[0]?.textContent || heading.textContent}</a>`,
+      )
+      .join("")}
+  `;
+}
+
+function rewriteRenderedUrls(document) {
+  article.querySelectorAll("img[src]").forEach((image) => {
+    const source = image.getAttribute("src");
+    if (source && !/^(https?:|data:|\/)/.test(source)) {
+      image.src = `${baseUrl}content/${resolveDocumentPath(document.path, source)}`;
+    }
+  });
+
+  article.querySelectorAll("a[href]").forEach((link) => {
+    const href = link.getAttribute("href");
+    if (!href || /^(https?:|mailto:|#|\/)/.test(href) || link.dataset.doc) return;
+    const resolved = resolveDocumentPath(document.path, href);
+    const localDocument = state.documents.find((item) => item.path === resolved);
+    if (localDocument) {
+      link.href = `?doc=${localDocument.id}`;
+      link.dataset.doc = localDocument.id;
+      link.removeAttribute("target");
+      return;
+    }
+    link.href = `${repositoryUrl}/blob/main/${resolved}`;
+    link.target = "_blank";
+    link.rel = "noreferrer";
+  });
+}
+
+async function openDocument(id, pushHistory = true) {
+  const fallbackId = state.language === "zh" ? "readme-zh" : "readme-en";
+  const document = state.documents.find((item) => item.id === id) || state.documents.find((item) => item.id === fallbackId);
+  state.activeDocument = document;
+  article.dataset.group = document.group;
+  renderNavigation();
+  article.innerHTML = `<div class="loading-line"></div>`;
+
+  const response = await fetch(`${baseUrl}content/${document.path}`);
+  if (!response.ok) throw new Error(`Unable to load ${document.path}`);
+  configureMarkdown(document);
+  const markdown = await response.text();
+  const body = DOMPurify.sanitize(await marked.parse(markdown), {
+    ADD_ATTR: ["target"],
+  });
+  article.innerHTML = `
+    <div class="article-meta">
+      <span>${copy[state.language].groups[document.group]}</span>
+      <span>·</span>
+      <span>${document.sourcePath}</span>
+    </div>
+    <div class="markdown-body">${body}</div>
+    <footer class="article-footer">
+      <a href="${repositoryUrl}/blob/main/${document.sourcePath}" target="_blank" rel="noreferrer">${copy[state.language].edit} ↗</a>
+    </footer>
+  `;
+  rewriteRenderedUrls(document);
+  renderToc();
+  closeMenu();
+  if (pushHistory) history.pushState({ doc: document.id }, "", `?doc=${document.id}`);
+  window.scrollTo({ top: 0, behavior: "instant" });
+}
+
+function closeMenu() {
+  sidebar.classList.remove("open");
+  backdrop.classList.remove("visible");
+  menuButton.setAttribute("aria-expanded", "false");
+}
+
+function toggleMenu() {
+  const open = !sidebar.classList.contains("open");
+  sidebar.classList.toggle("open", open);
+  backdrop.classList.toggle("visible", open);
+  menuButton.setAttribute("aria-expanded", String(open));
+}
+
+app.addEventListener("click", (event) => {
+  const documentLink = event.target.closest("[data-doc]");
+  if (documentLink) {
+    event.preventDefault();
+    openDocument(documentLink.dataset.doc);
+  }
+  if (event.target.closest("[data-action='menu']")) toggleMenu();
+  const languageButton = event.target.closest("[data-language]");
+  if (languageButton && languageButton.dataset.language !== state.language) {
+    state.language = languageButton.dataset.language;
+    localStorage.setItem("reme-docs-language", state.language);
+    state.query = "";
+    searchInput.value = "";
+    renderChrome();
+    openDocument(state.language === "zh" ? "readme-zh" : "readme-en");
+  }
+});
+
+searchInput.addEventListener("input", () => {
+  state.query = searchInput.value;
+  renderNavigation();
+});
+
+document.addEventListener("keydown", (event) => {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+    event.preventDefault();
+    searchInput.focus();
+  }
+  if (event.key === "Escape") closeMenu();
+});
+
+backdrop.addEventListener("click", closeMenu);
+window.addEventListener("popstate", (event) => openDocument(event.state?.doc || new URLSearchParams(location.search).get("doc"), false));
+
+const manifest = await fetch(`${baseUrl}content/manifest.json`).then((response) => response.json());
+state.documents = manifest.documents;
+renderChrome();
+await openDocument(new URLSearchParams(location.search).get("doc"), false);

--- a/github-pages/src/styles.css
+++ b/github-pages/src/styles.css
@@ -1,0 +1,160 @@
+:root {
+  color: #17221d;
+  background: #f4f7f5;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --ink: #17221d;
+  --muted: #65716a;
+  --line: #dce5e0;
+  --paper: #ffffff;
+  --green: #087f6a;
+  --blue: #3156d9;
+  --green-soft: #e5f5ef;
+  --code: #f3f5f2;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; scroll-padding-top: 92px; }
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at 8% 9%, rgba(27, 193, 164, 0.06), transparent 26rem),
+    #f4f7f5;
+}
+button, input { font: inherit; }
+a { color: inherit; }
+
+.topbar {
+  position: fixed;
+  inset: 0 0 auto 0;
+  z-index: 30;
+  height: 66px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 28px;
+  border-bottom: 1px solid rgba(213, 225, 219, 0.85);
+  background: rgba(250, 252, 251, 0.88);
+  backdrop-filter: blur(18px) saturate(140%);
+}
+
+.brand { display: flex; align-items: center; gap: 11px; color: var(--ink); text-decoration: none; font-weight: 760; }
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 11px;
+  color: white;
+  background: linear-gradient(145deg, #19c9b0, #3156d9 82%);
+  box-shadow: 0 7px 18px rgba(24, 123, 114, 0.2);
+  font-family: Georgia, serif;
+  font-size: 21px;
+}
+.brand-divider { width: 1px; height: 20px; background: var(--line); margin-left: 2px; }
+.brand-section { color: var(--muted); font-weight: 520; }
+.top-actions { display: flex; align-items: center; gap: 18px; }
+.github-link, .official-docs-link { color: #37443d; text-decoration: none; font-size: 13px; font-weight: 650; }
+.github-link:hover, .official-docs-link:hover { color: var(--green); }
+.official-docs-link { padding: 8px 12px; border: 1px solid #d7e5df; border-radius: 9px; background: rgba(255, 255, 255, 0.72); }
+.language-switch { display: flex; padding: 3px; border: 1px solid var(--line); border-radius: 9px; background: #f5f7f4; }
+.language-switch button { padding: 5px 9px; border: 0; border-radius: 6px; color: var(--muted); background: transparent; cursor: pointer; font-size: 12px; font-weight: 700; }
+.language-switch button.active { color: var(--ink); background: white; box-shadow: 0 1px 3px rgba(20, 40, 30, 0.1); }
+.menu-button { display: none; border: 1px solid var(--line); border-radius: 8px; background: white; padding: 7px 10px; cursor: pointer; }
+
+.docs-shell { display: grid; grid-template-columns: 276px minmax(0, 1fr) 224px; max-width: 1540px; min-height: 100vh; margin: 0 auto; padding-top: 66px; }
+.sidebar { position: sticky; top: 66px; height: calc(100vh - 66px); padding: 25px 20px 18px; overflow-y: auto; border-right: 1px solid var(--line); background: rgba(247, 250, 248, 0.78); }
+.search-box { display: flex; align-items: center; gap: 8px; height: 41px; padding: 0 11px; border: 1px solid #d8e3dd; border-radius: 11px; color: #7a857e; background: rgba(255, 255, 255, 0.84); box-shadow: 0 5px 18px rgba(29, 65, 48, 0.035); }
+.search-box:focus-within { border-color: #78aa8e; box-shadow: 0 0 0 3px rgba(22, 120, 76, 0.1); }
+.search-box input { width: 100%; border: 0; outline: 0; color: var(--ink); background: transparent; font-size: 13px; }
+.search-box kbd { padding: 2px 5px; border: 1px solid var(--line); border-radius: 4px; background: #f7f8f6; font-size: 10px; }
+.document-nav { padding: 12px 0 52px; }
+.nav-group { margin-top: 21px; }
+.nav-group h2 { margin: 0 10px 7px; color: #8a948e; font-size: 10px; font-weight: 800; letter-spacing: 0.11em; text-transform: uppercase; }
+.nav-group a { position: relative; display: block; padding: 7px 10px 7px 13px; border-radius: 8px; color: #536058; text-decoration: none; font-size: 13px; line-height: 1.4; }
+.nav-group a:hover { color: var(--ink); background: #f0f3ef; }
+.nav-group a.active { color: #086b5a; background: linear-gradient(90deg, #dff3ec, #eaf6f2); font-weight: 700; }
+.nav-group a.active::before { position: absolute; top: 9px; bottom: 9px; left: 0; width: 3px; border-radius: 3px; background: linear-gradient(#17b79d, #3470d8); content: ""; }
+.empty-state { padding: 24px 10px; color: var(--muted); font-size: 13px; }
+.sidebar-footer { position: sticky; bottom: -18px; display: flex; align-items: center; gap: 8px; margin: 0 -20px; padding: 14px 22px 18px; border-top: 1px solid var(--line); color: #7c8880; background: #f7faf8; font: 600 10px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.04em; text-transform: uppercase; }
+.status-dot { width: 6px; height: 6px; border-radius: 50%; background: #29a869; box-shadow: 0 0 0 3px #dff3e8; }
+
+.article-wrap { min-width: 0; padding: 58px clamp(32px, 5.8vw, 86px) 100px; background: rgba(255, 255, 255, 0.94); }
+.article { width: 100%; max-width: 820px; margin: 0 auto; }
+.article-meta { display: flex; gap: 8px; margin-bottom: 22px; color: #7d8d84; font: 600 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.article-meta span:first-child { padding: 3px 8px; border-radius: 999px; color: #08705e; background: #e6f5ef; }
+.markdown-body { color: #27332d; font-size: 16px; line-height: 1.78; }
+.markdown-body > :first-child { margin-top: 0; }
+.markdown-body h1 { margin: 0 0 30px; color: #112019; font-size: clamp(36px, 5vw, 54px); line-height: 1.06; letter-spacing: -0.04em; }
+.markdown-body h2 { margin: 58px 0 18px; padding-top: 4px; color: #14241c; font-size: 27px; line-height: 1.25; letter-spacing: -0.02em; }
+.markdown-body h3 { margin: 35px 0 12px; color: #1f3027; font-size: 20px; line-height: 1.35; }
+.markdown-body p, .markdown-body ul, .markdown-body ol { margin: 14px 0; }
+.markdown-body li { margin: 5px 0; }
+.markdown-body a { color: var(--green); text-decoration-color: #9cc8ae; text-underline-offset: 3px; }
+.markdown-body a:hover { text-decoration-color: var(--green); }
+.markdown-body img { display: block; max-width: 100%; height: auto; margin: 30px auto; border-radius: 14px; }
+/* README badges are linked images. Keep them in a compact row instead of applying the figure layout above. */
+.article[data-group="overview"] .markdown-body > p:has(> a > img[src*="img.shields.io"]) {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 7px;
+  max-width: 690px;
+  margin: 20px auto;
+}
+.article[data-group="overview"] .markdown-body > p > a > img[src*="img.shields.io"] {
+  display: inline-block;
+  width: auto;
+  max-height: 24px;
+  margin: 0;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+.markdown-body p[align="center"] { text-align: center; }
+.article[data-group="overview"] .markdown-body > p:first-child img { max-width: min(470px, 72%); margin-top: 8px; filter: drop-shadow(0 18px 25px rgba(44, 85, 164, 0.1)); }
+.markdown-body code { padding: 2px 5px; border-radius: 5px; background: var(--code); color: #315844; font: 0.88em/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.markdown-body pre { margin: 24px 0; padding: 19px 21px; overflow-x: auto; border: 1px solid #dce5e0; border-radius: 12px; background: linear-gradient(145deg, #f5f8f6, #f8faf9); box-shadow: inset 3px 0 0 #7bd0b6; }
+.markdown-body pre code { padding: 0; color: #263b30; background: none; font-size: 13px; }
+.markdown-body blockquote { margin: 24px 0; padding: 4px 20px; border-left: 3px solid #68aa85; color: #53635a; background: #f5faf7; }
+.markdown-body table { display: block; width: 100%; margin: 24px 0; overflow-x: auto; border-collapse: collapse; font-size: 14px; }
+.markdown-body th, .markdown-body td { padding: 10px 13px; border: 1px solid var(--line); text-align: left; }
+.markdown-body th { background: #f4f6f3; }
+.markdown-body hr { margin: 44px 0; border: 0; border-top: 1px solid var(--line); }
+.article-footer { margin-top: 70px; padding-top: 20px; border-top: 1px solid var(--line); }
+.article-footer a { color: var(--muted); text-decoration: none; font-size: 13px; }
+.article-footer a:hover { color: var(--green); }
+.loading-line { width: 55%; height: 12px; margin-top: 40px; border-radius: 9px; background: linear-gradient(90deg, #edf0ec, #f8faf7, #edf0ec); background-size: 200% 100%; animation: loading 1.2s infinite; }
+@keyframes loading { to { background-position: -200% 0; } }
+
+.toc-panel { position: sticky; top: 66px; height: calc(100vh - 66px); padding: 58px 24px; overflow-y: auto; border-left: 1px solid #e9efeb; background: rgba(252, 253, 252, 0.92); }
+.toc h2 { margin: 0 0 12px; color: #8a948e; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; }
+.toc a { display: block; padding: 5px 0; color: #7a857e; text-decoration: none; font-size: 12px; line-height: 1.45; }
+.toc a:hover { color: var(--green); }
+.toc .toc-h3 { padding-left: 12px; }
+.sidebar-backdrop { display: none; }
+
+@media (max-width: 1120px) {
+  .docs-shell { grid-template-columns: 250px minmax(0, 1fr); }
+  .toc-panel { display: none; }
+}
+
+@media (max-width: 760px) {
+  .topbar { height: 60px; padding: 0 16px; }
+  .brand-section, .brand-divider, .github-link { display: none; }
+  .official-docs-link { font-size: 12px; }
+  .menu-button { display: block; max-width: 112px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .top-actions { gap: 9px; }
+  .docs-shell { display: block; padding-top: 60px; }
+  .sidebar { position: fixed; z-index: 25; top: 60px; bottom: 0; left: 0; width: min(310px, 86vw); height: auto; transform: translateX(-105%); transition: transform 180ms ease; box-shadow: 16px 0 35px rgba(20, 40, 30, 0.12); }
+  .sidebar.open { transform: translateX(0); }
+  .sidebar-backdrop { position: fixed; z-index: 20; inset: 60px 0 0; width: 100%; border: 0; background: rgba(18, 30, 23, 0.35); }
+  .sidebar-backdrop.visible { display: block; }
+  .article-wrap { padding: 38px 20px 72px; }
+  .article-meta { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+  .markdown-body { font-size: 15px; }
+  .markdown-body h1 { font-size: 34px; }
+  .markdown-body h2 { margin-top: 46px; font-size: 24px; }
+  .article[data-group="overview"] .markdown-body > p:first-child img { max-width: 84%; }
+}

--- a/github-pages/vite.config.js
+++ b/github-pages/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  publicDir: ".generated",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ full = [
 
 [project.urls]
 Homepage = "https://github.com/agentscope-ai/ReMe"
-Documentation = "https://docs.agentscope.io/reme"
+Documentation = "https://reme.agentscope.io"
 Repository = "https://github.com/agentscope-ai/ReMe"
 
 [project.scripts]


### PR DESCRIPTION
## 概述

新增一个独立的 ReMe 文档站点，源码放在 `github-pages/`，不复用 ReMe Studio 的 `website/`。站点使用 Vite 构建，并通过 GitHub Actions 发布到 GitHub Pages。

## 独立站点与内容来源

- 新增独立的 Vite 项目及锁文件，和现有 Studio 前端保持隔离。
- 构建时从仓库事实来源生成内容，不在站点目录重复维护文档正文。
- 当前收录 `README.md`、`README_ZH.md`、`docs/`、`skills/reme_memory/SKILL.md` 和 `AGENTS.md`。
- 自动生成 28 个文档条目的 manifest，并复制 Markdown 与图片资源到临时构建目录。
- `.generated/`、`dist/` 和 `node_modules/` 均保持为可丢弃产物，不提交到仓库。

## 文档组织与阅读体验

- 按项目介绍、开始使用、核心原理、自动化能力、架构与场景、Agent 集成和开发者规范分组。
- 为共享文档和中英文文档提供明确的中英文名称映射。
- 支持中英文切换、文档搜索、当前页面目录、站内 Markdown 跳转和 GitHub 源文件入口。
- 支持桌面端三栏布局与移动端抽屉式导航。
- 修复 README shields 标签的换行排列，避免徽章被当作普通大图渲染。
- 标题保留可跳转的锚点 ID，但不再显示尾随的 `#` 符号。
- 使用与站点顶部品牌一致的渐变 `R` favicon。

## 域名与链接策略

- GitHub Pages 自定义域名设置为 `reme.agentscope.io`，并在发布产物中携带 `CNAME`。
- 静态资源使用相对路径，同一构建同时兼容自定义域名根路径和 `agentscope-ai.github.io/ReMe/` 项目路径。
- README、贡献文档、博客和 Python 项目元数据中的站点根入口统一为 `https://reme.agentscope.io`。
- AgentScope 现有文档的深层链接继续使用 `https://docs.agentscope.io/reme/latest/...`，避免错误拼接为 `reme.agentscope.io/latest/...`。

## 自动部署

- 新增 GitHub Pages workflow，在 `main` 的站点或文档内容发生变化时自动构建和发布。
- 使用 Node.js 22.13、`npm ci` 和 GitHub 官方 Pages actions。
- 支持从 GitHub Actions 页面手动触发。
- 仓库 Pages 设置仍需选择 GitHub Actions 作为发布源，并配置 `reme.agentscope.io` 为自定义域名。

## 本地开发说明

新增 `github-pages/README.md`，记录依赖安装、开发服务器、生产构建、预览方式、文档来源、目录结构和部署要求。

## 验证

- `npm run build`：通过。
- 发布产物检查：包含 `CNAME`，脚本、样式、favicon 均使用相对路径。
- `pre-commit run --files ...`：YAML、XML、TOML、JSON、私钥检测、尾随空格和 Pyroma 检查均通过。
- `git diff --check`：通过。
- 未运行 Python 单元测试：本次变更仅涉及文档、静态站点和发布配置。