### PR TITLE
fix(dsh): deduplicate pending memory guidance

### DIFF
--- a/packages/typescript/src/dsh/guidance.ts
+++ b/packages/typescript/src/dsh/guidance.ts
@@ -25,17 +25,25 @@ export function memoryGuidance(language: "en" | "zh" = "en"): string {
   return GUIDANCE[language];
 }
 
-export function hasGuidance(session: DshSession): boolean {
-  return (session.events || []).some((event) => {
-    const source = isRecord(event.data) ? event.data.source : undefined;
-    return (
-      event.type === "user/message" &&
-      isRecord(source) &&
-      source.kind === "plugin" &&
-      source.plugin === REME_PLUGIN_SOURCE &&
-      source.form === "instructions"
-    );
-  });
+export function hasGuidance(
+  session: DshSession,
+  pendingMessages: readonly unknown[] = [],
+): boolean {
+  return (
+    (session.events || []).some(
+      (event) => event.type === "user/message" && isGuidance(event.data),
+    ) || pendingMessages.some(isGuidance)
+  );
+}
+
+function isGuidance(value: unknown): boolean {
+  const source = isRecord(value) ? value.source : undefined;
+  return (
+    isRecord(source) &&
+    source.kind === "plugin" &&
+    source.plugin === REME_PLUGIN_SOURCE &&
+    source.form === "instructions"
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/typescript/src/dsh/index.ts
+++ b/packages/typescript/src/dsh/index.ts
@@ -61,7 +61,11 @@ export function apply(ctx: Context, input: ReMeConfigInput = {}): void {
       () => () => runtime.dispose(agent.session),
       "remeMemory.disposeSession()",
     );
-    if (agent.status !== "idle" || hasGuidance(agent.session)) return;
+    if (
+      agent.status !== "idle" ||
+      hasGuidance(agent.session, agent.inbox.nextStep)
+    )
+      return;
     agent.inject(
       createUserMessage({
         content: [{ type: "text", text: memoryGuidance(config.language) }],

--- a/packages/typescript/tests/dsh-index.test.mjs
+++ b/packages/typescript/tests/dsh-index.test.mjs
@@ -42,11 +42,14 @@ test("composes root-agent guidance and reme_search on supported DSH releases", a
 
   const injected = [];
   const agentCleanups = [];
+  const nextStep = [];
   const agent = {
     status: "idle",
     session: { id: "root", header: {}, events: [] },
+    inbox: { nextStep },
     inject(message) {
       injected.push(message);
+      nextStep.push(message);
     },
     ctx: {
       effect(execute) {
@@ -61,6 +64,9 @@ test("composes root-agent guidance and reme_search on supported DSH releases", a
   assert.equal(injected[0].source.kind, "plugin");
   assert.equal(injected[0].source.plugin, "reme-memory");
   assert.match(injected[0].content[0].text, /长期记忆/);
+
+  handlers.get("agent/session-start")({ agent, source: "resume" });
+  assert.equal(injected.length, 1);
 
   await Promise.all(agentCleanups.map((cleanup) => cleanup()));
   await Promise.all(cleanups.map((cleanup) => cleanup()));
@@ -162,6 +168,7 @@ test("registers a ReMe settings namespace and reads changed values for new sessi
     agent: {
       status: "idle",
       session: { id: "settings-session", header: {}, events: [] },
+      inbox: { nextStep: [] },
       inject(message) {
         injected.push(message);
       },


### PR DESCRIPTION
## Summary

Fix repeated `reme-memory` context injection when a DeepSeek Harness session is resumed multiple times before its first user turn.

ReMe injects its long-term-memory guidance from the `agent/session-start` lifecycle event. The existing duplicate check only inspected committed `user/message` events. In DSH, however, `agent.inject()` stages idle context in the durable `next-step` inbox and does not produce a `user/message` until a model step claims that context. If the same session was persisted and resumed before the first prompt, every resume saw no committed guidance and appended another pending copy. The first user turn then claimed all copies, producing several identical context-injection rows and unnecessarily enlarging the model request.

This change extends the guidance check to cover both sources that can currently own the instruction:

- committed `user/message` events in the session log; and
- unclaimed messages in the live agent's durable `nextStep` inbox projection.

The source matching remains strict: only plugin messages from `reme-memory` with the `instructions` form suppress a new injection. Other pending context does not affect ReMe initialization.

The DSH composition test now mirrors inbox staging and emits a second `agent/session-start` event with source `resume`. It verifies that the pending first injection prevents a duplicate.

## Related issue

No linked issue. This was reproduced from a real DSH transcript in which four resume cycles occurred before the first user prompt, resulting in four identical ReMe context rows.

## Contract and data impact

- [x] No public configuration, schema, CLI, endpoint, streaming, or workspace-layout contract changes
- [x] No user-owned memory files are deleted or rewritten
- [x] Derived indexes, catalogs, graphs, caches, and metadata remain rebuildable

The change only affects DSH session-start deduplication. Existing session logs and durable inbox events require no migration. Sessions that already contain duplicate pending guidance will still consume those existing entries once; subsequent resumes will not append more copies.

## Validation

- [x] Focused tests pass
- [x] Unit tests pass, or omitted tests are explained below
- [ ] `pre-commit run --all-files` passes, or omitted checks are explained below
- [x] Frontend checks were run when `website/` changed

Commands run from `packages/typescript`:

- `npm test` — passed, 48 tests
- `npm run format:check` — passed
- `npm run lint` — passed

`npm test` rebuilds the TypeScript package before executing all package tests. Repository-wide Python tests and `pre-commit run --all-files` were not run because the change is isolated to the TypeScript DSH adapter. No `website/` files changed, so frontend checks were not applicable.

## Checklist

- [x] I reviewed the diff for unrelated changes and sensitive data
- [x] Tests cover intentional behavior changes
- [x] Defaults, schemas, and concise documentation were updated together when required
- [x] Long-lived clients, tasks, services, and executors follow the application lifecycle

No defaults, schemas, documentation, or lifecycle ownership changed.

## Screenshots or additional notes

Observed persisted sequence before this fix:

1. `agent/session-start` injects ReMe guidance into `next-step`.
2. The session ends before any turn claims the inbox.
3. Resume reconstructs the pending inbox from `agent/inbox/spliced` events.
4. The old check sees no ReMe `user/message` and injects another copy.
5. The first user turn claims every pending copy and renders each one as a separate context-injection row.

After this fix, step 4 recognizes the pending instruction and returns without injecting again.
