### PR TITLE
fix: pin ClawHub source ref to publish SHA

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -171,7 +171,7 @@ jobs:
       tags: ${{ inputs.npm_tag }}
       source_repo: ${{ github.repository }}
       source_commit: ${{ github.sha }}
-      source_ref: ${{ github.ref }}
+      source_ref: ${{ github.sha }}
       source_path: typescript
       package_artifact_name: agentscope-ai-reme-clawhub-${{ inputs.version }}
       dry_run: false


### PR DESCRIPTION
## Summary

- pass the exact GitHub commit SHA as the ClawHub source ref
- satisfy trusted publishing source verification, which requires both source commit and source ref to match the authorized candidate SHA
- fix the release failure: `Trusted publish source ref must match the authorized candidate SHA`

## Validation

- `git diff --check`
- `npx prettier --check ../.github/workflows/release-typescript.yml`

The full test suite was not rerun because this is a one-line workflow metadata change.