### PR TITLE
fix: let ClawHub infer trusted publisher owner

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -166,7 +166,6 @@ jobs:
       id-token: write
     uses: openclaw/clawhub/.github/workflows/package-publish.yml@87ca030c30f3cfb78ab15c8e66b5ff1469c8f9c8 # v0.23.3
     with:
-      owner: agentscope-ai
       family: code-plugin
       version: ${{ needs.build.outputs.version }}
       tags: ${{ inputs.npm_tag }}


### PR DESCRIPTION
## Summary

- remove the explicit ClawHub package owner override
- let OIDC trusted publishing infer the owner from the registered package
- fix the release failure: `Trusted publishes must not override the package owner`

## Validation

- `git diff --check`
- `npx prettier --check ../.github/workflows/release-typescript.yml`

The full test suite was not rerun because this change only removes one reusable-workflow input.