### PR TITLE
ci: use trusted publishing for TypeScript package

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -1,6 +1,6 @@
 # Release checklist:
 # 1. Update packages/typescript/package.json and package-lock.json to the release version and merge them.
-# 2. Configure the NPM_TOKEN repository secret with publish access to the @agentscope-ai scope.
+# 2. Configure npm Trusted Publishing for agentscope-ai/ReMe and this workflow file.
 # 3. Run this workflow manually with the exact package version (an optional v prefix is accepted).
 # 4. Use the `next` tag for prereleases and `latest` only for stable releases.
 
@@ -128,6 +128,5 @@ jobs:
 
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ inputs.npm_tag }}
         run: npm publish dist/typescript/*.tgz --access public --tag "${NPM_TAG}" --provenance

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ keeping the files under the user's control.
 
 ## 📰 News
 
-- [2026.08] - Published [`@agentscope-ai/reme`](https://www.npmjs.com/package/@agentscope-ai/reme), providing native
-  ReMe memory integrations for DeepSeek Harness and OpenClaw.
+- [2026.08] - Published [`@agentscope-ai/reme`](https://www.npmjs.com/package/@agentscope-ai/reme), providing a native
+  ReMe memory integration for DeepSeek Harness.
 - [2026.08] - Published the [ReMe blog](https://agentscope-ai.github.io/ReMe/?doc=en-reme-blog), an end-to-end introduction to its local-first memory
   architecture, self-evolving workflows, hybrid search, proactive discovery, and benchmark results.
 - [2026.08] - [Experience-driven enhancement method](https://reme.agentscope.io/?doc=toolmemory-en) of agent tool-use execution built

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ keeping the files under the user's control.
 
 ## 📰 News
 
+- [2026.08] - Published [`@agentscope-ai/reme`](https://www.npmjs.com/package/@agentscope-ai/reme), providing native
+  ReMe memory integrations for DeepSeek Harness and OpenClaw.
 - [2026.08] - Published the [ReMe blog](https://agentscope-ai.github.io/ReMe/?doc=en-reme-blog), an end-to-end introduction to its local-first memory
   architecture, self-evolving workflows, hybrid search, proactive discovery, and benchmark results.
 - [2026.08] - [Experience-driven enhancement method](https://reme.agentscope.io/?doc=toolmemory-en) of agent tool-use execution built
@@ -97,6 +99,17 @@ cd ..
 ```
 
 The static build requires Node.js 22.13 or newer and makes Studio available from the source tree.
+
+### DeepSeek Harness Integration
+
+With the ReMe service running, install the npm package into the DeepSeek Harness Web profile:
+
+```bash
+dsh plugin --profile web add @agentscope-ai/reme
+```
+
+The plugin recalls relevant ReMe memory before agent steps and submits completed main-agent turns for automatic memory
+capture. See the [TypeScript integration guide](packages/typescript/README.md#deepseek-harness) for configuration.
 
 ### Environment Variables
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -53,8 +53,8 @@ Code 等 Agent 协作，在持续整理知识的同时，始终把文件控制�
 
 ## 📰 新闻
 
-- [2026.08] - 发布 [`@agentscope-ai/reme`](https://www.npmjs.com/package/@agentscope-ai/reme)，为 DeepSeek Harness 和
-  OpenClaw 提供原生 ReMe 记忆集成。
+- [2026.08] - 发布 [`@agentscope-ai/reme`](https://www.npmjs.com/package/@agentscope-ai/reme)，为 DeepSeek Harness
+  提供原生 ReMe 记忆集成。
 - [2026.08] - 发布 [ReMe 博客](https://agentscope-ai.github.io/ReMe/?doc=zh-reme-blog)，系统介绍本地优先的记忆架构、自进化工作流、混合检索、
   主动发现与评测结果。
 - [2026.08] - 基于 ReMe 的智能体工具使用

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -53,6 +53,8 @@ Code 等 Agent 协作，在持续整理知识的同时，始终把文件控制�
 
 ## 📰 新闻
 
+- [2026.08] - 发布 [`@agentscope-ai/reme`](https://www.npmjs.com/package/@agentscope-ai/reme)，为 DeepSeek Harness 和
+  OpenClaw 提供原生 ReMe 记忆集成。
 - [2026.08] - 发布 [ReMe 博客](https://agentscope-ai.github.io/ReMe/?doc=zh-reme-blog)，系统介绍本地优先的记忆架构、自进化工作流、混合检索、
   主动发现与评测结果。
 - [2026.08] - 基于 ReMe 的智能体工具使用
@@ -90,6 +92,17 @@ cd ..
 ```
 
 静态构建要求 Node.js 22.13 或更高版本，并让源码安装可以直接使用 Studio。
+
+### DeepSeek Harness 集成
+
+启动 ReMe 服务后，将 npm 包安装到 DeepSeek Harness 的 Web profile：
+
+```bash
+dsh plugin --profile web add @agentscope-ai/reme
+```
+
+插件会在 Agent step 前检索相关 ReMe 记忆，并将主 Agent 已完成的对话提交给自动记忆任务。配置方法见
+[TypeScript 集成指南](packages/typescript/README_ZH.md#deepseek-harness)。
 
 ### 环境变量
 


### PR DESCRIPTION
## Summary

- switch the TypeScript npm release from a long-lived `NPM_TOKEN` to npm Trusted Publishing via the existing GitHub OIDC permission
- document the published `@agentscope-ai/reme` DeepSeek Harness integration and its one-command installation in both root READMEs
- add the npm publication to the bilingual News sections

## Related issue

None.

## Contract and data impact

- [x] No public configuration, schema, CLI, endpoint, streaming, or workspace-layout contract changes
- [x] No user-owned memory files are deleted or rewritten
- [x] Derived indexes, catalogs, graphs, caches, and metadata remain rebuildable

## Validation

- [x] Focused checks pass: `pre-commit run --files .github/workflows/release-typescript.yml README.md README_ZH.md`
- [x] Unit tests omitted because this change only updates release authentication and documentation
- [x] `pre-commit run --all-files` omitted in favor of the focused checks above
- [x] Frontend checks not applicable; `website/` is unchanged

## Checklist

- [x] I reviewed the diff for unrelated changes and sensitive data
- [x] Tests are not required because runtime behavior is unchanged
- [x] Concise English and Chinese documentation were updated together
- [x] Application lifecycle behavior is unchanged

## Screenshots or additional notes

The npm package must keep its Trusted Publisher configured for `agentscope-ai/ReMe` and `.github/workflows/release-typescript.yml` before the next release.
