### PR TITLE
fix(plugin): Make plugin job and component config overrides atomic

### DIFF
--- a/benchmark/beam/run.py
+++ b/benchmark/beam/run.py
@@ -158,13 +158,13 @@ def create_reme_app(config: str = "benchmark", **overrides):
     plugin source changes visible to every multiprocessing worker.
     """
     from reme import Application
-    from reme.config import resolve_app_config
+    from reme.config import resolve_app_config_layers
 
     enabled_plugins = list(overrides.pop("plugins", ()) or ())
     if "beam" not in enabled_plugins:
         enabled_plugins.append("beam")
-    app_config = resolve_app_config(config=config, plugins=enabled_plugins, **overrides)
-    return Application(**app_config)
+    app_config = resolve_app_config_layers(config=config, plugins=enabled_plugins, **overrides)
+    return Application(resolved_config=app_config)
 
 
 # ---------------------------------------------------------------------------

--- a/benchmark/longmemeval/run.py
+++ b/benchmark/longmemeval/run.py
@@ -157,13 +157,13 @@ def create_reme_app(config: str = "benchmark", **overrides):
     plugin source changes visible to every multiprocessing worker.
     """
     from reme import Application
-    from reme.config import resolve_app_config
+    from reme.config import resolve_app_config_layers
 
     enabled_plugins = list(overrides.pop("plugins", ()) or ())
     if "lme" not in enabled_plugins:
         enabled_plugins.append("lme")
-    app_config = resolve_app_config(config=config, plugins=enabled_plugins, **overrides)
-    return Application(**app_config)
+    app_config = resolve_app_config_layers(config=config, plugins=enabled_plugins, **overrides)
+    return Application(resolved_config=app_config)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/en/framework.md
+++ b/docs/en/framework.md
@@ -234,8 +234,9 @@ bootstrap, and each `Application` receives a mutable copy. Runtime code resolves
 registry rather than changing the process-wide template. ReMe then loads only the installed plugins explicitly named by
 `plugins` in the resolved configuration. A plugin exposes its package through the `reme.plugins` Python entry-point
 group. The package's `plugin.yaml` has two optional mappings: `backends` maps registration names to
-`module:Class` targets, and `application_defaults` contributes a low-priority `ApplicationConfig` fragment. The
-entry-point name is the plugin's identity.
+`module:Class` targets, and `application_defaults` contributes an `ApplicationConfig` fragment. Ordinary fields are
+low-priority defaults. Named Jobs and Components are complete atomic definitions applied after the loaded config and
+in plugin enablement order; explicit CLI field overrides are applied last. The entry-point name is the plugin's identity.
 Plugins are enabled explicitly through the application config's `plugins` list or a `plugins=[...]` CLI override.
 Plugin registration therefore stays local to one application;
 duplicate `(component_type, backend)` providers fail during assembly instead of overwriting each other.

--- a/docs/en/plugin_management.md
+++ b/docs/en/plugin_management.md
@@ -52,8 +52,10 @@ application_defaults:
         - backend: example_step
 ```
 
-`application_defaults` is a partial `ApplicationConfig`. It is kept below the manifest's `backends` namespace because
-backend import declarations are part of plugin discovery and are not application configuration.
+`application_defaults` is a partial `ApplicationConfig`. Each named Job or Component included in it must nevertheless
+be a complete definition: matching names are atomic resources, not recursively merged fragments. It is kept below the
+manifest's `backends` namespace because backend import declarations are part of plugin discovery and are not
+application configuration.
 
 Use JSON when another local tool needs structured output:
 
@@ -155,9 +157,10 @@ Or add them for one service launch:
 reme start plugins='["auto-fin"]'
 ```
 
-When `config` is omitted, ReMe loads `default.yaml`. The plugin's `application_defaults` are merged below that config,
-so explicit config values and CLI overrides win. This mapping is an `ApplicationConfig` fragment, not a separate
-configuration schema. The plugin backends are registered only in that Application's local registry.
+When `config` is omitted, ReMe loads `default.yaml`. Ordinary plugin defaults remain below application values. Named
+Jobs and Components are atomic: the loaded config is applied first, then plugins in enablement order, so a later plugin
+replaces the complete same-name definition. Explicit CLI dot-notation overrides are applied last as field updates to
+the winning definition. The plugin backends are registered only in that Application's local registry.
 
 After the default HTTP service starts, access plugin Jobs through ReMe's CLI client or HTTP:
 

--- a/docs/en/plugin_management.md
+++ b/docs/en/plugin_management.md
@@ -160,7 +160,8 @@ reme start plugins='["auto-fin"]'
 When `config` is omitted, ReMe loads `default.yaml`. Ordinary plugin defaults remain below application values. Named
 Jobs and Components are atomic: the loaded config is applied first, then plugins in enablement order, so a later plugin
 replaces the complete same-name definition. Explicit CLI dot-notation overrides are applied last as field updates to
-the winning definition. The plugin backends are registered only in that Application's local registry.
+the winning definition. Keyword arguments passed directly to `ReMe(...)` use the same explicit-override layer. The
+plugin backends are registered only in that Application's local registry.
 
 After the default HTTP service starts, access plugin Jobs through ReMe's CLI client or HTTP:
 

--- a/docs/zh/framework.md
+++ b/docs/zh/framework.md
@@ -223,7 +223,8 @@ class VersionStep(BaseStep):
 内置实现通过 package import 填充内置注册表；bootstrap 完成后 ReMe 会冻结这个模板，并为每个 `Application` 创建可写副本。
 运行期代码通过当前 Application 的注册表解析 backend，不能修改进程级模板。随后只加载最终配置中 `plugins` 明确启用的已安装插件。
 插件通过 Python `reme.plugins` entry-point group 暴露其 package。package 内的 `plugin.yaml` 只有两个可选 mapping：
-`backends` 将注册名映射到 `module:Class`，`application_defaults` 提供低优先级的 `ApplicationConfig` 配置片段。
+`backends` 将注册名映射到 `module:Class`，`application_defaults` 提供 `ApplicationConfig` 配置片段。普通字段是低优先级
+默认值；具名 Job 和 Component 是完整的原子定义，在已加载配置之后按插件启用顺序应用，显式 CLI 字段 override 最后应用。
 entry-point 名称就是插件标识；使用
 应用配置的 `plugins` 列表或 CLI 的 `plugins=[...]` override 显式启用插件。插件注册因此只影响当前 Application；两个插件提供相同
 `(component_type, backend)` 时会在装配阶段失败，

--- a/docs/zh/plugin_management.md
+++ b/docs/zh/plugin_management.md
@@ -152,7 +152,8 @@ reme start plugins='["auto-fin"]'
 
 未传入 `config` 时，ReMe 加载 `default.yaml`。普通插件默认值仍低于应用配置。具名 Job 和 Component 按原子资源处理：
 先应用已加载配置，再按启用顺序应用插件，后面的插件会整体替换同名定义。显式 CLI dot-notation override 最后作为字段
-更新应用到胜出的完整定义。插件 backend 只注册到该 Application 的局部 registry。
+更新应用到胜出的完整定义；直接传给 `ReMe(...)` 的 Python kwargs 也属于这一显式 override 层。插件 backend 只注册到
+该 Application 的局部 registry。
 
 默认 HTTP service 启动后，可以通过 ReMe CLI client 或 HTTP 访问插件 Job：
 

--- a/docs/zh/plugin_management.md
+++ b/docs/zh/plugin_management.md
@@ -49,8 +49,9 @@ application_defaults:
         - backend: example_step
 ```
 
-`application_defaults` 是一段不完整的 `ApplicationConfig`。它与 manifest 的 `backends` 命名空间分开，因为 backend
-导入声明属于插件发现协议，并不是应用配置。
+`application_defaults` 是一段不完整的 `ApplicationConfig`，但其中出现的每个具名 Job 或 Component 都必须提供完整
+定义：同名资源按原子整体替换，不递归拼接。它与 manifest 的 `backends` 命名空间分开，因为 backend 导入声明属于插件
+发现协议，并不是应用配置。
 
 本地工具需要结构化结果时可以使用 JSON：
 
@@ -149,9 +150,9 @@ plugins:
 reme start plugins='["auto-fin"]'
 ```
 
-未传入 `config` 时，ReMe 加载 `default.yaml`。插件的 `application_defaults` 合并在该配置之下，因此显式配置和 CLI
-override 优先。这个 mapping 是 `ApplicationConfig` 配置片段，并不是另一套配置 schema。插件 backend 只注册到该
-Application 的局部 registry。
+未传入 `config` 时，ReMe 加载 `default.yaml`。普通插件默认值仍低于应用配置。具名 Job 和 Component 按原子资源处理：
+先应用已加载配置，再按启用顺序应用插件，后面的插件会整体替换同名定义。显式 CLI dot-notation override 最后作为字段
+更新应用到胜出的完整定义。插件 backend 只注册到该 Application 的局部 registry。
 
 默认 HTTP service 启动后，可以通过 ReMe CLI client 或 HTTP 访问插件 Job：
 

--- a/plugins/beam/README.md
+++ b/plugins/beam/README.md
@@ -26,8 +26,8 @@ each Application. Installing the plugin makes it discoverable but does not enabl
 `default`: only declared Jobs run, indexing is manual, and neither scheduled dream
 nor the optional `auto_dream` Job is enabled.
 The existing `auto_memory`, `agentic_answer`, `answer_judge`, `bench` and `judge`
-names and model environment variables are unchanged. Explicit application/CLI overrides
-still take precedence. Installing this plugin does not start an evaluation.
+names and model environment variables are unchanged. Explicit CLI field overrides are
+applied after the plugin's complete named resources. Installing this plugin does not start an evaluation.
 
 The shared answer base class lives in `reme.steps.benchmark.base_agentic_answer`.
 The old core-owned `reme.steps.benchmark.beam` Python import path is removed.

--- a/plugins/beam/README_ZH.md
+++ b/plugins/beam/README_ZH.md
@@ -23,7 +23,7 @@ editable 安装会注册 `beam` entry point，并让源码修改立即生效。r
 `reme start config=benchmark plugins='["beam"]'`。公共评测配置不继承 `default`，只运行声明的 Job：
 索引手动更新，dream 定时任务和可选的 `auto_dream`
 均保持关闭。原有 `auto_memory`、`agentic_answer`、`answer_judge`、`bench`、`judge` 名称及模型环境变量
-保持不变，显式应用参数和 CLI 覆盖仍优先。安装或启用插件不会自动开始评测。
+保持不变；显式 CLI 字段覆盖会在插件的完整具名资源之后应用。安装或启用插件不会自动开始评测。
 
 共享回答基类位于 `reme.steps.benchmark.base_agentic_answer`。
 原 `reme.steps.benchmark.beam` Python 导入路径已移除。自定义 Python 调用应从 `reme_beam`

--- a/plugins/beam/src/reme_beam/plugin.yaml
+++ b/plugins/beam/src/reme_beam/plugin.yaml
@@ -111,10 +111,3 @@ application_defaults:
           # Long sessions are split into turn-aligned segments and fed to the
           # agent incrementally; <= 0 disables splitting.
           max_segment_words: 10000
-
-  components:
-    as_llm:
-      default:
-        max_retries: 5
-      judge:
-        retry_delay: 5.0

--- a/plugins/lme/README.md
+++ b/plugins/lme/README.md
@@ -26,8 +26,8 @@ each Application. Installing the plugin makes it discoverable but does not enabl
 `default`: only declared Jobs run, indexing is manual, and neither scheduled dream
 nor the optional `auto_dream` Job is enabled.
 The existing `auto_memory`, `agentic_answer`, `answer_judge`, `bench` and `judge`
-names and model environment variables are unchanged. Explicit application/CLI overrides
-still take precedence. Installing this plugin does not start an evaluation.
+names and model environment variables are unchanged. Explicit CLI field overrides are
+applied after the plugin's complete named resources. Installing this plugin does not start an evaluation.
 
 The shared answer base class lives in `reme.steps.benchmark.base_agentic_answer`.
 The old core-owned `reme.steps.benchmark.lme` Python import path is removed.

--- a/plugins/lme/README_ZH.md
+++ b/plugins/lme/README_ZH.md
@@ -23,7 +23,7 @@ editable 安装会注册 `lme` entry point，并让源码修改立即生效。ru
 `reme start config=benchmark plugins='["lme"]'`。公共评测配置不继承 `default`，只运行声明的 Job：
 索引手动更新，dream 定时任务和可选的 `auto_dream`
 均保持关闭。原有 `auto_memory`、`agentic_answer`、`answer_judge`、`bench`、`judge` 名称及模型环境变量
-保持不变，显式应用参数和 CLI 覆盖仍优先。安装或启用插件不会自动开始评测。
+保持不变；显式 CLI 字段覆盖会在插件的完整具名资源之后应用。安装或启用插件不会自动开始评测。
 
 共享回答基类位于 `reme.steps.benchmark.base_agentic_answer`。
 原 `reme.steps.benchmark.lme` Python 导入路径已移除。自定义 Python 调用应从 `reme_lme`

--- a/plugins/lme/src/reme_lme/plugin.yaml
+++ b/plugins/lme/src/reme_lme/plugin.yaml
@@ -106,8 +106,3 @@ application_defaults:
           - messages
       steps:
         - backend: lme_auto_memory_step
-
-  components:
-    as_llm:
-      default:
-        max_retries: 3

--- a/reme/application.py
+++ b/reme/application.py
@@ -11,6 +11,7 @@ from . import __version__
 from .components import ApplicationContext, BaseComponent
 from .components.job import BackgroundJob, BaseJob, CronJob, StreamJob
 from .components.service import BaseService
+from .config import ResolvedAppConfig
 from .enumeration import ComponentEnum, ComponentType, component_type_name
 from .plugin import resolve_plugin_runtime
 from .schema import ComponentConfig, Response, StreamChunk
@@ -23,8 +24,10 @@ _NodeKey = tuple[str, str]
 class Application(BaseComponent):
     """Wires components from config and runs jobs against them."""
 
-    def __init__(self, **kwargs) -> None:
-        runtime = resolve_plugin_runtime(kwargs)
+    def __init__(self, *, resolved_config: ResolvedAppConfig | None = None, **kwargs) -> None:
+        if resolved_config is not None and kwargs:
+            resolved_config = resolved_config.with_overrides(kwargs)
+        runtime = resolve_plugin_runtime(resolved_config or ResolvedAppConfig(overrides=kwargs))
         self.context = ApplicationContext(registry=runtime.registry, **runtime.config)
         self._started_components: list[BaseComponent] = []
         self._component_mutation_lock = asyncio.Lock()

--- a/reme/application.py
+++ b/reme/application.py
@@ -36,6 +36,8 @@ class Application(BaseComponent):
             force_init=True,
         )
         super().__init__()
+        for warning in runtime.config_warnings:
+            logger.warning(warning)
         self._init_service()
 
         if self.config.enable_logo:

--- a/reme/components/agent_wrapper/codex_mcp_server.py
+++ b/reme/components/agent_wrapper/codex_mcp_server.py
@@ -2,10 +2,11 @@
 
 import argparse
 import json
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from ...config import ResolvedConfigSection, resolve_app_config
+from ...config import ResolvedAppConfig, deep_merge_config, resolve_app_config_layers
 from ...reme import ReMe
 
 
@@ -24,24 +25,24 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _prepare_config(
-    config: dict[str, Any],
+    config: ResolvedAppConfig | Mapping[str, Any],
     job_names: list[str],
     tool_context_id: str = "",
     injected_job_kwargs: dict[str, Any] | None = None,
-) -> dict[str, Any]:
+) -> ResolvedAppConfig | dict[str, Any]:
     """Configure the dedicated child Application to serve selected jobs over MCP STDIO."""
+    return_layers = isinstance(config, ResolvedAppConfig)
+    resolved = config if return_layers else ResolvedAppConfig(overrides=config)
+    visible = resolved.materialize()
     selected = set(job_names)
-    jobs: dict[str, dict[str, Any]] = {}
-    for name, raw_job_config in (config.get("jobs") or {}).items():
+    allowed_jobs: set[str] = set()
+    for name, raw_job_config in (visible.get("jobs") or {}).items():
         job_config = dict(raw_job_config)
         if job_config.get("backend") in {"background", "cron"}:
             continue
-        if name in selected:
-            # An explicit Codex job_tools selection has always overridden enable_serve.
-            job_config["enable_serve"] = True
-        jobs[name] = job_config
+        allowed_jobs.add(name)
 
-    missing = sorted(selected.difference(jobs))
+    missing = sorted(selected.difference(allowed_jobs))
     if missing:
         raise KeyError(f"Codex job tools not found or not request jobs: {', '.join(missing)}")
 
@@ -57,23 +58,26 @@ def _prepare_config(
     if injected:
         service["injected_job_kwargs"] = injected
 
-    prepared = dict(config)
-    raw_jobs = config.get("jobs")
-    if isinstance(raw_jobs, ResolvedConfigSection):
-        selected_paths = tuple((name, "enable_serve") for name in job_names)
-        jobs = ResolvedConfigSection(
-            jobs,
-            explicit_paths=tuple(dict.fromkeys((*raw_jobs.explicit_paths, *selected_paths))),
-        )
-    prepared["jobs"] = jobs
-    prepared["service"] = service
-    return prepared
+    base = dict(resolved.base)
+    if isinstance(base.get("jobs"), Mapping):
+        base["jobs"] = {name: value for name, value in base["jobs"].items() if name in allowed_jobs}
+
+    overrides = dict(resolved.overrides)
+    if isinstance(overrides.get("jobs"), Mapping):
+        overrides["jobs"] = {name: value for name, value in overrides["jobs"].items() if name in allowed_jobs}
+
+    # Job selection is an explicit server-owned patch. It must win after a
+    # plugin atomically replaces a loaded Job with the same name.
+    selected_patch = {name: {"enable_serve": True} for name in job_names}
+    overrides = deep_merge_config(overrides, {"jobs": selected_patch, "service": service})
+    prepared = ResolvedAppConfig(base=base, overrides=overrides)
+    return prepared if return_layers else prepared.materialize()
 
 
 def main() -> None:
     """Load ReMe and serve the requested jobs over STDIO."""
     args = _parse_args()
-    config = resolve_app_config(
+    config = resolve_app_config_layers(
         config=args.config,
         workspace_dir=str(Path(args.workspace).absolute()),
         enable_logo=False,
@@ -85,7 +89,7 @@ def main() -> None:
     if injected_job_kwargs is not None and not isinstance(injected_job_kwargs, dict):
         raise TypeError("--injected-job-kwargs must be a JSON object")
     config = _prepare_config(config, args.jobs, args.tool_context_id, injected_job_kwargs)
-    ReMe(**config).run_app()
+    ReMe(resolved_config=config).run_app()
 
 
 if __name__ == "__main__":

--- a/reme/components/agent_wrapper/codex_mcp_server.py
+++ b/reme/components/agent_wrapper/codex_mcp_server.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from ...config import resolve_app_config
+from ...config import ResolvedConfigSection, resolve_app_config
 from ...reme import ReMe
 
 
@@ -58,6 +58,13 @@ def _prepare_config(
         service["injected_job_kwargs"] = injected
 
     prepared = dict(config)
+    raw_jobs = config.get("jobs")
+    if isinstance(raw_jobs, ResolvedConfigSection):
+        selected_paths = tuple((name, "enable_serve") for name in job_names)
+        jobs = ResolvedConfigSection(
+            jobs,
+            explicit_paths=tuple(dict.fromkeys((*raw_jobs.explicit_paths, *selected_paths))),
+        )
     prepared["jobs"] = jobs
     prepared["service"] = service
     return prepared

--- a/reme/components/service/cli_service.py
+++ b/reme/components/service/cli_service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from .base_service import BaseService
 from ..component_registry import R
 from ..job import BaseJob
-from ...config import resolve_app_config
+from ...config import ResolvedAppConfig, resolve_app_config_layers
 from ...schema import ApplicationConfig
 from ...utils import get_logger
 
@@ -18,20 +18,22 @@ if TYPE_CHECKING:
 _APP_CONFIG_KEYS = set(ApplicationConfig.model_fields)
 
 
-def prepare_start_config(kwargs: dict) -> dict:
+def prepare_start_config(kwargs: dict) -> ResolvedAppConfig:
     """Resolve ``reme start`` kwargs, translating top-level ``job=...`` into internal cli service config."""
     if "job" not in kwargs:
-        return resolve_app_config(**kwargs)
+        return resolve_app_config_layers(**kwargs)
     return _prepare_job_start_config(dict(kwargs))
 
 
-def should_precheck_start(config: dict) -> bool:
+def should_precheck_start(config: ResolvedAppConfig | dict) -> bool:
     """CLI service does not bind a port, so it should skip service port prechecks."""
+    if isinstance(config, ResolvedAppConfig):
+        config = config.materialize()
     service = config.get("service")
     return not (isinstance(service, dict) and service.get("backend") == "cli")
 
 
-def _prepare_job_start_config(kwargs: dict) -> dict:
+def _prepare_job_start_config(kwargs: dict) -> ResolvedAppConfig:
     """Translate ``reme start job=...`` args into the internal cli service fields."""
     job = kwargs.pop("job")
     config_kwargs: dict = {}
@@ -48,15 +50,17 @@ def _prepare_job_start_config(kwargs: dict) -> dict:
     if "log_to_console" not in config_kwargs:
         get_logger(log_to_console=False, log_to_file=False, force_init=True)
 
-    config = resolve_app_config(**config_kwargs)
+    config = resolve_app_config_layers(**config_kwargs)
+    visible = config.materialize()
+    patch: dict[str, Any] = {}
     if "enable_logo" not in config_kwargs:
-        config["enable_logo"] = False
+        patch["enable_logo"] = False
     if "log_to_console" not in config_kwargs:
-        config["log_to_console"] = False
-    service = dict(config.get("service") or {})
+        patch["log_to_console"] = False
+    service = dict(visible.get("service") or {})
     service.update({"backend": "cli", "job": job, "job_args": job_args})
-    config["service"] = service
-    return config
+    patch["service"] = service
+    return config.with_overrides(patch)
 
 
 @R.register("cli")

--- a/reme/config/__init__.py
+++ b/reme/config/__init__.py
@@ -6,6 +6,7 @@ from .config_parser import (
     parse_action,
     parse_args,
     parse_kwargs,
+    ResolvedConfigSection,
     resolve_app_config,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "parse_action",
     "parse_args",
     "parse_kwargs",
+    "ResolvedConfigSection",
     "resolve_app_config",
 ]

--- a/reme/config/__init__.py
+++ b/reme/config/__init__.py
@@ -6,8 +6,9 @@ from .config_parser import (
     parse_action,
     parse_args,
     parse_kwargs,
-    ResolvedConfigSection,
+    ResolvedAppConfig,
     resolve_app_config,
+    resolve_app_config_layers,
 )
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "parse_action",
     "parse_args",
     "parse_kwargs",
-    "ResolvedConfigSection",
+    "ResolvedAppConfig",
     "resolve_app_config",
+    "resolve_app_config_layers",
 ]

--- a/reme/config/benchmark.yaml
+++ b/reme/config/benchmark.yaml
@@ -396,6 +396,7 @@ components:
       model: ${LLM_MODEL_NAME:-qwen3.6-flash}
       stream: true
       context_size: 200000
+      max_retries: 5
       retry_delay: 5.0
       credential:
         api_key: ${LLM_API_KEY:-}
@@ -409,6 +410,7 @@ components:
       stream: false
       context_size: 200000
       max_retries: 5
+      retry_delay: 5.0
       credential:
         api_key: ${LLM_API_KEY:-}
         base_url: ${LLM_BASE_URL:-}

--- a/reme/config/config_parser.py
+++ b/reme/config/config_parser.py
@@ -26,6 +26,32 @@ _ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?}")
 _LEADING_ZERO_RE = re.compile(r"^-?0\d")
 
 
+class ResolvedConfigSection(dict[str, Any]):
+    """A resolved mapping that retains its loaded base and explicit override.
+
+    ``resolve_app_config`` still returns an ordinary dict-compatible value, but
+    named resources need the two inputs separately so plugins can replace a
+    complete base definition before CLI dot-notation overrides are applied.
+    Keeping the provenance on the nested section also survives the established
+    ``Application(**resolved_config)`` calling convention.
+    """
+
+    def __init__(
+        self,
+        value: Mapping[str, Any],
+        *,
+        base: Any,
+        base_present: bool,
+        explicit_overrides: Any,
+        explicit_overrides_present: bool,
+    ) -> None:
+        super().__init__(value)
+        self.base = base
+        self.base_present = base_present
+        self.explicit_overrides = explicit_overrides
+        self.explicit_overrides_present = explicit_overrides_present
+
+
 def _repl(m: re.Match) -> str:
     name: str = m.group(1)
     # group(2) is None when the placeholder has no `:-default` part
@@ -272,7 +298,7 @@ def resolve_app_config(*, log_config: bool = True, **kwargs) -> dict:
     from ..utils import get_logger
 
     logger = get_logger(log_to_file=False)
-    configs: list[dict] = []
+    base_config: dict = {}
 
     # `config=path` arrives as a string here; `config.foo=bar` arrives as a
     # nested dict and is left in `kwargs` to be merged as a normal override.
@@ -281,16 +307,32 @@ def resolve_app_config(*, log_config: bool = True, **kwargs) -> dict:
         kwargs.pop("config")
         if log_config:
             logger.info(f"Loading config: {config_value}")
-        configs.append(_load_config(config_value))
+        base_config = _load_config(config_value)
     elif "default" in _CONFIG_REGISTRY:
         if log_config:
             logger.info("No config specified, loading 'default'")
-        configs.append(_load_config("default"))
+        base_config = _load_config("default")
 
-    configs.append(kwargs)
+    explicit_overrides = kwargs
+    merged = deep_merge_config(base_config, explicit_overrides)
 
-    merged: dict = {}
-    for cfg in configs:
-        merged = deep_merge_config(merged, cfg)
+    # Jobs and named component instances are complete resource definitions
+    # when supplied by config files or plugins. CLI dot-notation values remain
+    # field-level overrides, so retain these two layers until plugin resolution.
+    for section_name in ("jobs", "components"):
+        if section_name not in base_config and section_name not in explicit_overrides:
+            continue
+        section = merged.get(section_name)
+        if not isinstance(section, Mapping):
+            # Preserve invalid input verbatim so the schema or plugin merger can
+            # report it instead of obscuring the source through normalization.
+            continue
+        merged[section_name] = ResolvedConfigSection(
+            section,
+            base=base_config.get(section_name),
+            base_present=section_name in base_config,
+            explicit_overrides=explicit_overrides.get(section_name),
+            explicit_overrides_present=section_name in explicit_overrides,
+        )
 
     return merged

--- a/reme/config/config_parser.py
+++ b/reme/config/config_parser.py
@@ -4,12 +4,12 @@ import json
 import os
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass, field
 from importlib.metadata import EntryPoint
 from pathlib import Path
 from typing import Any
 
 import yaml
-from yaml.representer import SafeRepresenter
 
 from ..entry_point import (
     CONFIG_ENTRY_POINT_GROUP,
@@ -27,44 +27,25 @@ _ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?}")
 _LEADING_ZERO_RE = re.compile(r"^-?0\d")
 
 
-class ResolvedConfigSection(dict[str, Any]):
-    """A resolved mapping that retains which values were explicitly overridden.
+@dataclass(frozen=True)
+class ResolvedAppConfig:
+    """Application config layers retained until plugin resolution.
 
-    ``resolve_app_config`` still returns an ordinary dict-compatible value, but
-    named resources need field-level provenance so plugins can replace a
-    complete definition before CLI dot-notation overrides are applied. Only
-    paths are retained: values are always read from the visible mapping, so
-    normal dict mutations cannot diverge from hidden configuration snapshots.
+    Config files (including ``extends``) form ``base``. Values supplied by the
+    current CLI or Python call form ``overrides`` and are applied only after
+    plugins have selected complete named resources.
     """
 
-    def __init__(
-        self,
-        value: Mapping[str, Any],
-        *,
-        explicit_paths: tuple[tuple[str, ...], ...],
-    ) -> None:
-        super().__init__(value)
-        self.explicit_paths = explicit_paths
+    base: Mapping[str, Any] = field(default_factory=dict)
+    overrides: Mapping[str, Any] = field(default_factory=dict)
 
+    def materialize(self) -> dict[str, Any]:
+        """Return the visible config without discarding the stored layers."""
+        return deep_merge_config(self.base, self.overrides)
 
-# PyYAML dispatches representers by exact type, so teach its safe dumper that
-# this dict-compatible provenance carrier serializes exactly like a plain dict.
-yaml.SafeDumper.add_representer(ResolvedConfigSection, SafeRepresenter.represent_dict)
-
-
-def _mapping_leaf_paths(
-    value: Mapping[str, Any],
-    prefix: tuple[str, ...] = (),
-) -> tuple[tuple[str, ...], ...]:
-    """Return the leaf paths explicitly supplied by one config override."""
-    paths: list[tuple[str, ...]] = []
-    for key, child in value.items():
-        path = (*prefix, key)
-        if isinstance(child, Mapping) and child:
-            paths.extend(_mapping_leaf_paths(child, path))
-        else:
-            paths.append(path)
-    return tuple(paths)
+    def with_overrides(self, update: Mapping[str, Any]) -> "ResolvedAppConfig":
+        """Return new layers with an additional explicit configuration patch."""
+        return ResolvedAppConfig(base=self.base, overrides=deep_merge_config(self.overrides, update))
 
 
 def _repl(m: re.Match) -> str:
@@ -300,9 +281,8 @@ def parse_args(*args: str) -> tuple[str, dict]:
     return parse_action(args[0]), parse_kwargs(*args[1:])
 
 
-def resolve_app_config(*, log_config: bool = True, **kwargs) -> dict:
-    """Resolve full app-start config: load `config=path` file, fall back to
-    `default`, then deep-merge with the remaining kwargs as overrides.
+def resolve_app_config_layers(*, log_config: bool = True, **kwargs) -> ResolvedAppConfig:
+    """Resolve the loaded application config and explicit inputs as two layers.
 
     Therefore ``reme start plugins=[...]`` layers that plugin selection over
     ``default.yaml`` without requiring an explicit ``config=default``.
@@ -328,24 +308,14 @@ def resolve_app_config(*, log_config: bool = True, **kwargs) -> dict:
             logger.info("No config specified, loading 'default'")
         base_config = _load_config("default")
 
-    explicit_overrides = kwargs
-    merged = deep_merge_config(base_config, explicit_overrides)
+    return ResolvedAppConfig(base=base_config, overrides=kwargs)
 
-    # Jobs and named component instances are complete resource definitions
-    # when supplied by config files or plugins. CLI dot-notation values remain
-    # field-level overrides, so retain their paths until plugin resolution.
-    for section_name in ("jobs", "components"):
-        section = merged.get(section_name)
-        section_overrides = explicit_overrides.get(section_name)
-        if not isinstance(section, Mapping) or (
-            section_name in explicit_overrides and not isinstance(section_overrides, Mapping)
-        ):
-            # Preserve invalid input verbatim so the schema or plugin merger can
-            # report it instead of obscuring the source through normalization.
-            continue
-        merged[section_name] = ResolvedConfigSection(
-            section,
-            explicit_paths=_mapping_leaf_paths(section_overrides) if isinstance(section_overrides, Mapping) else (),
-        )
 
-    return merged
+def resolve_app_config(*, log_config: bool = True, **kwargs) -> dict[str, Any]:
+    """Return the visible loaded config as a plain mapping.
+
+    Startup paths that still need to apply plugins use
+    :func:`resolve_app_config_layers` so loaded resources and explicit inputs
+    retain their distinct precedence until plugin resolution.
+    """
+    return resolve_app_config_layers(log_config=log_config, **kwargs).materialize()

--- a/reme/config/config_parser.py
+++ b/reme/config/config_parser.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from yaml.representer import SafeRepresenter
 
 from ..entry_point import (
     CONFIG_ENTRY_POINT_GROUP,
@@ -27,29 +28,43 @@ _LEADING_ZERO_RE = re.compile(r"^-?0\d")
 
 
 class ResolvedConfigSection(dict[str, Any]):
-    """A resolved mapping that retains its loaded base and explicit override.
+    """A resolved mapping that retains which values were explicitly overridden.
 
     ``resolve_app_config`` still returns an ordinary dict-compatible value, but
-    named resources need the two inputs separately so plugins can replace a
-    complete base definition before CLI dot-notation overrides are applied.
-    Keeping the provenance on the nested section also survives the established
-    ``Application(**resolved_config)`` calling convention.
+    named resources need field-level provenance so plugins can replace a
+    complete definition before CLI dot-notation overrides are applied. Only
+    paths are retained: values are always read from the visible mapping, so
+    normal dict mutations cannot diverge from hidden configuration snapshots.
     """
 
     def __init__(
         self,
         value: Mapping[str, Any],
         *,
-        base: Any,
-        base_present: bool,
-        explicit_overrides: Any,
-        explicit_overrides_present: bool,
+        explicit_paths: tuple[tuple[str, ...], ...],
     ) -> None:
         super().__init__(value)
-        self.base = base
-        self.base_present = base_present
-        self.explicit_overrides = explicit_overrides
-        self.explicit_overrides_present = explicit_overrides_present
+        self.explicit_paths = explicit_paths
+
+
+# PyYAML dispatches representers by exact type, so teach its safe dumper that
+# this dict-compatible provenance carrier serializes exactly like a plain dict.
+yaml.SafeDumper.add_representer(ResolvedConfigSection, SafeRepresenter.represent_dict)
+
+
+def _mapping_leaf_paths(
+    value: Mapping[str, Any],
+    prefix: tuple[str, ...] = (),
+) -> tuple[tuple[str, ...], ...]:
+    """Return the leaf paths explicitly supplied by one config override."""
+    paths: list[tuple[str, ...]] = []
+    for key, child in value.items():
+        path = (*prefix, key)
+        if isinstance(child, Mapping) and child:
+            paths.extend(_mapping_leaf_paths(child, path))
+        else:
+            paths.append(path)
+    return tuple(paths)
 
 
 def _repl(m: re.Match) -> str:
@@ -318,21 +333,19 @@ def resolve_app_config(*, log_config: bool = True, **kwargs) -> dict:
 
     # Jobs and named component instances are complete resource definitions
     # when supplied by config files or plugins. CLI dot-notation values remain
-    # field-level overrides, so retain these two layers until plugin resolution.
+    # field-level overrides, so retain their paths until plugin resolution.
     for section_name in ("jobs", "components"):
-        if section_name not in base_config and section_name not in explicit_overrides:
-            continue
         section = merged.get(section_name)
-        if not isinstance(section, Mapping):
+        section_overrides = explicit_overrides.get(section_name)
+        if not isinstance(section, Mapping) or (
+            section_name in explicit_overrides and not isinstance(section_overrides, Mapping)
+        ):
             # Preserve invalid input verbatim so the schema or plugin merger can
             # report it instead of obscuring the source through normalization.
             continue
         merged[section_name] = ResolvedConfigSection(
             section,
-            base=base_config.get(section_name),
-            base_present=section_name in base_config,
-            explicit_overrides=explicit_overrides.get(section_name),
-            explicit_overrides_present=section_name in explicit_overrides,
+            explicit_paths=_mapping_leaf_paths(section_overrides) if isinstance(section_overrides, Mapping) else (),
         )
 
     return merged

--- a/reme/plugin.py
+++ b/reme/plugin.py
@@ -8,6 +8,7 @@ Python ``Plugin`` descriptors remain supported as a compatibility boundary.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from copy import deepcopy
 from dataclasses import dataclass, field
 from importlib import import_module
 from importlib.metadata import EntryPoint
@@ -17,6 +18,7 @@ from .components.base_component import ComponentMixin
 from .components.component_registry import ComponentRegistry, create_application_registry
 from .config import deep_merge_config, expand_env_vars
 from .entry_point import PLUGIN_ENTRY_POINT_GROUP, find_entry_points, load_entry_point, unique_entry_point
+from .enumeration import component_type_name
 from .plugin_manifest import PluginManifest, load_package_manifest
 
 
@@ -43,6 +45,86 @@ class PluginRuntime:
 
     config: dict[str, Any]
     registry: ComponentRegistry
+    config_warnings: tuple[str, ...] = ()
+
+
+_MISSING = object()
+
+
+def _without_named_resources(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return fields that retain the ordinary plugin-default merge behavior."""
+    return {key: value for key, value in config.items() if key not in {"jobs", "components"}}
+
+
+def _overlay_jobs(
+    current: Any,
+    owners: dict[tuple[Any, ...], str],
+    warnings: list[str],
+    layer: Mapping[str, Any],
+    source: str,
+) -> Any:
+    """Atomically overlay jobs from one source, warning on cross-source replacement."""
+    if "jobs" not in layer:
+        return current
+    jobs = layer["jobs"]
+    if not isinstance(jobs, Mapping):
+        owners.clear()
+        return deepcopy(jobs)
+
+    merged = dict(current) if isinstance(current, Mapping) else {}
+    for name, definition in jobs.items():
+        identity = ("jobs", name)
+        previous = owners.get(identity)
+        if previous is not None:
+            warnings.append(
+                f"Config collision at jobs.{name}: {source} replaces the complete definition from {previous}",
+            )
+        merged[name] = deepcopy(definition)
+        owners[identity] = source
+    return merged
+
+
+def _overlay_components(
+    current: Any,
+    owners: dict[tuple[Any, ...], str],
+    warnings: list[str],
+    layer: Mapping[str, Any],
+    source: str,
+) -> Any:
+    """Atomically overlay named component instances from one source."""
+    if "components" not in layer:
+        return current
+    components = layer["components"]
+    if not isinstance(components, Mapping):
+        owners.clear()
+        return deepcopy(components)
+
+    # Match ApplicationConfig normalization before comparing identities. If
+    # one source repeats an equivalent type, its later mapping wins without a
+    # new same-source diagnostic, preserving the existing validator behavior.
+    normalized = {component_type_name(component_type): group for component_type, group in components.items()}
+    merged = dict(current) if isinstance(current, Mapping) else {}
+    for component_type, group in normalized.items():
+        if not isinstance(group, Mapping):
+            merged[component_type] = deepcopy(group)
+            for identity in [identity for identity in owners if identity[1] == component_type]:
+                del owners[identity]
+            continue
+
+        current_group = merged.get(component_type)
+        merged_group = dict(current_group) if isinstance(current_group, Mapping) else {}
+        for name, definition in group.items():
+            identity = ("components", component_type, name)
+            previous = owners.get(identity)
+            if previous is not None:
+                warnings.append(
+                    f"Config collision at components.{component_type}.{name}: "
+                    f"{source} replaces the complete definition from {previous}",
+                )
+            merged_group[name] = deepcopy(definition)
+            owners[identity] = source
+        merged[component_type] = merged_group
+    return merged
 
 
 def _load_backend(target: str, *, plugin_name: str) -> type[ComponentMixin]:
@@ -115,12 +197,48 @@ class PluginManager:
             seen.add(name)
         return cls(plugins)
 
-    def merge_config(self, application_config: Mapping[str, Any]) -> dict[str, Any]:
-        """Place plugin application defaults below the user's resolved config."""
+    def _merge_config(self, application_config: Mapping[str, Any]) -> tuple[dict[str, Any], tuple[str, ...]]:
+        """Merge config and retain startup diagnostics for named resource replacement."""
+        plugin_layers = [expand_env_vars(plugin.config) for plugin in self.plugins]
+
+        # Ordinary fields retain their existing priority: plugin defaults are
+        # merged in enablement order, then application config wins.
         merged: dict[str, Any] = {}
-        for plugin in self.plugins:
-            merged = deep_merge_config(merged, expand_env_vars(plugin.config))
-        return deep_merge_config(merged, application_config)
+        for layer in plugin_layers:
+            merged = deep_merge_config(merged, _without_named_resources(layer))
+        merged = deep_merge_config(merged, _without_named_resources(application_config))
+
+        # Jobs and named component instances use the explicit plugin priority:
+        # application config is lowest and later enabled plugins are highest.
+        jobs: Any = _MISSING
+        components: Any = _MISSING
+        job_owners: dict[tuple[Any, ...], str] = {}
+        component_owners: dict[tuple[Any, ...], str] = {}
+        warnings: list[str] = []
+
+        jobs = _overlay_jobs(jobs, job_owners, warnings, application_config, "application config")
+        components = _overlay_components(
+            components,
+            component_owners,
+            warnings,
+            application_config,
+            "application config",
+        )
+        for plugin, layer in zip(self.plugins, plugin_layers):
+            source = f"plugin '{plugin.name}'"
+            jobs = _overlay_jobs(jobs, job_owners, warnings, layer, source)
+            components = _overlay_components(components, component_owners, warnings, layer, source)
+
+        if jobs is not _MISSING:
+            merged["jobs"] = jobs
+        if components is not _MISSING:
+            merged["components"] = components
+        return merged, tuple(warnings)
+
+    def merge_config(self, application_config: Mapping[str, Any]) -> dict[str, Any]:
+        """Apply plugin config while atomically replacing same-name jobs and components."""
+        merged, _ = self._merge_config(application_config)
+        return merged
 
     def register(self, registry: ComponentRegistry) -> None:
         """Register every backend into an application-local registry."""
@@ -130,8 +248,9 @@ class PluginManager:
 
 
 def resolve_plugin_runtime(application_config: Mapping[str, Any]) -> PluginRuntime:
-    """Build one local registry, with user config overriding plugin application defaults."""
+    """Build one local registry and merge explicitly enabled plugin configuration."""
     manager = PluginManager.discover(application_config.get("plugins") or ())
     registry = create_application_registry()
     manager.register(registry)
-    return PluginRuntime(config=manager.merge_config(application_config), registry=registry)
+    config, config_warnings = manager._merge_config(application_config)  # pylint: disable=protected-access
+    return PluginRuntime(config=config, registry=registry, config_warnings=config_warnings)

--- a/reme/plugin.py
+++ b/reme/plugin.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from .components.base_component import ComponentMixin
 from .components.component_registry import ComponentRegistry, create_application_registry
-from .config import ResolvedConfigSection, deep_merge_config, expand_env_vars
+from .config import ResolvedAppConfig, deep_merge_config, expand_env_vars
 from .entry_point import PLUGIN_ENTRY_POINT_GROUP, find_entry_points, load_entry_point, unique_entry_point
 from .enumeration import component_type_name
 from .plugin_manifest import PluginManifest, load_package_manifest
@@ -57,6 +57,30 @@ def _require_mapping(value: Any, path: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise TypeError(f"{path} must be a mapping")
     return value
+
+
+def _explicit_resource_overrides(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize explicit named-resource field patches."""
+    result: dict[str, Any] = {}
+    if "jobs" in config:
+        jobs = _require_mapping(config["jobs"], "explicit overrides.jobs")
+        for name in jobs:
+            if not isinstance(name, str):
+                raise TypeError(f"jobs names must be strings, got {type(name).__name__}")
+        result["jobs"] = jobs
+
+    if "components" in config:
+        components = _require_mapping(config["components"], "explicit overrides.components")
+        normalized: dict[str, Mapping[str, Any]] = {}
+        for component_type, group in components.items():
+            normalized_type = component_type_name(component_type)
+            instances = _require_mapping(group, f"explicit overrides.components.{component_type}")
+            for name in instances:
+                if not isinstance(name, str):
+                    raise TypeError(f"components names must be strings, got {type(name).__name__}")
+            normalized[normalized_type] = instances
+        result["components"] = normalized
+    return result
 
 
 def _replace_named(
@@ -125,37 +149,6 @@ def _overlay_atomic_resources(
             ("components", component_type),
         )
     return has_jobs, has_components
-
-
-def _split_application_resource_layers(
-    application_config: Mapping[str, Any],
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Separate atomic definitions from explicit field-level overrides."""
-    application_layer: dict[str, Any] = {}
-    explicit_overrides: dict[str, Any] = {}
-    for section_name in ("jobs", "components"):
-        if section_name not in application_config:
-            continue
-        section = application_config[section_name]
-        application_layer[section_name] = section
-        if not isinstance(section, ResolvedConfigSection):
-            continue
-
-        projected: dict[str, Any] = {}
-        for path in section.explicit_paths:
-            current: Any = section
-            for key in path:
-                if not isinstance(current, Mapping) or key not in current:
-                    break
-                current = current[key]
-            else:
-                target = projected
-                for key in path[:-1]:
-                    target = target.setdefault(key, {})
-                target[path[-1]] = current
-        if projected:
-            explicit_overrides[section_name] = projected
-    return application_layer, explicit_overrides
 
 
 def _load_backend(target: str, *, plugin_name: str) -> type[ComponentMixin]:
@@ -228,8 +221,22 @@ class PluginManager:
             seen.add(name)
         return cls(plugins)
 
-    def _merge_config(self, application_config: Mapping[str, Any]) -> tuple[dict[str, Any], tuple[str, ...]]:
-        """Merge config and retain startup diagnostics for named resource replacement."""
+    def _merge_config(
+        self,
+        application_config: ResolvedAppConfig | Mapping[str, Any],
+    ) -> tuple[dict[str, Any], tuple[str, ...]]:
+        """Merge layered config and retain named-resource replacement diagnostics.
+
+        A plain mapping represents direct Python overrides. Config-file callers
+        use ``ResolvedAppConfig`` to retain the loaded base as a provider layer.
+        """
+        resolved = (
+            application_config
+            if isinstance(application_config, ResolvedAppConfig)
+            else ResolvedAppConfig(overrides=application_config)
+        )
+        base = _require_mapping(resolved.base, "application config")
+        overrides = _require_mapping(resolved.overrides, "explicit overrides")
         plugin_layers = [
             (
                 f"plugin '{plugin.name}'",
@@ -243,13 +250,13 @@ class PluginManager:
         merged: dict[str, Any] = {}
         for _, layer in plugin_layers:
             merged = deep_merge_config(merged, _without_named_resources(layer))
-        merged = deep_merge_config(merged, _without_named_resources(application_config))
+        merged = deep_merge_config(merged, _without_named_resources(base))
+        merged = deep_merge_config(merged, _without_named_resources(overrides))
 
         # Complete jobs and named component instances are atomic resources:
         # loaded application config is lowest and later plugins are highest.
         # Explicit CLI dot-notation values are field-level overrides applied
         # after the winning complete resource has been selected.
-        application_resources, explicit_resource_overrides = _split_application_resource_layers(application_config)
         jobs: dict[str, Any] = {}
         components: dict[str, dict[str, Any]] = {}
         job_owners: dict[tuple[str, ...], str] = {}
@@ -258,7 +265,7 @@ class PluginManager:
         has_jobs = False
         has_components = False
 
-        atomic_layers = [("application config", application_resources), *plugin_layers]
+        atomic_layers = [("application config", base), *plugin_layers]
         for source, layer in atomic_layers:
             layer_has_jobs, layer_has_components = _overlay_atomic_resources(
                 jobs,
@@ -279,11 +286,11 @@ class PluginManager:
 
         # CLI/config kwargs use the established deep-merge contract. They are
         # patches to the selected complete resources, not additional providers.
-        merged = deep_merge_config(merged, explicit_resource_overrides)
+        merged = deep_merge_config(merged, _explicit_resource_overrides(overrides))
         return merged, tuple(warnings)
 
-    def merge_config(self, application_config: Mapping[str, Any]) -> dict[str, Any]:
-        """Apply plugin config while atomically replacing same-name jobs and components."""
+    def merge_config(self, application_config: ResolvedAppConfig | Mapping[str, Any]) -> dict[str, Any]:
+        """Apply plugins, treating a plain Python mapping as explicit overrides."""
         merged, _ = self._merge_config(application_config)
         return merged
 
@@ -294,10 +301,15 @@ class PluginManager:
                 registry.add(backend.name, backend.implementation, owner=plugin.name)
 
 
-def resolve_plugin_runtime(application_config: Mapping[str, Any]) -> PluginRuntime:
+def resolve_plugin_runtime(application_config: ResolvedAppConfig | Mapping[str, Any]) -> PluginRuntime:
     """Build one local registry and merge explicitly enabled plugin configuration."""
-    manager = PluginManager.discover(application_config.get("plugins") or ())
+    resolved = (
+        application_config
+        if isinstance(application_config, ResolvedAppConfig)
+        else ResolvedAppConfig(overrides=application_config)
+    )
+    manager = PluginManager.discover(resolved.materialize().get("plugins") or ())
     registry = create_application_registry()
     manager.register(registry)
-    config, config_warnings = manager._merge_config(application_config)  # pylint: disable=protected-access
+    config, config_warnings = manager._merge_config(resolved)  # pylint: disable=protected-access
     return PluginRuntime(config=config, registry=registry, config_warnings=config_warnings)

--- a/reme/plugin.py
+++ b/reme/plugin.py
@@ -8,7 +8,6 @@ Python ``Plugin`` descriptors remain supported as a compatibility boundary.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from copy import deepcopy
 from dataclasses import dataclass, field
 from importlib import import_module
 from importlib.metadata import EntryPoint
@@ -16,7 +15,7 @@ from typing import Any
 
 from .components.base_component import ComponentMixin
 from .components.component_registry import ComponentRegistry, create_application_registry
-from .config import deep_merge_config, expand_env_vars
+from .config import ResolvedConfigSection, deep_merge_config, expand_env_vars
 from .entry_point import PLUGIN_ENTRY_POINT_GROUP, find_entry_points, load_entry_point, unique_entry_point
 from .enumeration import component_type_name
 from .plugin_manifest import PluginManifest, load_package_manifest
@@ -48,83 +47,104 @@ class PluginRuntime:
     config_warnings: tuple[str, ...] = ()
 
 
-_MISSING = object()
-
-
 def _without_named_resources(config: Mapping[str, Any]) -> dict[str, Any]:
     """Return fields that retain the ordinary plugin-default merge behavior."""
     return {key: value for key, value in config.items() if key not in {"jobs", "components"}}
 
 
-def _overlay_jobs(
-    current: Any,
-    owners: dict[tuple[Any, ...], str],
-    warnings: list[str],
-    layer: Mapping[str, Any],
-    source: str,
-) -> Any:
-    """Atomically overlay jobs from one source, warning on cross-source replacement."""
-    if "jobs" not in layer:
-        return current
-    jobs = layer["jobs"]
-    if not isinstance(jobs, Mapping):
-        owners.clear()
-        return deepcopy(jobs)
+def _require_mapping(value: Any, path: str) -> Mapping[str, Any]:
+    """Reject an invalid config fragment at its source."""
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{path} must be a mapping")
+    return value
 
-    merged = dict(current) if isinstance(current, Mapping) else {}
-    for name, definition in jobs.items():
-        identity = ("jobs", name)
+
+def _replace_named(
+    target: dict[str, Any],
+    incoming: Mapping[str, Any],
+    owners: dict[tuple[str, ...], str],
+    warnings: list[str],
+    source: str,
+    prefix: tuple[str, ...],
+) -> None:
+    """Atomically replace resources identified by ``prefix + name``."""
+    for name, definition in incoming.items():
+        if not isinstance(name, str):
+            raise TypeError(f"{'.'.join(prefix)} names must be strings, got {type(name).__name__}")
+        identity = (*prefix, name)
         previous = owners.get(identity)
         if previous is not None:
             warnings.append(
-                f"Config collision at jobs.{name}: {source} replaces the complete definition from {previous}",
+                f"Config collision at {'.'.join(identity)}: "
+                f"{source} replaces the complete definition from {previous}",
             )
-        merged[name] = deepcopy(definition)
+        target[name] = definition
         owners[identity] = source
-    return merged
 
 
-def _overlay_components(
-    current: Any,
-    owners: dict[tuple[Any, ...], str],
+def _overlay_atomic_resources(
+    jobs: dict[str, Any],
+    components: dict[str, dict[str, Any]],
+    job_owners: dict[tuple[str, ...], str],
+    component_owners: dict[tuple[str, ...], str],
     warnings: list[str],
     layer: Mapping[str, Any],
     source: str,
-) -> Any:
-    """Atomically overlay named component instances from one source."""
-    if "components" not in layer:
-        return current
-    components = layer["components"]
-    if not isinstance(components, Mapping):
-        owners.clear()
-        return deepcopy(components)
+) -> tuple[bool, bool]:
+    """Overlay the two resource kinds with atomic identities."""
+    has_jobs = "jobs" in layer
+    has_components = "components" in layer
+
+    if has_jobs:
+        incoming_jobs = _require_mapping(layer["jobs"], f"{source}.jobs")
+        _replace_named(jobs, incoming_jobs, job_owners, warnings, source, ("jobs",))
+
+    if not has_components:
+        return has_jobs, has_components
+
+    raw_components = _require_mapping(layer["components"], f"{source}.components")
 
     # Match ApplicationConfig normalization before comparing identities. If
     # one source repeats an equivalent type, its later mapping wins without a
     # new same-source diagnostic, preserving the existing validator behavior.
-    normalized = {component_type_name(component_type): group for component_type, group in components.items()}
-    merged = dict(current) if isinstance(current, Mapping) else {}
+    normalized = {
+        component_type_name(component_type): _require_mapping(
+            group,
+            f"{source}.components.{component_type}",
+        )
+        for component_type, group in raw_components.items()
+    }
     for component_type, group in normalized.items():
-        if not isinstance(group, Mapping):
-            merged[component_type] = deepcopy(group)
-            for identity in [identity for identity in owners if identity[1] == component_type]:
-                del owners[identity]
-            continue
+        target_group = components.setdefault(component_type, {})
+        _replace_named(
+            target_group,
+            group,
+            component_owners,
+            warnings,
+            source,
+            ("components", component_type),
+        )
+    return has_jobs, has_components
 
-        current_group = merged.get(component_type)
-        merged_group = dict(current_group) if isinstance(current_group, Mapping) else {}
-        for name, definition in group.items():
-            identity = ("components", component_type, name)
-            previous = owners.get(identity)
-            if previous is not None:
-                warnings.append(
-                    f"Config collision at components.{component_type}.{name}: "
-                    f"{source} replaces the complete definition from {previous}",
-                )
-            merged_group[name] = deepcopy(definition)
-            owners[identity] = source
-        merged[component_type] = merged_group
-    return merged
+
+def _split_application_resource_layers(
+    application_config: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Separate loaded resource definitions from explicit field overrides."""
+    base_layer: dict[str, Any] = {}
+    explicit_overrides: dict[str, Any] = {}
+    for section_name in ("jobs", "components"):
+        if section_name not in application_config:
+            continue
+        section = application_config[section_name]
+        if not isinstance(section, ResolvedConfigSection):
+            base_layer[section_name] = section
+            continue
+        if section.base_present:
+            base_layer[section_name] = section.base
+        if section.explicit_overrides_present:
+            explicit_overrides[section_name] = section.explicit_overrides
+    return base_layer, explicit_overrides
 
 
 def _load_backend(target: str, *, plugin_name: str) -> type[ComponentMixin]:
@@ -199,40 +219,56 @@ class PluginManager:
 
     def _merge_config(self, application_config: Mapping[str, Any]) -> tuple[dict[str, Any], tuple[str, ...]]:
         """Merge config and retain startup diagnostics for named resource replacement."""
-        plugin_layers = [expand_env_vars(plugin.config) for plugin in self.plugins]
+        plugin_layers = [
+            (
+                f"plugin '{plugin.name}'",
+                _require_mapping(expand_env_vars(plugin.config), f"plugin '{plugin.name}'"),
+            )
+            for plugin in self.plugins
+        ]
 
         # Ordinary fields retain their existing priority: plugin defaults are
         # merged in enablement order, then application config wins.
         merged: dict[str, Any] = {}
-        for layer in plugin_layers:
+        for _, layer in plugin_layers:
             merged = deep_merge_config(merged, _without_named_resources(layer))
         merged = deep_merge_config(merged, _without_named_resources(application_config))
 
-        # Jobs and named component instances use the explicit plugin priority:
-        # application config is lowest and later enabled plugins are highest.
-        jobs: Any = _MISSING
-        components: Any = _MISSING
-        job_owners: dict[tuple[Any, ...], str] = {}
-        component_owners: dict[tuple[Any, ...], str] = {}
+        # Complete jobs and named component instances are atomic resources:
+        # loaded application config is lowest and later plugins are highest.
+        # Explicit CLI dot-notation values are field-level overrides applied
+        # after the winning complete resource has been selected.
+        application_resources, explicit_resource_overrides = _split_application_resource_layers(application_config)
+        jobs: dict[str, Any] = {}
+        components: dict[str, dict[str, Any]] = {}
+        job_owners: dict[tuple[str, ...], str] = {}
+        component_owners: dict[tuple[str, ...], str] = {}
         warnings: list[str] = []
+        has_jobs = False
+        has_components = False
 
-        jobs = _overlay_jobs(jobs, job_owners, warnings, application_config, "application config")
-        components = _overlay_components(
-            components,
-            component_owners,
-            warnings,
-            application_config,
-            "application config",
-        )
-        for plugin, layer in zip(self.plugins, plugin_layers):
-            source = f"plugin '{plugin.name}'"
-            jobs = _overlay_jobs(jobs, job_owners, warnings, layer, source)
-            components = _overlay_components(components, component_owners, warnings, layer, source)
+        atomic_layers = [("application config", application_resources), *plugin_layers]
+        for source, layer in atomic_layers:
+            layer_has_jobs, layer_has_components = _overlay_atomic_resources(
+                jobs,
+                components,
+                job_owners,
+                component_owners,
+                warnings,
+                layer,
+                source,
+            )
+            has_jobs |= layer_has_jobs
+            has_components |= layer_has_components
 
-        if jobs is not _MISSING:
+        if has_jobs:
             merged["jobs"] = jobs
-        if components is not _MISSING:
+        if has_components:
             merged["components"] = components
+
+        # CLI/config kwargs use the established deep-merge contract. They are
+        # patches to the selected complete resources, not additional providers.
+        merged = deep_merge_config(merged, explicit_resource_overrides)
         return merged, tuple(warnings)
 
     def merge_config(self, application_config: Mapping[str, Any]) -> dict[str, Any]:

--- a/reme/plugin.py
+++ b/reme/plugin.py
@@ -130,21 +130,32 @@ def _overlay_atomic_resources(
 def _split_application_resource_layers(
     application_config: Mapping[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Separate loaded resource definitions from explicit field overrides."""
-    base_layer: dict[str, Any] = {}
+    """Separate atomic definitions from explicit field-level overrides."""
+    application_layer: dict[str, Any] = {}
     explicit_overrides: dict[str, Any] = {}
     for section_name in ("jobs", "components"):
         if section_name not in application_config:
             continue
         section = application_config[section_name]
+        application_layer[section_name] = section
         if not isinstance(section, ResolvedConfigSection):
-            base_layer[section_name] = section
             continue
-        if section.base_present:
-            base_layer[section_name] = section.base
-        if section.explicit_overrides_present:
-            explicit_overrides[section_name] = section.explicit_overrides
-    return base_layer, explicit_overrides
+
+        projected: dict[str, Any] = {}
+        for path in section.explicit_paths:
+            current: Any = section
+            for key in path:
+                if not isinstance(current, Mapping) or key not in current:
+                    break
+                current = current[key]
+            else:
+                target = projected
+                for key in path[:-1]:
+                    target = target.setdefault(key, {})
+                target[path[-1]] = current
+        if projected:
+            explicit_overrides[section_name] = projected
+    return application_layer, explicit_overrides
 
 
 def _load_backend(target: str, *, plugin_name: str) -> type[ComponentMixin]:

--- a/reme/plugin_cli.py
+++ b/reme/plugin_cli.py
@@ -220,12 +220,12 @@ def _uninstall_plugin(args: argparse.Namespace) -> int:
 def _validate_plugins(manager) -> None:
     """Validate imports, registry ownership, and merged application schema."""
     from .components.component_registry import create_application_registry
-    from .config.config_parser import resolve_app_config
+    from .config.config_parser import resolve_app_config_layers
     from .schema.application_config import ApplicationConfig
 
     registry = create_application_registry()
     manager.register(registry)
-    ApplicationConfig(**manager.merge_config(resolve_app_config(log_config=False)))
+    ApplicationConfig(**manager.merge_config(resolve_app_config_layers(log_config=False)))
 
 
 def _validate_installed(name: str) -> list[str]:

--- a/reme/reme.py
+++ b/reme/reme.py
@@ -7,7 +7,7 @@ import sys
 
 from .application import Application
 from .components.service.cli_service import prepare_start_config, should_precheck_start
-from .config import parse_action, parse_kwargs, resolve_app_config
+from .config import ResolvedAppConfig, parse_action, parse_kwargs, resolve_app_config
 from .enumeration import ComponentEnum
 from .plugin import resolve_plugin_runtime
 from .utils import cli_find_reme, load_env, precheck_start, running_app_config
@@ -91,11 +91,13 @@ def _run_plugin_command(argv: Sequence[str]) -> None:
 
 def _start_application(kwargs: dict, environment: dict) -> None:
     """Resolve startup configuration and run the application."""
-    kwargs = prepare_start_config(kwargs)
-    kwargs["environment"] = environment
-    if should_precheck_start(kwargs) and not precheck_start(kwargs.get("service")):
+    prepared = prepare_start_config(kwargs)
+    config = prepared if isinstance(prepared, ResolvedAppConfig) else ResolvedAppConfig(overrides=prepared)
+    config = config.with_overrides({"environment": environment})
+    visible = config.materialize()
+    if should_precheck_start(config) and not precheck_start(visible.get("service")):
         return
-    ReMe(**kwargs).run_app()
+    ReMe(resolved_config=config).run_app()
 
 
 def main() -> None:

--- a/tests/unit/test_codex_agent_wrapper.py
+++ b/tests/unit/test_codex_agent_wrapper.py
@@ -18,8 +18,9 @@ from reme.components.agent_wrapper.codex_agent_wrapper import CodexAgentWrapper
 from reme.components.agent_wrapper.codex_mcp_server import _prepare_config
 from reme.components.job import BackgroundJob
 from reme.components.outbound_proxy import FixedHttpOutboundProxy
-from reme.config import resolve_app_config
+from reme.config import ResolvedAppConfig, resolve_app_config
 from reme.enumeration import ChunkEnum, ComponentEnum
+from reme.plugin import Plugin, PluginManager
 from reme.schema import ApplicationConfig, Response
 
 
@@ -196,6 +197,22 @@ def test_prepare_config_rejects_missing_or_background_selected_jobs():
         _prepare_config({"jobs": {}}, ["missing"])
     with pytest.raises(KeyError, match="watch"):
         _prepare_config({"jobs": {"watch": {"backend": "background"}}}, ["watch"])
+
+
+def test_prepare_config_job_selection_survives_plugin_replacement():
+    resolved = ResolvedAppConfig(
+        base={"jobs": {"selected": {"backend": "base", "enable_serve": False}}},
+    )
+    prepared = _prepare_config(resolved, ["selected"])
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"selected": {"backend": "plugin"}}})],
+    )
+
+    assert isinstance(prepared, ResolvedAppConfig)
+    assert manager.merge_config(prepared)["jobs"]["selected"] == {
+        "backend": "plugin",
+        "enable_serve": True,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -11,6 +11,7 @@ from reme.config.config_parser import (
     parse_args,
     parse_dot_notation,
     resolve_app_config,
+    resolve_app_config_layers,
 )
 
 
@@ -79,6 +80,30 @@ def test_resolve_app_config_layers_plugins_over_default():
 
     assert config["service"]["backend"] == "http"
     assert config["plugins"] == ["auto-fin"]
+
+
+def test_resolve_app_config_layers_keep_loaded_values_and_explicit_inputs_separate(tmp_path):
+    """Loaded resource providers stay separate from explicit field patches."""
+    config_path = tmp_path / "base.yaml"
+    config_path.write_text("language: base\njobs:\n  task:\n    backend: base\n", encoding="utf-8")
+
+    resolved = resolve_app_config_layers(
+        config=str(config_path),
+        log_config=False,
+        language="override",
+        jobs={"task": {"enable_serve": False}},
+    )
+
+    assert resolved.base["language"] == "base"
+    assert resolved.base["jobs"]["task"] == {"backend": "base"}
+    assert resolved.overrides == {
+        "language": "override",
+        "jobs": {"task": {"enable_serve": False}},
+    }
+    assert resolved.materialize()["jobs"]["task"] == {
+        "backend": "base",
+        "enable_serve": False,
+    }
 
 
 def test_default_config_registers_daily_write_job():

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -6,12 +6,11 @@ from pathlib import Path
 from threading import Lock
 
 import pytest
-import yaml
 
 from reme.application import Application
 from reme.components.base_component import BaseComponent, ComponentMixin
 from reme.components.component_registry import ComponentRegistry, R
-from reme.config.config_parser import _load_config, resolve_app_config
+from reme.config.config_parser import ResolvedAppConfig, _load_config, resolve_app_config_layers
 from reme.enumeration import ComponentEnum
 from reme.plugin import Backend, Plugin, PluginManager, _load_backend
 from reme.plugin_manifest import parse_plugin_manifest
@@ -76,10 +75,12 @@ def test_plugin_application_defaults_are_below_application_config():
     )
 
     merged = manager.merge_config(
-        {
-            "language": "application",
-            "jobs": {"task": {"backend": "application_job", "application_only": True}},
-        },
+        ResolvedAppConfig(
+            base={
+                "language": "application",
+                "jobs": {"task": {"backend": "application_job", "application_only": True}},
+            },
+        ),
     )
 
     assert merged["language"] == "application"
@@ -95,7 +96,7 @@ def test_later_plugin_atomically_replaces_same_name_job_and_records_each_collisi
     )
 
     merged, warnings = manager._merge_config(  # pylint: disable=protected-access
-        {"jobs": {"task": {"backend": "application", "application_only": True}}},
+        ResolvedAppConfig(base={"jobs": {"task": {"backend": "application", "application_only": True}}}),
     )
 
     assert merged["jobs"]["task"] == {"backend": "second", "second_only": True}
@@ -115,7 +116,7 @@ def test_cli_override_patches_job_after_atomic_plugin_replacement(tmp_path):
 """,
         encoding="utf-8",
     )
-    resolved = resolve_app_config(
+    resolved = resolve_app_config_layers(
         config=str(base),
         log_config=False,
         jobs={"task": {"enable_serve": False}},
@@ -124,9 +125,7 @@ def test_cli_override_patches_job_after_atomic_plugin_replacement(tmp_path):
         [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin", "plugin_only": True}}})],
     )
 
-    # Expanding a resolved config into Application kwargs retains provenance on
-    # the nested resource sections.
-    merged, warnings = manager._merge_config(dict(resolved))
+    merged, warnings = manager._merge_config(resolved)
 
     assert merged["jobs"]["task"] == {
         "backend": "plugin",
@@ -138,7 +137,7 @@ def test_cli_override_patches_job_after_atomic_plugin_replacement(tmp_path):
     )
 
 
-def test_resolved_resource_provenance_tracks_only_current_visible_values(tmp_path):
+def test_post_resolution_patch_adds_job_field_after_atomic_plugin_replacement(tmp_path):
     base = tmp_path / "base.yaml"
     base.write_text(
         """jobs:
@@ -148,47 +147,55 @@ def test_resolved_resource_provenance_tracks_only_current_visible_values(tmp_pat
 """,
         encoding="utf-8",
     )
-    raw_overrides = {"task": {"enable_serve": False}}
-    resolved = resolve_app_config(
+    resolved = resolve_app_config_layers(
         config=str(base),
         log_config=False,
-        jobs=raw_overrides,
     )
     manager = PluginManager(
         [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin", "plugin_only": True}}})],
     )
 
-    # Mutating the original override must not change the resolved config;
-    # mutating the visible resolved value must be honored.
-    raw_overrides["task"]["enable_serve"] = True
-    assert resolved["jobs"]["task"]["enable_serve"] is False
-    resolved["jobs"]["task"]["enable_serve"] = True
+    resolved = resolved.with_overrides({"jobs": {"task": {"enable_serve": False}}})
 
-    assert manager.merge_config(dict(resolved))["jobs"]["task"] == {
+    assert manager.merge_config(resolved)["jobs"]["task"] == {
         "backend": "plugin",
         "plugin_only": True,
-        "enable_serve": True,
-    }
-
-    del resolved["jobs"]["task"]["enable_serve"]
-    assert manager.merge_config(dict(resolved))["jobs"]["task"] == {
-        "backend": "plugin",
-        "plugin_only": True,
+        "enable_serve": False,
     }
 
 
-def test_resolved_config_sections_safe_dump_as_plain_mappings(tmp_path):
+def test_post_resolution_job_replacement_is_an_explicit_field_patch(tmp_path):
     base = tmp_path / "base.yaml"
-    base.write_text("jobs:\n  task:\n    backend: base\n", encoding="utf-8")
-    resolved = resolve_app_config(
-        config=str(base),
-        log_config=False,
-        jobs={"task": {"enable_serve": False}},
+    base.write_text("jobs:\n  task:\n    backend: application\n", encoding="utf-8")
+    resolved = resolve_app_config_layers(config=str(base), log_config=False).with_overrides(
+        {"jobs": {"task": {"backend": "replacement", "enable_serve": False}}},
+    )
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin", "plugin_only": True}}})],
     )
 
-    dumped = yaml.safe_dump(resolved)
+    assert manager.merge_config(resolved)["jobs"]["task"] == {
+        "backend": "replacement",
+        "plugin_only": True,
+        "enable_serve": False,
+    }
 
-    assert yaml.safe_load(dumped) == resolved
+
+def test_materialized_config_copy_has_explicit_python_mapping_semantics(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text("jobs:\n  task:\n    backend: application\n", encoding="utf-8")
+    copied = dict(resolve_app_config_layers(config=str(base), log_config=False).materialize())
+    copied["jobs"] = dict(copied["jobs"])
+    copied["jobs"]["task"] = {"backend": "copied", "enable_serve": False}
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin", "plugin_only": True}}})],
+    )
+
+    assert manager.merge_config(copied)["jobs"]["task"] == {
+        "backend": "copied",
+        "plugin_only": True,
+        "enable_serve": False,
+    }
 
 
 def test_atomic_resource_replacement_preserves_runtime_object_identity():
@@ -213,7 +220,7 @@ def test_atomic_resources_reject_invalid_fragments_at_their_source(application_c
     manager = PluginManager([Plugin(name="later", config={"jobs": {"valid": {"backend": "base"}}})])
 
     with pytest.raises(TypeError, match=message):
-        manager.merge_config(application_config)
+        manager.merge_config(ResolvedAppConfig(base=application_config))
 
 
 def test_identical_same_name_job_warns_while_different_names_are_merged():
@@ -223,7 +230,7 @@ def test_identical_same_name_job_warns_while_different_names_are_merged():
     )
 
     merged, warnings = manager._merge_config(  # pylint: disable=protected-access
-        {"jobs": {"shared": definition, "application_only": definition}},
+        ResolvedAppConfig(base={"jobs": {"shared": definition, "application_only": definition}}),
     )
 
     assert set(merged["jobs"]) == {"shared", "plugin_only", "application_only"}
@@ -250,14 +257,16 @@ def test_plugin_component_identity_is_normalized_before_atomic_replacement():
     )
 
     merged, warnings = manager._merge_config(  # pylint: disable=protected-access
-        {
-            "components": {
-                "as_llm": {
-                    "default": {"backend": "application", "application_only": True},
-                    "other": {"backend": "other"},
+        ResolvedAppConfig(
+            base={
+                "components": {
+                    "as_llm": {
+                        "default": {"backend": "application", "application_only": True},
+                        "other": {"backend": "other"},
+                    },
                 },
             },
-        },
+        ),
     )
 
     assert merged["components"]["as_llm"] == {
@@ -299,7 +308,7 @@ def test_same_component_name_in_different_types_does_not_conflict():
     )
 
     merged, warnings = manager._merge_config(  # pylint: disable=protected-access
-        {"components": {"as_llm": {"default": {"backend": "application"}}}},
+        ResolvedAppConfig(base={"components": {"as_llm": {"default": {"backend": "application"}}}}),
     )
 
     assert merged["components"] == {
@@ -358,7 +367,7 @@ def test_benchmark_plugins_share_benchmark_llm_component_definitions(plugin_name
     manifest = parse_plugin_manifest(manifest_path.read_text(encoding="utf-8"), plugin_name=plugin_name)
     manager = PluginManager([Plugin(name=plugin_name, config=manifest.application_defaults)])
 
-    merged, warnings = manager._merge_config(_load_config("benchmark"))
+    merged, warnings = manager._merge_config(ResolvedAppConfig(base=_load_config("benchmark")))
     config = ApplicationConfig(**merged)
 
     default = config.components["as_llm"]["default"]
@@ -447,13 +456,17 @@ def test_application_logs_config_collisions_before_resource_instantiation(monkey
     monkeypatch.setattr(Application, "_init_jobs", lambda self: events.append(("jobs", None)))
 
     Application(
-        plugins=["example"],
-        jobs={"task": {"backend": "application"}},
-        workspace_dir=str(tmp_path),
-        enable_logo=False,
-        log_to_console=False,
-        log_to_file=False,
-        service={"backend": "unused"},
+        resolved_config=ResolvedAppConfig(
+            base={"jobs": {"task": {"backend": "application"}}},
+            overrides={
+                "plugins": ["example"],
+                "workspace_dir": str(tmp_path),
+                "enable_logo": False,
+                "log_to_console": False,
+                "log_to_file": False,
+                "service": {"backend": "unused"},
+            },
+        ),
     )
 
     assert events[0] == (
@@ -465,6 +478,31 @@ def test_application_logs_config_collisions_before_resource_instantiation(monkey
         "components",
         "jobs",
     ]
+
+
+def test_direct_python_kwargs_are_explicit_resource_overrides(monkeypatch, tmp_path):
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin", "plugin_only": True}}})],
+    )
+    monkeypatch.setattr(PluginManager, "discover", classmethod(lambda cls, specs: manager))
+    monkeypatch.setattr(Application, "_init_service", lambda self: None)
+    monkeypatch.setattr(Application, "_init_components", lambda self: None)
+    monkeypatch.setattr(Application, "_init_jobs", lambda self: None)
+
+    app = Application(
+        plugins=["example"],
+        jobs={"task": {"backend": "python", "enable_serve": False}},
+        workspace_dir=str(tmp_path),
+        enable_logo=False,
+        log_to_console=False,
+        log_to_file=False,
+        service={"backend": "unused"},
+    )
+
+    task = app.config.jobs["task"]
+    assert task.backend == "python"
+    assert task.enable_serve is False
+    assert task.model_extra["plugin_only"] is True
 
 
 def test_plugin_backend_collision_fails_with_both_owners():

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -3,16 +3,18 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
 
 from pathlib import Path
+from threading import Lock
 
 import pytest
 
 from reme.application import Application
 from reme.components.base_component import BaseComponent, ComponentMixin
 from reme.components.component_registry import ComponentRegistry, R
-from reme.config.config_parser import _load_config
+from reme.config.config_parser import _load_config, resolve_app_config
 from reme.enumeration import ComponentEnum
 from reme.plugin import Backend, Plugin, PluginManager, _load_backend
 from reme.plugin_manifest import parse_plugin_manifest
+from reme.schema import ApplicationConfig
 
 
 class _PluginStep(ComponentMixin):
@@ -100,6 +102,64 @@ def test_later_plugin_atomically_replaces_same_name_job_and_records_each_collisi
         "Config collision at jobs.task: plugin 'first' replaces the complete definition from application config",
         "Config collision at jobs.task: plugin 'second' replaces the complete definition from plugin 'first'",
     )
+
+
+def test_cli_override_patches_job_after_atomic_plugin_replacement(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        """jobs:
+  task:
+    backend: application
+    application_only: true
+""",
+        encoding="utf-8",
+    )
+    resolved = resolve_app_config(
+        config=str(base),
+        log_config=False,
+        jobs={"task": {"enable_serve": False}},
+    )
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin", "plugin_only": True}}})],
+    )
+
+    # Expanding a resolved config into Application kwargs retains provenance on
+    # the nested resource sections.
+    merged, warnings = manager._merge_config(dict(resolved))
+
+    assert merged["jobs"]["task"] == {
+        "backend": "plugin",
+        "plugin_only": True,
+        "enable_serve": False,
+    }
+    assert warnings == (
+        "Config collision at jobs.task: plugin 'example' replaces the complete definition from application config",
+    )
+
+
+def test_atomic_resource_replacement_preserves_runtime_object_identity():
+    lock = Lock()
+    definition = {"backend": "base", "runtime_lock": lock}
+
+    merged = PluginManager().merge_config({"jobs": {"task": definition}})
+
+    assert merged["jobs"]["task"] is definition
+    assert merged["jobs"]["task"]["runtime_lock"] is lock
+
+
+@pytest.mark.parametrize(
+    ("application_config", "message"),
+    [
+        ({"jobs": []}, "application config.jobs must be a mapping"),
+        ({"components": {"as_llm": []}}, "application config.components.as_llm must be a mapping"),
+        ({"jobs": {1: {"backend": "base"}}}, "jobs names must be strings"),
+    ],
+)
+def test_atomic_resources_reject_invalid_fragments_at_their_source(application_config, message):
+    manager = PluginManager([Plugin(name="later", config={"jobs": {"valid": {"backend": "base"}}})])
+
+    with pytest.raises(TypeError, match=message):
+        manager.merge_config(application_config)
 
 
 def test_identical_same_name_job_warns_while_different_names_are_merged():
@@ -234,6 +294,28 @@ def test_plugin_application_defaults_expand_environment(monkeypatch):
 
     assert merged["limit"] == 12
     assert merged["jobs"]["task"]["limit"] == 12
+
+
+@pytest.mark.parametrize("plugin_name", ["lme", "beam"])
+def test_benchmark_plugins_share_benchmark_llm_component_definitions(plugin_name):
+    project_root = Path(__file__).parents[2]
+    package_name = "reme_lme" if plugin_name == "lme" else "reme_beam"
+    manifest_path = project_root / "plugins" / plugin_name / "src" / package_name / "plugin.yaml"
+    manifest = parse_plugin_manifest(manifest_path.read_text(encoding="utf-8"), plugin_name=plugin_name)
+    manager = PluginManager([Plugin(name=plugin_name, config=manifest.application_defaults)])
+
+    merged, warnings = manager._merge_config(_load_config("benchmark"))
+    config = ApplicationConfig(**merged)
+
+    default = config.components["as_llm"]["default"]
+    judge = config.components["as_llm"]["judge"]
+    assert default.backend
+    assert default.model_extra["max_retries"] == 5
+    assert default.model_extra["retry_delay"] == 5.0
+    assert judge.backend
+    assert judge.model_extra["max_retries"] == 5
+    assert judge.model_extra["retry_delay"] == 5.0
+    assert not [warning for warning in warnings if "components.as_llm" in warning]
 
 
 def test_plugin_registers_into_only_the_supplied_registry():

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from threading import Lock
 
 import pytest
+import yaml
 
 from reme.application import Application
 from reme.components.base_component import BaseComponent, ComponentMixin
@@ -135,6 +136,59 @@ def test_cli_override_patches_job_after_atomic_plugin_replacement(tmp_path):
     assert warnings == (
         "Config collision at jobs.task: plugin 'example' replaces the complete definition from application config",
     )
+
+
+def test_resolved_resource_provenance_tracks_only_current_visible_values(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        """jobs:
+  task:
+    backend: application
+    enable_serve: true
+""",
+        encoding="utf-8",
+    )
+    raw_overrides = {"task": {"enable_serve": False}}
+    resolved = resolve_app_config(
+        config=str(base),
+        log_config=False,
+        jobs=raw_overrides,
+    )
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin", "plugin_only": True}}})],
+    )
+
+    # Mutating the original override must not change the resolved config;
+    # mutating the visible resolved value must be honored.
+    raw_overrides["task"]["enable_serve"] = True
+    assert resolved["jobs"]["task"]["enable_serve"] is False
+    resolved["jobs"]["task"]["enable_serve"] = True
+
+    assert manager.merge_config(dict(resolved))["jobs"]["task"] == {
+        "backend": "plugin",
+        "plugin_only": True,
+        "enable_serve": True,
+    }
+
+    del resolved["jobs"]["task"]["enable_serve"]
+    assert manager.merge_config(dict(resolved))["jobs"]["task"] == {
+        "backend": "plugin",
+        "plugin_only": True,
+    }
+
+
+def test_resolved_config_sections_safe_dump_as_plain_mappings(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text("jobs:\n  task:\n    backend: base\n", encoding="utf-8")
+    resolved = resolve_app_config(
+        config=str(base),
+        log_config=False,
+        jobs={"task": {"enable_serve": False}},
+    )
+
+    dumped = yaml.safe_dump(resolved)
+
+    assert yaml.safe_load(dumped) == resolved
 
 
 def test_atomic_resource_replacement_preserves_runtime_object_identity():

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -64,21 +64,176 @@ def test_plugin_application_defaults_are_below_application_config():
         [
             Plugin(
                 name="example",
-                config={"jobs": {"task": {"backend": "base", "value": 1}}},
+                config={
+                    "language": "plugin",
+                    "jobs": {"task": {"backend": "plugin_job", "plugin_only": True}},
+                },
             ),
         ],
     )
 
-    merged = manager.merge_config({"jobs": {"task": {"value": 2}}})
+    merged = manager.merge_config(
+        {
+            "language": "application",
+            "jobs": {"task": {"backend": "application_job", "application_only": True}},
+        },
+    )
 
-    assert merged["jobs"]["task"] == {"backend": "base", "value": 2}
+    assert merged["language"] == "application"
+    assert merged["jobs"]["task"] == {"backend": "plugin_job", "plugin_only": True}
+
+
+def test_later_plugin_atomically_replaces_same_name_job_and_records_each_collision():
+    manager = PluginManager(
+        [
+            Plugin(name="first", config={"jobs": {"task": {"backend": "first", "first_only": True}}}),
+            Plugin(name="second", config={"jobs": {"task": {"backend": "second", "second_only": True}}}),
+        ],
+    )
+
+    merged, warnings = manager._merge_config(  # pylint: disable=protected-access
+        {"jobs": {"task": {"backend": "application", "application_only": True}}},
+    )
+
+    assert merged["jobs"]["task"] == {"backend": "second", "second_only": True}
+    assert warnings == (
+        "Config collision at jobs.task: plugin 'first' replaces the complete definition from application config",
+        "Config collision at jobs.task: plugin 'second' replaces the complete definition from plugin 'first'",
+    )
+
+
+def test_identical_same_name_job_warns_while_different_names_are_merged():
+    definition = {"backend": "same"}
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"shared": definition, "plugin_only": definition}})],
+    )
+
+    merged, warnings = manager._merge_config(  # pylint: disable=protected-access
+        {"jobs": {"shared": definition, "application_only": definition}},
+    )
+
+    assert set(merged["jobs"]) == {"shared", "plugin_only", "application_only"}
+    expected = "Config collision at jobs.shared: " + (
+        "plugin 'example' replaces the complete definition from application config"
+    )
+    assert warnings == (expected,)
+
+
+def test_plugin_component_identity_is_normalized_before_atomic_replacement():
+    manager = PluginManager(
+        [
+            Plugin(
+                name="example",
+                config={
+                    "components": {
+                        " as_llm ": {
+                            "default": {"backend": "plugin", "plugin_only": True},
+                        },
+                    },
+                },
+            ),
+        ],
+    )
+
+    merged, warnings = manager._merge_config(  # pylint: disable=protected-access
+        {
+            "components": {
+                "as_llm": {
+                    "default": {"backend": "application", "application_only": True},
+                    "other": {"backend": "other"},
+                },
+            },
+        },
+    )
+
+    assert merged["components"]["as_llm"] == {
+        "default": {"backend": "plugin", "plugin_only": True},
+        "other": {"backend": "other"},
+    }
+    assert warnings == (
+        "Config collision at components.as_llm.default: "
+        "plugin 'example' replaces the complete definition from application config",
+    )
+
+
+def test_later_plugin_atomically_replaces_same_name_component():
+    manager = PluginManager(
+        [
+            Plugin(
+                name="first",
+                config={"components": {"tokenizer": {"default": {"backend": "first", "first_only": True}}}},
+            ),
+            Plugin(
+                name="second",
+                config={"components": {"tokenizer": {"default": {"backend": "second"}}}},
+            ),
+        ],
+    )
+
+    merged, warnings = manager._merge_config({})  # pylint: disable=protected-access
+
+    assert merged["components"]["tokenizer"]["default"] == {"backend": "second"}
+    assert warnings == (
+        "Config collision at components.tokenizer.default: "
+        "plugin 'second' replaces the complete definition from plugin 'first'",
+    )
+
+
+def test_same_component_name_in_different_types_does_not_conflict():
+    manager = PluginManager(
+        [Plugin(name="example", config={"components": {"tokenizer": {"default": {"backend": "plugin"}}}})],
+    )
+
+    merged, warnings = manager._merge_config(  # pylint: disable=protected-access
+        {"components": {"as_llm": {"default": {"backend": "application"}}}},
+    )
+
+    assert merged["components"] == {
+        "as_llm": {"default": {"backend": "application"}},
+        "tokenizer": {"default": {"backend": "plugin"}},
+    }
+    assert not warnings
+
+
+def test_same_source_component_type_normalization_uses_later_definition_without_warning():
+    manager = PluginManager(
+        [
+            Plugin(
+                name="example",
+                config={
+                    "components": {
+                        "as_llm ": {"default": {"backend": "first"}},
+                        "as_llm": {"default": {"backend": "second"}},
+                    },
+                },
+            ),
+        ],
+    )
+
+    merged, warnings = manager._merge_config({})  # pylint: disable=protected-access
+
+    assert merged["components"] == {"as_llm": {"default": {"backend": "second"}}}
+    assert not warnings
 
 
 def test_plugin_application_defaults_expand_environment(monkeypatch):
     monkeypatch.setenv("PLUGIN_LIMIT", "12")
-    manager = PluginManager([Plugin(name="example", config={"limit": "${PLUGIN_LIMIT}"})])
+    manager = PluginManager(
+        [
+            Plugin(
+                name="example",
+                config={
+                    "limit": "${PLUGIN_LIMIT}",
+                    "jobs": {"task": {"backend": "base", "limit": "${PLUGIN_LIMIT}"}},
+                },
+            ),
+        ],
+    )
 
-    assert manager.merge_config({})["limit"] == 12
+    merged = manager.merge_config({})
+
+    assert merged["limit"] == 12
+    assert merged["jobs"]["task"]["limit"] == 12
 
 
 def test_plugin_registers_into_only_the_supplied_registry():
@@ -130,6 +285,50 @@ async def test_plugin_registers_and_runs_custom_component_type(monkeypatch, tmp_
     assert component.backend == "updated"
     await app.close()
     assert component.is_started is False
+
+
+def test_application_logs_config_collisions_before_resource_instantiation(monkeypatch, tmp_path):
+    events = []
+    manager = PluginManager(
+        [Plugin(name="example", config={"jobs": {"task": {"backend": "plugin"}}})],
+    )
+
+    class RecordingLogger:
+        def bind(self, **_kwargs):
+            return self
+
+        def warning(self, message):
+            events.append(("warning", message))
+
+        def info(self, _message):
+            events.append(("info", None))
+
+    monkeypatch.setattr(PluginManager, "discover", classmethod(lambda cls, specs: manager))
+    monkeypatch.setattr("reme.application.get_logger", lambda **_kwargs: RecordingLogger())
+    monkeypatch.setattr("reme.components.base_component.get_logger", lambda **_kwargs: RecordingLogger())
+    monkeypatch.setattr(Application, "_init_service", lambda self: events.append(("service", None)))
+    monkeypatch.setattr(Application, "_init_components", lambda self: events.append(("components", None)))
+    monkeypatch.setattr(Application, "_init_jobs", lambda self: events.append(("jobs", None)))
+
+    Application(
+        plugins=["example"],
+        jobs={"task": {"backend": "application"}},
+        workspace_dir=str(tmp_path),
+        enable_logo=False,
+        log_to_console=False,
+        log_to_file=False,
+        service={"backend": "unused"},
+    )
+
+    assert events[0] == (
+        "warning",
+        "Config collision at jobs.task: plugin 'example' replaces the complete definition from application config",
+    )
+    assert [kind for kind, _ in events if kind in {"service", "components", "jobs"}] == [
+        "service",
+        "components",
+        "jobs",
+    ]
 
 
 def test_plugin_backend_collision_fails_with_both_owners():

--- a/tests/unit/test_reme_cli.py
+++ b/tests/unit/test_reme_cli.py
@@ -13,6 +13,7 @@ from reme.components.service.cli_service import CliService
 from reme import reme as reme_module
 from reme.components.base_component import ComponentMixin
 from reme.components.component_registry import create_application_registry
+from reme.config import ResolvedAppConfig
 from reme.enumeration import ComponentEnum
 from reme.plugin import Backend, Plugin, PluginManager, PluginRuntime
 
@@ -129,31 +130,35 @@ def test_main_saves_loaded_environment_in_start_config(monkeypatch):
     main_globals = reme_module.main.__globals__
     monkeypatch.setattr("sys.argv", ["reme", "start"])
     monkeypatch.setitem(main_globals, "load_env", lambda: {"TOOL_ENV": "configured"})
-    monkeypatch.setitem(main_globals, "prepare_start_config", lambda _kwargs: {"service": {"backend": "cli"}})
+    monkeypatch.setitem(
+        main_globals,
+        "prepare_start_config",
+        lambda _kwargs: ResolvedAppConfig(base={"service": {"backend": "cli"}}),
+    )
     monkeypatch.setitem(main_globals, "ReMe", FakeReMe)
 
     reme_module.main()
 
-    assert observed == {
-        "config": {
-            "service": {"backend": "cli"},
-            "environment": {"TOOL_ENV": "configured"},
-        },
-        "ran": True,
+    assert observed["config"]["resolved_config"].materialize() == {
+        "service": {"backend": "cli"},
+        "environment": {"TOOL_ENV": "configured"},
     }
+    assert observed["ran"] is True
 
 
 def test_prepare_start_config_moves_unknown_start_args_to_job_args(monkeypatch):
     """``reme start job=...`` is translated into a one-shot cli service config."""
 
-    monkeypatch.setattr(
-        cli_service,
-        "resolve_app_config",
-        lambda **kwargs: {
-            **kwargs,
-            "service": {"backend": "http", "host": "127.0.0.1"},
-        },
-    )
+    seen = {}
+
+    def resolve_layers(**kwargs):
+        seen.update(kwargs)
+        return ResolvedAppConfig(
+            base={"service": {"backend": "http", "host": "127.0.0.1"}},
+            overrides={"workspace_dir": kwargs["workspace_dir"]},
+        )
+
+    monkeypatch.setattr(cli_service, "resolve_app_config_layers", resolve_layers)
 
     cfg = cli_service.prepare_start_config(
         {
@@ -165,7 +170,8 @@ def test_prepare_start_config_moves_unknown_start_args_to_job_args(monkeypatch):
         },
     )
 
-    assert cfg["config"] == "jinli_lme"
+    assert seen["config"] == "jinli_lme"
+    cfg = cfg.materialize()
     assert cfg["workspace_dir"] == "/tmp/reme"
     assert cfg["enable_logo"] is False
     assert cfg["log_to_console"] is False


### PR DESCRIPTION
## Summary

Plugin configuration currently uses recursive deep merging. When an application and a plugin, or two plugins, define the same job or component instance, this can combine fields from different definitions into an invalid hybrid configuration.

Treat the following named resources as atomic at the plugin merge boundary:

- `jobs.<name>`
- `components.<zell_type>.<name>`

Application config has the lowest priority, and plugins are applied in enablement order so later plugins win. Every replacement emits a startup warning identifying the resource path and both sources.

Other configuration fields retain their existing deep-merge behavior. Configuration-file `extends`, CLI dot-notation parsing, backend collision handling, and plugin validation are unchanged.

## Related issue

N/A

## Contract and data impact

- [ ] No public configuration, schema, CLI, endpoint, streaming, or workspace-layout contract changes
- [x] No user-owned memory files are deleted or rewritten
- [x] Derived indexes, catalogs, graphs, caches, and metadata remain rebuildable

This intentionally changes the plugin configuration merge contract for same-name jobs and component instances. A higher-priority definition now replaces the complete lower-priority definition instead of recursively merging with it.

Applications relying on fields inherited through a same-name plugin collision must move those fields into the winning definition, change the plugin order, or use distinct resource names. Startup warnings identify affected resource paths. No data migration or recovery action is required.

## Validation

- [x] Focused tests pass
- [x] Unit tests pass, or omitted tests are explained below
- [ ] `pre-commit run --all-files` passes, or omitted checks are explained below
- [x] Frontend checks were run when `reme_studio/` changed

Validation performed:

- `pytest tests/unit/test_plugin.py tests/unit/test_reme_cli.py tests/unit/test_logging_config.py -q`
  - 47 passed.
- `pytest tests/unit -q`
  - 1106 passed and 31 skipped.
  - Two local socket tests initially failed because the sandbox prohibited binding to `127.0.0.1`.
- `pytest tests/unit/test_service_utils.py::test_pid_on_port_finds_own_listening_socket tests/unit/test_service_utils.py::test_pid_on_port_none_when_nobody_listening -q`
  - 2 passed when rerun with local socket access.
- `PYLINTHOME=/private/tmp/reme-pylint-cache pre-commit run --files reme/plugin.py reme/application.py tests/unit/test_STAplugin.py`
  - AST, private-key detection, trailing whitespace, trailing commas, Black, Kitchensink Fl Essentialsnth Botsflake CADock8 voo P

 gantIÓNladeTokenizer:\/\//explanation plugin and component type normalization tests were run, including identical definitions, plugin ordering, environment expansion, and warning ordering.
- `git diff --check`
  - Passed.

`pre-commit run --all-files` was not run. All hooks passed for the modified Python files.

No `reme_studio/` files changed, so frontend checks were not required.

## Checklist

- [x] I reviewed the diff for unrelated changes and sensitive data
- [x] Tests cover intentional behavior changes
- [x] Defaults, schemas, and concise documentation were updated together when required
- [x] Long-lived clients, tasks, services, and executors follow the application lifecycle

## Screenshots or additional notes

No UI changes.

Warnings are emitted after the final application logger is initialized and before service, component, or job instantiation. Warning messages contain resource paths and source names only; configuration values and expanded environment variables are not logged.

Follow-up work may define separate conflict policies for `service`, `mcp_servers`, and `environment`, or preserve CLI provenance to support a future priority order such as application defaults, plugins, then explicit CLI overrides.