### PR TITLE
fix(embedding): exclude provider initialization from health timeout

### DIFF
--- a/reme/components/as_embedding/__init__.py
+++ b/reme/components/as_embedding/__init__.py
@@ -121,6 +121,15 @@ class BaseAsEmbedding(BaseComponent):
         response = await self.model(inputs, **kwargs)  # pylint: disable=not-callable
         return response.embeddings
 
+    def initialize_model(self) -> None:
+        """Construct the provider without making a remote request.
+
+        Callers that apply their own request timeout can initialize first so
+        one-time SDK imports and client construction do not consume that
+        timeout budget. Normal embedding calls remain lazily initialized.
+        """
+        self._ensure_model()
+
     async def _start(self) -> None:
         """Defer provider construction until the first remote embedding call."""
         return None

--- a/reme/components/embedding_store/local_embedding_store.py
+++ b/reme/components/embedding_store/local_embedding_store.py
@@ -71,6 +71,11 @@ class LocalEmbeddingStore(BaseEmbeddingStore):
     async def health_check(self, timeout: float = 5.0) -> bool:
         tag = f"[EMBEDDING HEALTH CHECK] name={self.name} workspace_dir={self.workspace_path}"
         try:
+            # Provider construction may synchronously import an SDK and build
+            # its HTTP client. Keep that one-time work outside the request
+            # timeout so the full budget applies to the initialized provider
+            # call instead of being consumed before a request can be sent.
+            self.as_embedding.initialize_model()
             result = await asyncio.wait_for(self.as_embedding(["ping"]), timeout=timeout)
             if not result or result[0] is None:
                 raise RuntimeError("empty embedding")

--- a/tests/unit/test_local_embedding_store.py
+++ b/tests/unit/test_local_embedding_store.py
@@ -19,6 +19,9 @@ class FakeAsEmbedding:
     dimensions = 2
     vector_space_id = "fakespace000"
 
+    def initialize_model(self):
+        """Mirror the real component's idempotent initialization hook."""
+
     async def __call__(self, texts: list[str], **_kwargs):
         return [[1.0] if text == "bad" else [1.0, 0.0] for text in texts]
 
@@ -28,6 +31,9 @@ class BadHealthAsEmbedding:
 
     dimensions = 2
     vector_space_id = "fakespace000"
+
+    def initialize_model(self):
+        """Mirror the real component's idempotent initialization hook."""
 
     async def __call__(self, _texts: list[str], **_kwargs):
         return [[1.0]]
@@ -143,6 +149,39 @@ def test_health_check_rejects_wrong_dimension():
 
         assert await store.health_check() is False
         assert store.is_healthy is False
+
+    run(go())
+
+
+def test_health_check_starts_timeout_after_provider_initialization(monkeypatch):
+    """One-time client construction must not consume the request timeout."""
+
+    async def go():
+        events = []
+
+        class InitializingAsEmbedding(FakeAsEmbedding):
+            """Record initialization and provider-call ordering."""
+
+            def initialize_model(self):
+                events.append("initialized")
+
+            async def __call__(self, texts: list[str], **_kwargs):
+                events.append("remote request")
+                return [[1.0, 0.0] for _ in texts]
+
+        original_wait_for = asyncio.wait_for
+
+        async def checked_wait_for(awaitable, timeout):
+            assert events == ["initialized"]
+            assert timeout == 5.0
+            return await original_wait_for(awaitable, timeout)
+
+        store = LocalEmbeddingStore(name="t_local_embedding_health_timeout_scope")
+        store.as_embedding = InitializingAsEmbedding()
+        monkeypatch.setattr(asyncio, "wait_for", checked_wait_for)
+
+        assert await store.health_check(timeout=5.0) is True
+        assert events == ["initialized", "remote request"]
 
     run(go())
 


### PR DESCRIPTION
## Summary

- initialize the embedding provider before starting the health-check timeout
- reserve the configured timeout budget for the initialized provider call
- keep normal embedding calls lazily initialized
- add regression coverage for initialization/request ordering

The startup probe previously wrapped lazy SDK imports and HTTP client construction inside `asyncio.wait_for()`. On slower Windows environments, initialization could consume the five-second budget before `/api/embed` was sent.

## Validation

- `pytest tests/unit/test_local_embedding_store.py -q` (21 passed)
- `pre-commit run --files reme/components/as_embedding/__init__.py reme/components/embedding_store/local_embedding_store.py tests/unit/test_local_embedding_store.py`

Related to agentscope-ai/QwenPaw#7156.