### PR TITLE
fix: skip dependency bindings in status memory walk

### DIFF
--- a/reme/__init__.py
+++ b/reme/__init__.py
@@ -1,6 +1,6 @@
 """ReMe CLI package."""
 
-__version__ = "0.4.1.10"
+__version__ = "0.4.1.11"
 
 from . import config
 from . import constants

--- a/reme/steps/common/status.py
+++ b/reme/steps/common/status.py
@@ -9,6 +9,7 @@ import psutil
 
 from ..base_step import BaseStep
 from ...components import BaseComponent, R
+from ...components.base_component import Dependency
 from ...enumeration import ComponentEnum
 
 _SKIPPED_COMPONENT_ATTRIBUTES = {"app_context", "logger"}
@@ -47,6 +48,8 @@ def _component_size(obj: object) -> int:
         seen.add(value_id)
 
         if isinstance(value, BaseComponent) and value_id != root_id:
+            return 0
+        if isinstance(value, Dependency):
             return 0
         if isinstance(value, (type, ModuleType)):
             return 0

--- a/tests/unit/test_status_step.py
+++ b/tests/unit/test_status_step.py
@@ -3,7 +3,7 @@
 import asyncio
 
 from reme.components.application_context import ApplicationContext
-from reme.components.base_component import BaseComponent
+from reme.components.base_component import BaseComponent, Dependency
 from reme.enumeration import ComponentEnum
 from reme.steps.common.status import (
     StatusStep,
@@ -33,6 +33,18 @@ def test_component_size_does_not_charge_referenced_components_twice():
     dependency_size = _component_size(dependency)
 
     assert dependency_size > owner_size
+
+
+def test_component_size_ignores_preserved_dependency_bindings():
+    """Resolved components retain dependency specs for live replacement."""
+    component = _SizedComponent(b"payload")
+    component._binding_specs["as_embedding"] = Dependency(  # pylint: disable=protected-access
+        ComponentEnum.AS_EMBEDDING,
+        "default",
+    )
+    component._is_started = True  # pylint: disable=protected-access
+
+    assert _component_size(component) > 0
 
 
 def test_collect_memory_reports_only_stateful_data_components_and_sum(tmp_path):


### PR DESCRIPTION
## Summary

The status memory walker traversed preserved component `_binding_specs` and called `hasattr(..., "__dict__")` on unresolved `Dependency` objects. `Dependency.__getattr__` intentionally raises before resolution, so the status job could fail even after the owning component had started.

This change treats dependency placeholders as external references during memory estimation, adds a regression test for the post-start preserved binding state, and bumps ReMe to `0.4.1.11`.

## Related issue

No linked issue.

## Contract and data impact

- [x] No public configuration, schema, CLI, endpoint, streaming, or workspace-layout contract changes
- [x] No user-owned memory files are deleted or rewritten
- [x] Derived indexes, catalogs, graphs, caches, and metadata remain rebuildable

## Validation

- [x] Focused tests pass
- [x] Unit tests pass, or omitted tests are explained below
- [x] `pre-commit run --all-files` passes, or omitted checks are explained below
- [x] Frontend checks were run when `reme_studio/` changed

Validation performed:

- `python -m pytest tests/unit/test_status_step.py -v`: 4 passed
- `python -m pytest tests/unit -q`: 1109 passed, 31 skipped
- `python -m pytest tests/unit/test_package_versions.py -q`: 14 passed after the version bump
- `pre-commit run --files reme/__init__.py reme/steps/common/status.py tests/unit/test_status_step.py`: all hooks passed
- `git diff --check`: passed

`pre-commit run --all-files` was not run because only three Python files changed; all configured hooks were run against every changed file. Frontend checks were not applicable because `reme_studio/` did not change.

## Checklist

- [x] I reviewed the diff for unrelated changes and sensitive data
- [x] Tests cover intentional behavior changes
- [x] Defaults, schemas, and concise documentation were updated together when required
- [x] Long-lived clients, tasks, services, and executors follow the application lifecycle

## Screenshots or additional notes

No UI changes.
