### PR TITLE
ci: harden build and release workflows

### DIFF
--- a/.github/workflows/_build-docs.yml
+++ b/.github/workflows/_build-docs.yml
@@ -26,12 +26,14 @@ jobs:
         working-directory: github-pages
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22.13'
+          node-version: '22.22.3'
           cache: npm
           cache-dependency-path: github-pages/package-lock.json
 
@@ -47,10 +49,10 @@ jobs:
 
       - name: Configure Pages
         if: inputs.upload_pages_artifact
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload Pages artifact
         if: inputs.upload_pages_artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: github-pages/dist

--- a/.github/workflows/_build-python-packages.yml
+++ b/.github/workflows/_build-python-packages.yml
@@ -23,10 +23,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
 
@@ -95,7 +97,7 @@ jobs:
 
       - name: Upload ReMe distributions
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reme-distributions
           path: dist/reme/

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -16,7 +16,6 @@ on:
       - 'typescript/README*.md'
       - 'plugins/*/README*.md'
       - 'benchmark/*/README*.md'
-      - 'skills/reme_memory/SKILL.md'
   pull_request:
     branches: [main, master, dev, develop]
     paths:
@@ -32,7 +31,6 @@ on:
       - 'typescript/README*.md'
       - 'plugins/*/README*.md'
       - 'benchmark/*/README*.md'
-      - 'skills/reme_memory/SKILL.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -8,9 +8,10 @@ on:
       - '.github/workflows/_build-python-packages.yml'
       - '.github/workflows/release-python.yml'
       - 'pyproject.toml'
-      - 'reme/__init__.py'
-      - 'reme/utils/web_static.py'
+      - 'README.md'
+      - 'reme/**'
       - 'scripts/bump_version.py'
+      - 'tests/unit/test_package_versions.py'
       - 'LICENSE'
   pull_request:
     branches: [main, master, dev, develop]
@@ -19,9 +20,10 @@ on:
       - '.github/workflows/_build-python-packages.yml'
       - '.github/workflows/release-python.yml'
       - 'pyproject.toml'
-      - 'reme/__init__.py'
-      - 'reme/utils/web_static.py'
+      - 'README.md'
+      - 'reme/**'
       - 'scripts/bump_version.py'
+      - 'tests/unit/test_package_versions.py'
       - 'LICENSE'
   workflow_dispatch:
 

--- a/.github/workflows/ci-python-quality.yml
+++ b/.github/workflows/ci-python-quality.yml
@@ -17,10 +17,12 @@ jobs:
     name: Pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/ci-python-tests.yml
+++ b/.github/workflows/ci-python-tests.yml
@@ -24,10 +24,12 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/ci-reme-studio.yml
+++ b/.github/workflows/ci-reme-studio.yml
@@ -38,12 +38,14 @@ jobs:
         working-directory: reme_studio
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: "22"
+          node-version: "22.22.3"
           cache: npm
           cache-dependency-path: reme_studio/package-lock.json
 
@@ -60,10 +62,12 @@ jobs:
         run: npm test
 
       - name: Verify npm package
-        run: npm pack --dry-run
+        run: |
+          npm pack --pack-destination "${RUNNER_TEMP}"
+          tar -tzf "${RUNNER_TEMP}"/agentscope-ai-reme_studio-*.tgz | grep '^package/dist-static/index.html$'
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -75,3 +79,12 @@ jobs:
           python scripts/package_studio.py
           python -m build reme_studio --outdir dist/studio
           python -m twine check dist/studio/*
+          STUDIO_WHEEL="$(pwd)/$(ls dist/studio/reme_studio-*.whl)"
+          python -m venv "${RUNNER_TEMP}/reme-studio-package-smoke"
+          "${RUNNER_TEMP}/reme-studio-package-smoke/bin/python" -m pip install "${STUDIO_WHEEL}"
+          cd "${RUNNER_TEMP}"
+          "${RUNNER_TEMP}/reme-studio-package-smoke/bin/python" - <<'PY'
+          from reme_studio import static_dir
+
+          assert (static_dir() / "index.html").is_file()
+          PY

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -31,9 +31,11 @@ jobs:
         working-directory: typescript
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22.22.3'
           cache: npm

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -24,10 +24,12 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,6 @@ on:
       - "typescript/README*.md"
       - "plugins/*/README*.md"
       - "benchmark/*/README*.md"
-      - "skills/reme_memory/SKILL.md"
       - "AGENTS.md"
       - ".github/workflows/deploy-docs.yml"
       - ".github/workflows/_build-docs.yml"
@@ -21,8 +20,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -33,7 +30,7 @@ jobs:
     name: Build documentation
     uses: ./.github/workflows/_build-docs.yml
     with:
-      run_tests: false
+      run_tests: true
       upload_pages_artifact: true
     permissions:
       contents: read
@@ -46,7 +43,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/policy-pr-title.yml
+++ b/.github/workflows/policy-pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
-        uses: amannn/action-semantic-pull-request@v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-auto-fin.yml
+++ b/.github/workflows/release-auto-fin.yml
@@ -1,7 +1,7 @@
 # 发布操作手册：
 # 1. 先将 plugins/auto-fin/pyproject.toml 中的 project.version 更新为待发布版本并合入目标分支。
 # 2. 确认插件依赖的 reme-ai 版本已经发布到 PyPI；本工作流会在构建阶段验证该依赖可下载。
-# 3. 确认仓库 Actions Secret 已配置 PYPI_API_TOKEN，且 PyPI 上不存在相同版本。
+# 3. 确认 PyPI Trusted Publisher 已绑定本仓库、此工作流和 pypi environment，且 PyPI 上不存在相同版本。
 # 4. 在 GitHub 仓库的 Actions 页面选择“Release / Auto Fin plugin”，点击“Run workflow”。
 # 5. 输入与 project.version 完全一致的版本号（例如 0.1.0）后运行；版本也可以带 v 前缀。
 #
@@ -34,10 +34,12 @@ jobs:
       RELEASE_VERSION: ${{ inputs.version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
 
@@ -82,10 +84,12 @@ jobs:
         run: python -m pytest plugins/auto-fin -q
 
       - name: Require the plugin-enabled ReMe release on PyPI
+        env:
+          REME_REQUIREMENT: ${{ steps.package.outputs.reme_requirement }}
         run: |
           python -m pip download --no-deps \
             --dest "${RUNNER_TEMP}/reme-auto-fin-core" \
-            "${{ steps.package.outputs.reme_requirement }}"
+            "${REME_REQUIREMENT}"
 
       - name: Build and check distributions
         run: |
@@ -113,7 +117,7 @@ jobs:
           PY
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reme-auto-fin-${{ inputs.version }}
           path: dist/auto-fin/
@@ -122,17 +126,19 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: reme-auto-fin-${{ inputs.version }}
           path: dist/auto-fin
 
       - name: Publish reme-auto-fin
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/auto-fin

--- a/.github/workflows/release-daily-paper.yml
+++ b/.github/workflows/release-daily-paper.yml
@@ -1,7 +1,7 @@
 # Release checklist:
 # 1. Update project.version in plugins/daily_paper/pyproject.toml and merge it into the target branch.
 # 2. Publish the required reme-ai version before this plugin; the build verifies that dependency on PyPI.
-# 3. Confirm PYPI_API_TOKEN is configured and the version does not already exist on PyPI.
+# 3. Configure PyPI Trusted Publishing for this repository/workflow and its pypi environment.
 # 4. Run "Release / Daily Paper plugin" from GitHub Actions with the exact project version (a v prefix is accepted).
 #
 # Recommended order: reme-ai -> reme-daily-paper -> downstream applications enabling plugins: [daily-paper].
@@ -33,10 +33,12 @@ jobs:
       RELEASE_VERSION: ${{ inputs.version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
 
@@ -81,10 +83,12 @@ jobs:
         run: python -m pytest plugins/daily_paper -q
 
       - name: Require the plugin-enabled ReMe release on PyPI
+        env:
+          REME_REQUIREMENT: ${{ steps.package.outputs.reme_requirement }}
         run: |
           python -m pip download --no-deps \
             --dest "${RUNNER_TEMP}/reme-daily-paper-core" \
-            "${{ steps.package.outputs.reme_requirement }}"
+            "${REME_REQUIREMENT}"
 
       - name: Build and check distributions
         run: |
@@ -123,7 +127,7 @@ jobs:
           PY
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reme-daily-paper-${{ inputs.version }}
           path: dist/daily-paper/
@@ -132,17 +136,19 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: reme-daily-paper-${{ inputs.version }}
           path: dist/daily-paper
 
       - name: Publish reme-daily-paper
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/daily-paper

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -2,6 +2,8 @@ name: Release / Python packages
 
 # reme-ai[qwenpaw] is verified before publication. Publish the independently
 # versioned reme-auto-fin and reme-daily-paper requirements first.
+# Configure a PyPI Trusted Publisher for this repository, workflow, and its
+# pypi environment before running the manual release.
 
 on:
   workflow_dispatch:
@@ -10,34 +12,38 @@ on:
         description: Release version
         required: true
         type: string
-  release:
-    types: [published]
 
 permissions:
   contents: read
+
+concurrency:
+  group: publish-reme-ai
+  cancel-in-progress: false
 
 jobs:
   build:
     name: Build and verify distributions
     uses: ./.github/workflows/_build-python-packages.yml
     with:
-      expected_version: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+      expected_version: ${{ inputs.version }}
       upload_artifacts: true
 
   publish-reme:
     needs: build
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Download ReMe distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: reme-distributions
           path: dist/reme
 
       - name: Publish ReMe
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/reme
           skip-existing: true

--- a/.github/workflows/release-reme-studio.yml
+++ b/.github/workflows/release-reme-studio.yml
@@ -1,6 +1,6 @@
 # Release checklist:
 # 1. Update reme_studio/pyproject.toml, package.json, and package-lock.json to the same Studio version.
-# 2. Configure PyPI and npm publishing credentials for this workflow.
+# 2. Configure npm Trusted Publishing and PyPI Trusted Publishing with the pypi environment.
 # 3. Run this workflow manually with the exact Studio version.
 
 name: Release / ReMe Studio
@@ -38,15 +38,17 @@ jobs:
       NPM_TAG: ${{ inputs.npm_tag }}
 
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          node-version: "22.13"
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22.22.3"
           cache: npm
           cache-dependency-path: reme_studio/package-lock.json
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -93,7 +95,20 @@ jobs:
           python -m build reme_studio --outdir dist/studio-python
           python -m twine check dist/studio-python/*
 
-      - uses: actions/upload-artifact@v4
+      - name: Verify Studio distributions and isolated installation
+        run: |
+          STUDIO_WHEEL="$(pwd)/$(ls dist/studio-python/reme_studio-*.whl)"
+          tar -tzf dist/studio-npm/*.tgz | grep '^package/dist-static/index.html$'
+          python -m venv "${RUNNER_TEMP}/reme-studio-package-smoke"
+          "${RUNNER_TEMP}/reme-studio-package-smoke/bin/python" -m pip install "${STUDIO_WHEEL}"
+          cd "${RUNNER_TEMP}"
+          "${RUNNER_TEMP}/reme-studio-package-smoke/bin/python" - <<'PY'
+          from reme_studio import static_dir
+
+          assert (static_dir() / "index.html").is_file()
+          PY
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reme-studio-${{ inputs.version }}
           path: |
@@ -104,17 +119,19 @@ jobs:
   publish-python:
     needs: build
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: reme-studio-${{ inputs.version }}
           path: dist
 
       - name: Publish ReMe Studio to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/studio-python
           skip-existing: true
 
@@ -125,12 +142,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: reme-studio-${{ inputs.version }}
           path: dist

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -47,10 +47,12 @@ jobs:
       NPM_TAG: ${{ inputs.npm_tag }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22.22.3'
 
@@ -101,7 +103,7 @@ jobs:
           npm pack --pack-destination "${RUNNER_TEMP}/reme-typescript-package"
 
       - name: Upload npm tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: agentscope-ai-reme-${{ inputs.version }}
           path: ${{ runner.temp }}/reme-typescript-package/*.tgz
@@ -116,13 +118,13 @@ jobs:
 
     steps:
       - name: Set up Node for npm
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org
 
       - name: Download npm tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: agentscope-ai-reme-${{ inputs.version }}
           path: dist/typescript
@@ -149,7 +151,7 @@ jobs:
       actions: read
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.3
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@87ca030c30f3cfb78ab15c8e66b5ff1469c8f9c8 # v0.23.3
     with:
       owner: agentscope-ai
       family: code-plugin

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -30,15 +30,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- gate documentation deployment on its test suite and broaden Python package CI path coverage
- verify the actual Studio npm tarball and isolated Python wheel before publication
- make the core release manual-only, serialize core publication, and prevent unrelated GitHub Releases from triggering it
- migrate Python package publication to PyPI Trusted Publishing through the `pypi` environment
- pin all remote Actions and reusable workflows to commit SHAs, disable persisted checkout credentials, scope Pages/OIDC permissions to the jobs that need them, and avoid direct shell interpolation of step outputs
- standardize build-time Node.js on 22.22.3 and remove stale documentation triggers

## Required repository configuration

Before using the Python release workflows after merge:

1. Create and protect a GitHub environment named `pypi`.
2. Configure a PyPI Trusted Publisher for each project (`reme-ai`, `reme_studio`, `reme-auto-fin`, and `reme-daily-paper`) with repository `agentscope-ai/ReMe`, its corresponding release workflow filename, and environment `pypi`.

The workflows no longer consume `PYPI_API_TOKEN`.

## Validation

- `actionlint v1.7.12 .github/workflows/*.yml`
- `uvx zizmor .github/workflows` — no findings
- `pre-commit run --all-files`
- documentation `npm test` and `npm run build` — 3 tests passed and production build succeeded
- Studio `npm run format:check`, `npm run lint`, and `npm test` — 33 tests passed
- `pytest tests/unit/test_package_versions.py -q` — 14 passed
- built and inspected the Studio npm tarball
- built and checked the Studio wheel/sdist with Twine
- installed the Studio wheel in an isolated environment and verified `static_dir()/index.html`
- YAML parsing and `git diff --check`

Credentialed publication was not run.
