### PR TITLE
fix(index): tolerate invalid text encoding

### DIFF
--- a/docs/en/memory_as_file.md
+++ b/docs/en/memory_as_file.md
@@ -388,3 +388,8 @@ This lets the agent see not only an isolated paragraph but also its structural p
 
 Non-Markdown files use `DefaultFileChunker` by default. It splits by byte size and preserves a small overlap. For
 Markdown, the chunker also avoids cutting `[[wikilinks]]` in the middle.
+
+`DefaultFileChunker` and `MarkdownFileChunker` decode files with their configured `encoding` and normalize platform
+newlines to LF before indexing. Their default `invalid_encoding_policy: replace` keeps decodable content searchable
+when a source contains invalid bytes, without modifying the source file. Set `invalid_encoding_policy: strict` on a
+chunker component to reject such files instead.

--- a/docs/zh/memory_as_file.md
+++ b/docs/zh/memory_as_file.md
@@ -363,3 +363,7 @@ FileChunk[]
 这样检索命中时，Agent 不只看到孤立段落，还能看到它在原文件中的结构位置。
 
 非 Markdown 默认走 `DefaultFileChunker`：按字节大小切分，并保留少量 overlap；对 Markdown 则会避免把 `[[wikilink]]` 从中间切开。
+
+`DefaultFileChunker` 和 `MarkdownFileChunker` 使用各自配置的 `encoding` 解码文件，并在索引前将平台换行符统一为
+LF。默认的 `invalid_encoding_policy: replace` 会在源文件含无效字节时保留其中可解码的内容用于检索，但不会修改源
+文件；如需拒绝此类文件，可在 chunker 组件上设置 `invalid_encoding_policy: strict`。

--- a/reme/components/file_chunker/default_file_chunker.py
+++ b/reme/components/file_chunker/default_file_chunker.py
@@ -2,6 +2,7 @@
 
 from bisect import bisect_right
 from pathlib import Path
+from typing import Literal
 
 import aiofiles
 import yaml
@@ -11,14 +12,28 @@ from ..component_registry import R
 from ...schema import FileChunk, FileFrontMatter, FileNode
 from ...utils.wikilink_handler import WikilinkHandler
 
+InvalidEncodingPolicy = Literal["replace", "strict"]
+
 
 @R.register("default")
 class DefaultFileChunker(BaseFileChunker):
     """Default chunker that splits files into byte-based overlapping chunks."""
 
-    def __init__(self, encoding: str = "utf-8", chunk_byte_size: int = 10000, overlap_byte_size: int = 100, **kwargs):
+    def __init__(
+        self,
+        encoding: str = "utf-8",
+        invalid_encoding_policy: InvalidEncodingPolicy = "replace",
+        chunk_byte_size: int = 10000,
+        overlap_byte_size: int = 100,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
+        if invalid_encoding_policy not in {"replace", "strict"}:
+            raise ValueError(
+                f"invalid_encoding_policy must be 'replace' or 'strict', got {invalid_encoding_policy!r}",
+            )
         self.encoding = encoding
+        self.invalid_encoding_policy = invalid_encoding_policy
         self.chunk_byte_size = max(100, chunk_byte_size)
         self.overlap_byte_size = max(4, overlap_byte_size)
 
@@ -37,13 +52,28 @@ class DefaultFileChunker(BaseFileChunker):
             front_matter = FileFrontMatter()
         return front_matter, text[end_idx + 4 :].lstrip("\n")
 
+    async def _read_text_for_indexing(self, file_path: Path) -> str:
+        """Decode text for a derived index without modifying the source file."""
+        async with aiofiles.open(file_path, "rb") as f:
+            data = await f.read()
+        try:
+            return data.decode(self.encoding)
+        except UnicodeDecodeError as exc:
+            if self.invalid_encoding_policy == "strict":
+                raise
+            invalid_bytes = data[exc.start : exc.end].hex(" ")
+            self.logger.warning(
+                f"Invalid {self.encoding} in {file_path} at byte {exc.start} (bytes: {invalid_bytes}); "
+                "indexed with replacement characters; source file unchanged",
+            )
+            return data.decode(self.encoding, errors="replace")
+
     async def chunk(self, path: str | Path) -> tuple[FileNode, list[FileChunk]]:
         file_path = Path(path)
         stat = file_path.stat()
         rel_path = self.to_workspace_relative(path)
 
-        async with aiofiles.open(file_path, encoding=self.encoding) as f:
-            text = await f.read()
+        text = await self._read_text_for_indexing(file_path)
 
         if not text:
             return FileNode(path=rel_path, st_mtime=stat.st_mtime), []

--- a/reme/components/file_chunker/default_file_chunker.py
+++ b/reme/components/file_chunker/default_file_chunker.py
@@ -22,9 +22,10 @@ class DefaultFileChunker(BaseFileChunker):
     def __init__(
         self,
         encoding: str = "utf-8",
-        invalid_encoding_policy: InvalidEncodingPolicy = "replace",
         chunk_byte_size: int = 10000,
         overlap_byte_size: int = 100,
+        *,
+        invalid_encoding_policy: InvalidEncodingPolicy = "replace",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -57,7 +58,7 @@ class DefaultFileChunker(BaseFileChunker):
         async with aiofiles.open(file_path, "rb") as f:
             data = await f.read()
         try:
-            return data.decode(self.encoding)
+            text = data.decode(self.encoding)
         except UnicodeDecodeError as exc:
             if self.invalid_encoding_policy == "strict":
                 raise
@@ -66,7 +67,14 @@ class DefaultFileChunker(BaseFileChunker):
                 f"Invalid {self.encoding} in {file_path} at byte {exc.start} (bytes: {invalid_bytes}); "
                 "indexed with replacement characters; source file unchanged",
             )
-            return data.decode(self.encoding, errors="replace")
+            text = data.decode(self.encoding, errors="replace")
+            # Some codecs (for example ASCII) cannot encode U+FFFD. Convert the
+            # decoded fallback to that codec's own replacement representation so
+            # later byte-based chunking remains safe.
+            text = text.encode(self.encoding, errors="replace").decode(self.encoding)
+
+        # Match the universal-newline behavior of the previous text-mode reads.
+        return text.replace("\r\n", "\n").replace("\r", "\n")
 
     async def chunk(self, path: str | Path) -> tuple[FileNode, list[FileChunk]]:
         file_path = Path(path)

--- a/reme/components/file_chunker/markdown_file_chunker.py
+++ b/reme/components/file_chunker/markdown_file_chunker.py
@@ -24,7 +24,7 @@ import yaml
 from pydantic import ValidationError
 
 
-from .default_file_chunker import DefaultFileChunker
+from .default_file_chunker import DefaultFileChunker, InvalidEncodingPolicy
 from ..component_registry import R
 from ...schema import (
     FileChunk,
@@ -103,6 +103,7 @@ class MarkdownFileChunker(DefaultFileChunker):
     def __init__(
         self,
         encoding: str = "utf-8",
+        invalid_encoding_policy: InvalidEncodingPolicy = "replace",
         chunk_byte_size: int = 10000,
         embed_toc: bool = True,
         max_ast_sections: int | None = 100,
@@ -110,7 +111,12 @@ class MarkdownFileChunker(DefaultFileChunker):
         include_frontmatter_keys_in_metadata: list[str] | None = None,
         **kwargs,
     ):
-        super().__init__(encoding=encoding, chunk_byte_size=chunk_byte_size, **kwargs)
+        super().__init__(
+            encoding=encoding,
+            invalid_encoding_policy=invalid_encoding_policy,
+            chunk_byte_size=chunk_byte_size,
+            **kwargs,
+        )
         self.embed_toc = embed_toc
         self.max_ast_sections = max(0, max_ast_sections) if max_ast_sections is not None else None
         self.include_frontmatter_in_metadata = include_frontmatter_in_metadata
@@ -119,7 +125,8 @@ class MarkdownFileChunker(DefaultFileChunker):
     async def chunk(self, path: str | Path) -> tuple[FileNode, list[FileChunk]]:
         file_path = Path(path)
         rel_path = self.to_workspace_relative(path)
-        front_matter, content, line_offset = self._parse_front_matter(file_path.read_text(encoding=self.encoding))
+        text = await self._read_text_for_indexing(file_path)
+        front_matter, content, line_offset = self._parse_front_matter(text)
 
         chunks: list[FileChunk] = []
         if content and content.strip():

--- a/reme/components/file_chunker/markdown_file_chunker.py
+++ b/reme/components/file_chunker/markdown_file_chunker.py
@@ -103,12 +103,13 @@ class MarkdownFileChunker(DefaultFileChunker):
     def __init__(
         self,
         encoding: str = "utf-8",
-        invalid_encoding_policy: InvalidEncodingPolicy = "replace",
         chunk_byte_size: int = 10000,
         embed_toc: bool = True,
         max_ast_sections: int | None = 100,
         include_frontmatter_in_metadata: bool = False,
         include_frontmatter_keys_in_metadata: list[str] | None = None,
+        *,
+        invalid_encoding_policy: InvalidEncodingPolicy = "replace",
         **kwargs,
     ):
         super().__init__(

--- a/tests/unit/test_default_file_chunker.py
+++ b/tests/unit/test_default_file_chunker.py
@@ -107,6 +107,59 @@ def test_invalid_encoding_policy_is_validated():
         raise AssertionError("invalid encoding policy must be rejected")
 
 
+def test_constructor_preserves_positional_arguments():
+    """New decoding options must not reinterpret the established positional API."""
+    chunker = DefaultFileChunker("utf-8", 5000, 100)
+
+    assert chunker.encoding == "utf-8"
+    assert chunker.chunk_byte_size == 5000
+    assert chunker.overlap_byte_size == 100
+
+
+def test_newlines_are_normalized_before_chunking():
+    """Binary reads retain the universal-newline behavior of the old text reader."""
+
+    async def run():
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(b"alpha\r\nbeta\rgamma\n")
+            temp_path = f.name
+
+        try:
+            chunker = DefaultFileChunker()
+            _, original_chunks = await chunker.chunk(temp_path)
+            with open(temp_path, "wb") as f:
+                f.write(b"alpha\nbeta\ngamma\n")
+            _, normalized_chunks = await chunker.chunk(temp_path)
+
+            assert [chunk.text for chunk in original_chunks] == ["alpha\nbeta\ngamma\n"]
+            assert [chunk.id for chunk in original_chunks] == [chunk.id for chunk in normalized_chunks]
+        finally:
+            os.unlink(temp_path)
+
+    asyncio.run(run())
+
+
+def test_ascii_replacement_remains_encodable():
+    """Replacement mode must survive byte-based chunking with a single-byte codec."""
+
+    async def run():
+        source = b"valid\xffinvalid"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(source)
+            temp_path = f.name
+
+        try:
+            _, chunks = await DefaultFileChunker(encoding="ascii").chunk(temp_path)
+
+            assert [chunk.text for chunk in chunks] == ["valid?invalid"]
+            with open(temp_path, "rb") as f:
+                assert f.read() == source
+        finally:
+            os.unlink(temp_path)
+
+    asyncio.run(run())
+
+
 def test_parse_links_bare():
     """Bare wikilink: [[target]]."""
     links = WikilinkHandler.extract_links("see [[note]]", "src.md")

--- a/tests/unit/test_default_file_chunker.py
+++ b/tests/unit/test_default_file_chunker.py
@@ -97,6 +97,16 @@ def test_parse_with_custom_encoding():
     asyncio.run(run())
 
 
+def test_invalid_encoding_policy_is_validated():
+    """Reject misspelled policies instead of silently changing decoding behavior."""
+    try:
+        DefaultFileChunker(invalid_encoding_policy="ignore")
+    except ValueError as exc:
+        assert "invalid_encoding_policy" in str(exc)
+    else:
+        raise AssertionError("invalid encoding policy must be rejected")
+
+
 def test_parse_links_bare():
     """Bare wikilink: [[target]]."""
     links = WikilinkHandler.extract_links("see [[note]]", "src.md")

--- a/tests/unit/test_markdown_file_chunker.py
+++ b/tests/unit/test_markdown_file_chunker.py
@@ -102,6 +102,59 @@ def test_invalid_utf8_strict_policy_still_raises():
     asyncio.run(run())
 
 
+def test_constructor_preserves_positional_arguments():
+    """The decoding policy must not shift the established positional parameters."""
+    chunker = MarkdownFileChunker("utf-8", 5000, False, 10, True, ["name"])
+
+    assert chunker.encoding == "utf-8"
+    assert chunker.chunk_byte_size == 5000
+    assert chunker.embed_toc is False
+    assert chunker.max_ast_sections == 10
+    assert chunker.include_frontmatter_in_metadata is True
+    assert chunker.include_frontmatter_keys_in_metadata == ["name"]
+
+
+def test_plain_text_fallback_normalizes_newlines():
+    """Markdown fallback chunks stay stable for equivalent platform newlines."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            path = os.path.join(tmp, "fallback.md")
+            with open(path, "wb") as f:
+                f.write(b"# One\r\nbody\r# Two\r\nbody\r\n")
+
+            chunker = MarkdownFileChunker(max_ast_sections=0)
+            _, original_chunks = await chunker.chunk("fallback.md")
+            with open(path, "wb") as f:
+                f.write(b"# One\nbody\n# Two\nbody\n")
+            _, normalized_chunks = await chunker.chunk("fallback.md")
+
+            assert [chunk.text for chunk in original_chunks] == [chunk.text for chunk in normalized_chunks]
+            assert [chunk.id for chunk in original_chunks] == [chunk.id for chunk in normalized_chunks]
+
+    asyncio.run(run())
+
+
+def test_invalid_ascii_is_replaced_for_markdown():
+    """Markdown byte accounting accepts the configured codec's replacement text."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            source = b"# valid\ncontent before \xff content after\n"
+            path = os.path.join(tmp, "invalid.md")
+            with open(path, "wb") as f:
+                f.write(source)
+
+            chunker = MarkdownFileChunker(encoding="ascii")
+            _, chunks = await chunker.chunk("invalid.md")
+
+            assert "content before ? content after" in "\n".join(chunk.text for chunk in chunks)
+            with open(path, "rb") as f:
+                assert f.read() == source
+
+    asyncio.run(run())
+
+
 def test_parse_frontmatter_only():
     """A file with only frontmatter (no body) → no chunks, no links."""
 

--- a/tests/unit/test_markdown_file_chunker.py
+++ b/tests/unit/test_markdown_file_chunker.py
@@ -57,6 +57,51 @@ def test_parse_empty_file():
     asyncio.run(run())
 
 
+def test_invalid_utf8_is_replaced_without_modifying_source():
+    """Bad source bytes degrade the derived index but remain untouched on disk."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            source = b"# valid\ncontent before \xcd content after\n"
+            path = os.path.join(tmp, "invalid.md")
+            with open(path, "wb") as f:
+                f.write(source)
+
+            chunker = MarkdownFileChunker()
+            with patch.object(chunker.logger, "warning") as warning:
+                node, chunks = await chunker.chunk("invalid.md")
+
+            assert node.path == "invalid.md"
+            assert "content before \ufffd content after" in "\n".join(chunk.text for chunk in chunks)
+            with open(path, "rb") as f:
+                assert f.read() == source
+            warning.assert_called_once_with(
+                "Invalid utf-8 in invalid.md at byte 23 (bytes: cd); "
+                "indexed with replacement characters; source file unchanged",
+            )
+
+    asyncio.run(run())
+
+
+def test_invalid_utf8_strict_policy_still_raises():
+    """Strict mode remains available when callers require exact decoding."""
+
+    async def run():
+        with tempfile.TemporaryDirectory() as tmp, temp_chdir(tmp):
+            with open(os.path.join(tmp, "invalid.md"), "wb") as f:
+                f.write(b"valid\xcdinvalid")
+
+            chunker = MarkdownFileChunker(invalid_encoding_policy="strict")
+            try:
+                await chunker.chunk("invalid.md")
+            except UnicodeDecodeError as exc:
+                assert exc.start == 5
+            else:
+                raise AssertionError("strict policy must reject invalid UTF-8")
+
+    asyncio.run(run())
+
+
 def test_parse_frontmatter_only():
     """A file with only frontmatter (no body) → no chunks, no links."""
 


### PR DESCRIPTION
## Summary

Text chunkers previously decoded workspace files strictly with the configured encoding. A single invalid UTF-8 byte raised `UnicodeDecodeError`, caused `UpdateChangesStep` to skip the file, and retriggered the same failure during later startup or watch scans. This could leave otherwise readable memory content absent from the derived search index.

This change:

- introduces a typed `InvalidEncodingPolicy` with `replace` and `strict` modes;
- defaults Markdown and plain-text chunkers to `replace`, preserving all decodable content in the derived index;
- reads source files as bytes, attempts strict decoding first, and only falls back after an actual decode error;
- emits a warning with the source path, byte offset, and invalid byte sequence in hexadecimal;
- explicitly exposes the policy on `MarkdownFileChunker` instead of passing it through untyped `**kwargs`;
- retains `strict` mode for callers that require the previous fail-fast behavior; and
- validates dynamically supplied values at runtime because `Literal` annotations alone do not validate YAML or component kwargs.

The fallback is intentionally limited to Markdown and default plain-text chunkers. JSON and JSONL remain strict because replacement characters could invalidate or alter their structured records.

Most importantly, indexing never rewrites or transcodes the workspace source file. Replacement characters exist only in the rebuildable derived chunks. A later source-file repair changes its mtime and allows the watcher to replace the degraded index entry with clean content.

## Related issue

No linked issue.

## Contract and data impact

- [ ] No public configuration, schema, CLI, endpoint, streaming, or workspace-layout contract changes
- [x] No user-owned memory files are deleted or rewritten
- [x] Derived indexes, catalogs, graphs, caches, and metadata remain rebuildable

This adds the backward-compatible optional component argument `invalid_encoding_policy`. Its default is `replace`; setting it to `strict` preserves the previous decoding behavior. No built-in YAML keys, Pydantic schemas, CLI arguments, endpoints, or workspace layouts change.

For malformed text, the default indexing outcome intentionally changes from skipping the entire file to indexing its decodable content with Unicode replacement characters and a warning. Valid files are unchanged.

## Validation

- [x] Focused tests pass
- [ ] Unit tests pass, or omitted tests are explained below
- [ ] `pre-commit run --all-files` passes, or omitted checks are explained below
- [x] Frontend checks were run when `website/` changed

Exact checks run:

- `PYTHONPATH=/Users/yuli/workspace/ReMe pytest tests/unit/test_markdown_file_chunker.py tests/unit/test_default_file_chunker.py tests/unit/test_config_parser.py -q` — **68 passed**
- `PYTHONPATH=/Users/yuli/workspace/ReMe pytest tests/unit/test_background_steps.py -q -k "update_index or index_update_loop_init"` — **6 passed, 56 deselected**
- `pre-commit run --files reme/components/file_chunker/default_file_chunker.py reme/components/file_chunker/markdown_file_chunker.py tests/unit/test_default_file_chunker.py tests/unit/test_markdown_file_chunker.py` — **passed**, including AST, private-key, whitespace, trailing-comma, Black, Flake8, and Pylint checks
- `git diff --check` — **passed**

The complete unit suite and `pre-commit run --all-files` were not run because the change is isolated to text chunk decoding and the focused chunker plus index-update coverage passed. Frontend validation is not applicable because `website/` was not changed.

## Checklist

- [x] I reviewed the diff for unrelated changes and sensitive data
- [x] Tests cover intentional behavior changes
- [x] Defaults, schemas, and concise documentation were updated together when required
- [x] Long-lived clients, tasks, services, and executors follow the application lifecycle

No built-in configuration or schema update is required: the constructor default provides the behavior consistently for existing configurations, while runtime validation covers optional dynamic overrides. This change creates no long-lived resources.

## Screenshots or additional notes

No UI changes; screenshots are not applicable.

The warning format is designed to make source repair actionable without reporting a false indexing failure. For example:

```text
Invalid utf-8 in memory/2026-05-24.md at byte 3493 (bytes: cd); indexed with replacement characters; source file unchanged
```

Repairing the original file as valid UTF-8 is still recommended. This fallback keeps the remaining memory searchable until that repair occurs.