### PR TITLE
ci: publish reme-ai from GitHub releases

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,7 +1,8 @@
 name: Release / Python packages
 
+# GitHub Releases in this repository publish only the reme-ai Python package.
 # Configure a PyPI Trusted Publisher for this repository, workflow, and its
-# pypi environment before running the manual release.
+# pypi environment before running an automatic or manual release.
 
 on:
   workflow_dispatch:
@@ -10,6 +11,8 @@ on:
         description: Release version
         required: true
         type: string
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -23,7 +26,7 @@ jobs:
     name: Build and verify distributions
     uses: ./.github/workflows/_build-python-packages.yml
     with:
-      expected_version: ${{ inputs.version }}
+      expected_version: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
       upload_artifacts: true
 
   publish-reme:


### PR DESCRIPTION
## Summary

- trigger the Python release workflow when a GitHub Release is published
- treat GitHub Releases in this repository as `reme-ai` releases only
- validate the Release tag against `reme.__version__` before publishing
- retain the manual workflow dispatch, PyPI Trusted Publishing environment, and serialized publication

## Behavior

A Release such as `v0.4.1.10` now builds and publishes only the `reme-ai` distributions. The already-published `v0.4.1.9` Release event will not be replayed and still requires a one-time manual workflow run.

## Validation

- `pre-commit run --files .github/workflows/release-python.yml`
- `PYTHONPATH=. pytest tests/unit/test_package_versions.py -q` — 14 passed
- `python scripts/bump_version.py --check --expected-version v0.4.1.9`
- `git diff --check`

`actionlint` was not available locally.