### PR TITLE
fix(ci): support AgentScope 2.0.6 eager model initialization

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,11 +28,4 @@ jobs:
         run: |
           pre-commit install
       - name: Pre-commit starts
-        run: |
-          pre-commit run --all-files > pre-commit.log 2>&1 || true
-          cat pre-commit.log
-          if grep -q Failed pre-commit.log; then
-            echo -e "\e[41m  [**FAIL**] Please install pre-commit and format your code first. \e[0m"
-            exit 1
-          fi
-          echo -e "\e[46m  ********************************Passed******************************** \e[0m"
+        run: pre-commit run --all-files

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -55,7 +55,7 @@ jobs:
           Pop-Location
 
       - name: Run version job
-        run: reme start service.backend=cli job=version
+        run: reme start config=tests/fixtures/config/version-smoke.yaml job=version
 
       - name: Run Windows path tests
         run: |

--- a/packages/reme_ai_studio/pyproject.toml
+++ b/packages/reme_ai_studio/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reme-ai-studio"
-version = "0.4.1.7"
+version = "0.4.1.8"
 description = "Optional ReMe Studio static frontend."
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ dependencies = [
 
 [project.optional-dependencies]
 web = [
-    "reme-ai-studio==0.4.1.7",
+    "reme-ai-studio==0.4.1.8",
 ]
 core = [
-    "agentscope==2.0.6",
+    "agentscope[model-ollama]==2.0.6",
     "claude-agent-sdk>=0.2.126",
     "dingtalk-stream>=0.24.3",
     "openai-codex>=0.144.4",
@@ -58,7 +58,7 @@ core = [
     "neo4j>=6.2.0",
     "networkx>=3.4.2",
     "polars>=1.43.0",
-    "reme-ai-studio==0.4.1.7",
+    "reme-ai-studio==0.4.1.8",
 ]
 dev = [
     "packaging>=24.2",

--- a/reme/__init__.py
+++ b/reme/__init__.py
@@ -1,6 +1,6 @@
 """ReMe CLI package."""
 
-__version__ = "0.4.1.7"
+__version__ = "0.4.1.8"
 
 from . import config
 from . import constants

--- a/tests/fixtures/config/version-smoke.yaml
+++ b/tests/fixtures/config/version-smoke.yaml
@@ -1,0 +1,17 @@
+workspace_dir: ${RUNNER_TEMP}/reme-version-smoke
+enable_logo: false
+log_to_console: false
+log_to_file: false
+
+service:
+  backend: cli
+
+jobs:
+  version:
+    backend: base
+    description: return reme package version
+    parameters:
+      type: object
+      properties: {}
+    steps:
+      - backend: version_step


### PR DESCRIPTION
## 背景

将 AgentScope 从 `2.0.4.post1` 升级到 `2.0.6` 后，ReMe 的 Linux 单测和 Windows smoke workflow 出现了稳定失败：

- `unittest.yml` 在 Python 3.11、3.12、3.13 上均有两个 Ollama embedding 测试失败，错误为 `ModuleNotFoundError: No module named 'ollama'`。
- `windows-smoke.yml` 在执行 `reme start service.backend=cli job=version` 时失败，OpenAI SDK 报告缺少 API key，后续 Windows 路径测试因此没有执行。

这不是 workflow YAML 或矩阵配置错误，而是 AgentScope 2.0.6 的模型初始化时机发生了变化：

- `OllamaEmbeddingModel` 现在在构造阶段创建客户端并导入 `ollama`，不再等到第一次 embedding 请求。
- OpenAI chat model 现在也在构造阶段创建客户端，因此应用启动默认 LLM 组件时会立即验证凭据。

## 修改内容

### 1. 显式安装 AgentScope Ollama extra

将 core 依赖从：

```toml
agentscope==2.0.6
```

调整为：

```toml
agentscope[model-ollama]==2.0.6
```

ReMe 已注册并测试 Ollama embedding backend，因此 core 开发/运行环境应包含对应 provider SDK。这样 `pip install -e ".[dev,core]"` 会同时安装 `ollama>=0.5.4`，恢复三个 Python 版本上的 Ollama 测试。

### 2. 使用无模型依赖的 Windows version smoke 配置

新增 `tests/fixtures/config/version-smoke.yaml`，其中只配置：

- 隔离在 `RUNNER_TEMP` 下的 workspace；
- CLI service；
- `version` base job；
- 不包含 LLM、agent wrapper 或 embedding 组件。

Windows workflow 改为：

```powershell
reme start config=tests/fixtures/config/version-smoke.yaml job=version
```

该命令仍然覆盖 ReMe 配置加载、Application 初始化、CLI service、job/step 注册、启动与反向关闭的完整生命周期，但不会为了读取包版本而初始化无关的外部模型客户端，也不需要在 CI 中放置虚假 API key。

### 3. 让 pre-commit 正确传播失败状态

原 workflow 使用 `pre-commit run ... || true` 后再搜索日志中的 `Failed`。如果 pre-commit 自身异常退出且输出不包含该字符串，workflow 可能误报成功。

现在直接执行：

```bash
pre-commit run --all-files
```

由 GitHub Actions 根据真实退出码判断结果。

### 4. 同步发布版本

由于依赖契约和发布内容发生变化，将 ReMe 与 ReMe Studio 的版本统一更新为 `0.4.1.8`，并同步两个 `reme-ai-studio` 精确版本约束。

## 验证结果

已通过：

- `pytest tests/unit/test_local_embedding_store.py -v`：20 passed
- `pytest tests/unit/test_package_versions.py -v`：14 passed
- `python scripts/bump_version.py --check --expected-version 0.4.1.8`
- 使用新 fixture 执行 CLI version smoke，输出 `0.4.1.8`
- 变更文件对应的全部 pre-commit hooks
- `actionlint 1.7.12` 检查以下 workflows：
  - `unittest.yml`
  - `windows-smoke.yml`
  - `pre-commit.yml`
  - `npm-format.yml`

补充执行完整 unit suite 时，本机存在多个历史 editable 安装造成的 `reme` namespace/全局日志状态污染，结果为 1053 passed、2 failed；两个剩余失败分别来自子进程解析到污染的 namespace 和日志全局状态，不涉及本 PR 修改的 Ollama、版本或 workflow 路径。干净的 GitHub runner 将继续作为完整矩阵验证依据。

## 兼容性与安全性

- 不改变 CLI 参数、配置键、workspace 布局、API schema 或 streaming 协议。
- Windows smoke workspace 位于 `RUNNER_TEMP`，不会向仓库 `.reme/` 写入测试状态。
- version smoke 不访问任何外部模型服务。
- Ollama SDK 通过 AgentScope 官方 extra 引入，避免 ReMe 单独维护重复的 provider 版本约束。
