### PR TITLE
ci: allow bootstrap release before qwenpaw plugins

### DIFF
--- a/.github/workflows/_build-python-packages.yml
+++ b/.github/workflows/_build-python-packages.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: false
         type: boolean
+      verify_qwenpaw_dependencies:
+        description: Verify that independently published qwenpaw plugins are installable
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -79,10 +84,10 @@ jobs:
           assert (static_dir() / "index.html").is_file()
           PY
 
-      # qwenpaw composes independently released plugins. Keep this before the
-      # artifact upload so a core release cannot advertise an unavailable extra.
+      # qwenpaw composes independently released plugins. Bootstrap releases may
+      # skip this check to publish the reme-ai version required by those plugins.
       - name: Verify released qwenpaw dependencies
-        if: inputs.expected_version != ''
+        if: inputs.expected_version != '' && inputs.verify_qwenpaw_dependencies
         run: |
           REME_WHEEL="$(pwd)/$(ls dist/reme/reme_ai-[0-9]*.whl)"
           python -m venv "${RUNNER_TEMP}/reme-qwenpaw-package-smoke"

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,7 +1,8 @@
 name: Release / Python packages
 
-# reme-ai[qwenpaw] is verified before publication. Publish the independently
-# versioned reme-auto-fin and reme-daily-paper requirements first.
+# reme-ai[qwenpaw] is normally verified before publication. For a bootstrap
+# release where the plugins require this new reme-ai version, disable that
+# verification, publish reme-ai first, and then publish the plugins.
 # Configure a PyPI Trusted Publisher for this repository, workflow, and its
 # pypi environment before running the manual release.
 
@@ -12,6 +13,11 @@ on:
         description: Release version
         required: true
         type: string
+      verify_qwenpaw_dependencies:
+        description: Verify already-published Auto Fin and Daily Paper packages
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -27,6 +33,7 @@ jobs:
     with:
       expected_version: ${{ inputs.version }}
       upload_artifacts: true
+      verify_qwenpaw_dependencies: ${{ inputs.verify_qwenpaw_dependencies }}
 
   publish-reme:
     needs: build


### PR DESCRIPTION
## Summary

- add an explicit switch for verifying published qwenpaw plugin dependencies
- keep verification enabled by default
- allow bootstrap releases to publish the reme-ai version required by independently versioned plugins

## Context

The release workflow currently deadlocks when new plugin versions require the unreleased reme-ai version, while the reme-ai release requires those plugin versions to already exist on PyPI. Bootstrap releases can now disable only the qwenpaw online installation check, publish reme-ai, and then publish the plugins.

## Validation

- python -m pytest tests/unit/test_package_versions.py -q
- pre-commit run --files .github/workflows/_build-python-packages.yml .github/workflows/release-python.yml
- git diff --check