### PR TITLE
ci(deps): automate AgentScope updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "cron"
+      cronjob: "30 9 * * *"
+      timezone: "Asia/Shanghai"
+    allow:
+      - dependency-name: "agentscope"
+    cooldown:
+      exclude:
+        - "agentscope"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/release-auto-fin.yml
+++ b/.github/workflows/release-auto-fin.yml
@@ -83,9 +83,19 @@ jobs:
           ]
           if len(agentscope_requirements) != 1 or agentscope_requirements[0].name != "agentscope":
               raise SystemExit(f"Expected one agentscope dependency, found {agentscope_requirements!r}")
+          agentscope_requirement = agentscope_requirements[0]
+          agentscope_specifiers = list(agentscope_requirement.specifier)
+          if (
+              agentscope_requirement.extras != {"model-ollama"}
+              or agentscope_requirement.marker is not None
+              or len(agentscope_specifiers) != 1
+              or agentscope_specifiers[0].operator != "=="
+              or Version(agentscope_specifiers[0].version).is_prerelease
+          ):
+              raise SystemExit(f"Expected a stable exact agentscope[model-ollama] pin, found {agentscope_requirement}")
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               print(f"reme_requirement={reme_requirement}", file=output)
-              print(f"agentscope_requirement={agentscope_requirements[0]}", file=output)
+              print(f"agentscope_requirement={agentscope_requirement}", file=output)
           print(f"Publishing {project['name']} {actual}")
           PY
 

--- a/.github/workflows/release-auto-fin.yml
+++ b/.github/workflows/release-auto-fin.yml
@@ -77,8 +77,15 @@ jobs:
               raise SystemExit(f"Expected a base reme-ai dependency, found {requirements[0]!r}")
           if Version("0.4.1.8") in reme_requirement.specifier or Version("0.4.1.9") not in reme_requirement.specifier:
               raise SystemExit(f"Expected reme-ai>=0.4.1.9, found {requirements[0]!r}")
+          root_project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+          agentscope_requirements = [
+              Requirement(value) for value in root_project["optional-dependencies"]["as"]
+          ]
+          if len(agentscope_requirements) != 1 or agentscope_requirements[0].name != "agentscope":
+              raise SystemExit(f"Expected one agentscope dependency, found {agentscope_requirements!r}")
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               print(f"reme_requirement={reme_requirement}", file=output)
+              print(f"agentscope_requirement={agentscope_requirements[0]}", file=output)
           print(f"Publishing {project['name']} {actual}")
           PY
 
@@ -100,6 +107,8 @@ jobs:
           python -m twine check dist/auto-fin/*
 
       - name: Verify distributions and isolated installation
+        env:
+          AGENTSCOPE_REQUIREMENT: ${{ steps.package.outputs.agentscope_requirement }}
         run: |
           AUTO_FIN_WHEEL="$(pwd)/$(ls dist/auto-fin/reme_auto_fin-*.whl)"
           AUTO_FIN_SDIST="$(pwd)/$(ls dist/auto-fin/reme_auto_fin-*.tar.gz)"
@@ -107,7 +116,7 @@ jobs:
           python -m tarfile -l "${AUTO_FIN_SDIST}" | grep '/LICENSE'
           python -m venv "${RUNNER_TEMP}/reme-auto-fin-smoke"
           "${RUNNER_TEMP}/reme-auto-fin-smoke/bin/python" -m pip install \
-            "agentscope[model-ollama]==2.0.7" "${AUTO_FIN_WHEEL}"
+            "${AGENTSCOPE_REQUIREMENT}" "${AUTO_FIN_WHEEL}"
           cd "${RUNNER_TEMP}"
           "${RUNNER_TEMP}/reme-auto-fin-smoke/bin/python" - <<'PY'
           from importlib.metadata import distribution

--- a/.github/workflows/release-daily-paper.yml
+++ b/.github/workflows/release-daily-paper.yml
@@ -82,9 +82,19 @@ jobs:
           ]
           if len(agentscope_requirements) != 1 or agentscope_requirements[0].name != "agentscope":
               raise SystemExit(f"Expected one agentscope dependency, found {agentscope_requirements!r}")
+          agentscope_requirement = agentscope_requirements[0]
+          agentscope_specifiers = list(agentscope_requirement.specifier)
+          if (
+              agentscope_requirement.extras != {"model-ollama"}
+              or agentscope_requirement.marker is not None
+              or len(agentscope_specifiers) != 1
+              or agentscope_specifiers[0].operator != "=="
+              or Version(agentscope_specifiers[0].version).is_prerelease
+          ):
+              raise SystemExit(f"Expected a stable exact agentscope[model-ollama] pin, found {agentscope_requirement}")
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               print(f"reme_requirement={reme_requirements[0]}", file=output)
-              print(f"agentscope_requirement={agentscope_requirements[0]}", file=output)
+              print(f"agentscope_requirement={agentscope_requirement}", file=output)
           print(f"Publishing {project['name']} {actual}")
           PY
 

--- a/.github/workflows/release-daily-paper.yml
+++ b/.github/workflows/release-daily-paper.yml
@@ -76,8 +76,15 @@ jobs:
               raise SystemExit(f"Expected reme-ai>=0.4.1.9, found {reme_requirements!r}")
           if sum(requirement.name == "pypdf" for requirement in requirements) != 1:
               raise SystemExit("Expected exactly one pypdf dependency")
+          root_project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+          agentscope_requirements = [
+              Requirement(value) for value in root_project["optional-dependencies"]["as"]
+          ]
+          if len(agentscope_requirements) != 1 or agentscope_requirements[0].name != "agentscope":
+              raise SystemExit(f"Expected one agentscope dependency, found {agentscope_requirements!r}")
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               print(f"reme_requirement={reme_requirements[0]}", file=output)
+              print(f"agentscope_requirement={agentscope_requirements[0]}", file=output)
           print(f"Publishing {project['name']} {actual}")
           PY
 
@@ -99,6 +106,8 @@ jobs:
           python -m twine check dist/daily-paper/*
 
       - name: Verify distributions and isolated installation
+        env:
+          AGENTSCOPE_REQUIREMENT: ${{ steps.package.outputs.agentscope_requirement }}
         run: |
           DAILY_PAPER_WHEEL="$(pwd)/$(ls dist/daily-paper/reme_daily_paper-*.whl)"
           DAILY_PAPER_SDIST="$(pwd)/$(ls dist/daily-paper/reme_daily_paper-*.tar.gz)"
@@ -108,7 +117,7 @@ jobs:
           python -m tarfile -l "${DAILY_PAPER_SDIST}" | grep '/LICENSE'
           python -m venv "${RUNNER_TEMP}/reme-daily-paper-smoke"
           "${RUNNER_TEMP}/reme-daily-paper-smoke/bin/python" -m pip install \
-            "agentscope[model-ollama]==2.0.7" "${DAILY_PAPER_WHEEL}"
+            "${AGENTSCOPE_REQUIREMENT}" "${DAILY_PAPER_WHEEL}"
           cd "${RUNNER_TEMP}"
           "${RUNNER_TEMP}/reme-daily-paper-smoke/bin/python" - <<'PY'
           from importlib.metadata import distribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
 [project.optional-dependencies]
 as = [
-    "agentscope[model-ollama]==2.0.7",
+    "agentscope[model-ollama]==2.0.7.post1",
 ]
 web = [
     "reme_studio",

--- a/tests/unit/test_package_versions.py
+++ b/tests/unit/test_package_versions.py
@@ -42,7 +42,15 @@ def test_studio_packages_have_independent_identity() -> None:
     assert studio_config["project"]["name"] == "reme_studio"
     assert npm_config["name"] == "@agentscope-ai/reme_studio"
     assert studio_config["project"]["version"] == npm_config["version"]
-    assert main_config["project"]["optional-dependencies"]["as"] == ["agentscope[model-ollama]==2.0.7"]
+    agentscope_requirements = [Requirement(value) for value in main_config["project"]["optional-dependencies"]["as"]]
+    assert len(agentscope_requirements) == 1
+    agentscope_requirement = agentscope_requirements[0]
+    assert agentscope_requirement.name == "agentscope"
+    assert agentscope_requirement.extras == {"model-ollama"}
+    agentscope_specifiers = list(agentscope_requirement.specifier)
+    assert len(agentscope_specifiers) == 1
+    assert agentscope_specifiers[0].operator == "=="
+    assert not Version(agentscope_specifiers[0].version).is_prerelease
     assert main_config["project"]["optional-dependencies"]["web"] == ["reme_studio"]
     assert main_config["project"]["optional-dependencies"]["core"].count("reme-ai[as]") == 1
     assert main_config["project"]["optional-dependencies"]["core"].count("reme_studio") == 1

--- a/tests/unit/test_package_versions.py
+++ b/tests/unit/test_package_versions.py
@@ -47,6 +47,7 @@ def test_studio_packages_have_independent_identity() -> None:
     agentscope_requirement = agentscope_requirements[0]
     assert agentscope_requirement.name == "agentscope"
     assert agentscope_requirement.extras == {"model-ollama"}
+    assert agentscope_requirement.marker is None
     agentscope_specifiers = list(agentscope_requirement.specifier)
     assert len(agentscope_specifiers) == 1
     assert agentscope_specifiers[0].operator == "=="


### PR DESCRIPTION
## Summary

- check PyPI daily at 09:30 Asia/Shanghai for stable AgentScope releases through Dependabot
- open version-update PRs only for the pinned `agentscope[model-ollama]` dependency
- update the root pin to the current stable `2.0.7.post1` release
- keep plugin release smoke tests aligned by reading the root dependency dynamically
- validate the stable exact-pin contract, including the required extra and absence of environment markers

## Related issue

N/A

## Contract and data impact

- [x] No public configuration, schema, CLI, endpoint, streaming, or workspace-layout contract changes
- [x] No user-owned memory files are deleted or rewritten
- [x] Derived indexes, catalogs, graphs, caches, and metadata remain rebuildable

## Validation

- [x] `pytest tests/unit/test_package_versions.py -v` (14 passed)
- [x] `pre-commit run --files pyproject.toml tests/unit/test_package_versions.py .github/workflows/release-auto-fin.yml .github/workflows/release-daily-paper.yml`
- [x] Updated YAML and TOML files parsed successfully through pre-commit
- [ ] Full unit suite not run; changes are limited to dependency automation, release workflow wiring, and the focused package metadata test

## Checklist

- [x] I reviewed the diff for unrelated changes and sensitive data
- [x] Tests cover intentional behavior changes
- [x] Defaults, schemas, and concise documentation were updated together when required
- [x] Long-lived clients, tasks, services, and executors follow the application lifecycle