### PR TITLE
ci: update release workflow actions and smoke checks

### DIFF
--- a/.github/workflows/_build-python-packages.yml
+++ b/.github/workflows/_build-python-packages.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload ReMe distributions
         if: inputs.upload_artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: reme-distributions
           path: dist/reme/

--- a/.github/workflows/release-auto-fin.yml
+++ b/.github/workflows/release-auto-fin.yml
@@ -109,11 +109,23 @@ jobs:
           "${RUNNER_TEMP}/reme-auto-fin-smoke/bin/python" - <<'PY'
           from importlib.metadata import distribution
 
+          from reme.plugin_manifest import load_package_manifest
+
           package = distribution("reme-auto-fin")
           plugins = {entry.name: entry for entry in package.entry_points if entry.group == "reme.plugins"}
-          configs = {entry.name: entry for entry in package.entry_points if entry.group == "reme.configs"}
-          assert plugins["auto-fin"].load().name == "auto-fin"
-          assert configs["auto-fin"].load().is_file()
+          assert plugins["auto-fin"].value == "reme_auto_fin"
+          manifest = load_package_manifest("reme_auto_fin", plugin_name="auto-fin")
+          assert set(manifest.backends) == {
+              "auto_fin_data_step",
+              "auto_fin_topic_step",
+              "auto_fin_merge_step",
+          }
+          assert set(manifest.application_defaults["jobs"]) == {
+              "auto_fin",
+              "auto_fin_0930_cron",
+              "auto_fin_1130_cron",
+              "auto_fin_1800_cron",
+          }
           PY
 
       - name: Upload distributions

--- a/.github/workflows/release-auto-fin.yml
+++ b/.github/workflows/release-auto-fin.yml
@@ -117,7 +117,7 @@ jobs:
           PY
 
       - name: Upload distributions
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: reme-auto-fin-${{ inputs.version }}
           path: dist/auto-fin/
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: reme-auto-fin-${{ inputs.version }}
           path: dist/auto-fin

--- a/.github/workflows/release-daily-paper.yml
+++ b/.github/workflows/release-daily-paper.yml
@@ -127,7 +127,7 @@ jobs:
           PY
 
       - name: Upload distributions
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: reme-daily-paper-${{ inputs.version }}
           path: dist/daily-paper/
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: reme-daily-paper-${{ inputs.version }}
           path: dist/daily-paper

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -44,7 +44,7 @@ jobs:
       id-token: write
     steps:
       - name: Download ReMe distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: reme-distributions
           path: dist/reme

--- a/.github/workflows/release-reme-studio.yml
+++ b/.github/workflows/release-reme-studio.yml
@@ -108,7 +108,7 @@ jobs:
           assert (static_dir() / "index.html").is_file()
           PY
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: reme-studio-${{ inputs.version }}
           path: |
@@ -124,7 +124,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: reme-studio-${{ inputs.version }}
           path: dist
@@ -147,7 +147,7 @@ jobs:
           node-version: "24"
           registry-url: https://registry.npmjs.org
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: reme-studio-${{ inputs.version }}
           path: dist

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -103,7 +103,7 @@ jobs:
           npm pack --pack-destination "${RUNNER_TEMP}/reme-typescript-package"
 
       - name: Upload npm tarball
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: agentscope-ai-reme-${{ inputs.version }}
           path: ${{ runner.temp }}/reme-typescript-package/*.tgz
@@ -124,7 +124,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Download npm tarball
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: agentscope-ai-reme-${{ inputs.version }}
           path: dist/typescript


### PR DESCRIPTION
## Summary

- upgrade pinned upload-artifact references from v4 to v6
- upgrade pinned download-artifact references from v4 to v7
- update all Python, plugin, Studio, and TypeScript release workflows consistently
- migrate the Auto Fin wheel smoke test from legacy Python plugin/config entry points to the current package-only plugin.yaml contract

## Context

GitHub-hosted runners warn that the pinned v4 artifact actions target deprecated Node.js 20 and are being forced onto Node.js 24. The updated versions declare Node.js 24 directly while preserving the repository SHA-pinning policy.

The Auto Fin release smoke test also expected the old Plugin descriptor and reme.configs entry point. Auto Fin now exposes a package-only reme.plugins entry point and declares its backends and jobs in plugin.yaml, so the release check now validates that current contract like the Daily Paper workflow.

## Validation

- pre-commit checks for all changed workflows
- python -m pytest plugins/auto-fin -q (9 passed)
- built the Auto Fin wheel, installed it into an isolated target, and verified its entry point and packaged manifest
- git diff --check
- verified no v4 upload-artifact or download-artifact references remain under .github/workflows