### PR TITLE
fix(docs): use uncached navigation icon

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -256,7 +256,7 @@ export default defineConfig({
     },
   },
   head: [
-    ["link", { rel: "icon", type: "image/svg+xml", href: `${base}favicon.svg` }],
+    ["link", { rel: "icon", type: "image/svg+xml", href: `${base}reme-icon.svg` }],
     ["meta", { name: "theme-color", content: "#087f6a" }],
     ["script", {}, legacyRedirectScript],
   ],
@@ -277,7 +277,7 @@ export default defineConfig({
     buildLlmsFiles(siteConfig.outDir);
   },
   themeConfig: {
-    logo: "/favicon.svg",
+    logo: "/reme-icon.svg",
     siteTitle: "ReMe",
     nav: [
       ...nav("zh"),

--- a/docs/figure/reme-icon.svg
+++ b/docs/figure/reme-icon.svg
@@ -15,7 +15,6 @@
     </filter>
   </defs>
 
-  <!-- Liquid glass tile shared with the full ReMe wordmark. -->
   <g filter="url(#shadow)">
     <rect x="3" y="3" width="58" height="58" rx="18" fill="url(#glass)"/>
     <rect x="3.75" y="3.75" width="56.5" height="56.5" rx="17.25" fill="none" stroke="url(#brand)" stroke-opacity="0.46" stroke-width="1.5"/>

--- a/github-pages/scripts/generate-content.mjs
+++ b/github-pages/scripts/generate-content.mjs
@@ -201,6 +201,7 @@ await cp(path.join(repoDir, "docs"), outputDir, {
   filter: (source) => ![".DS_Store", "plans"].includes(path.basename(source)),
 });
 await cp(path.join(siteDir, "public", "CNAME"), path.join(outputDir, "public", "CNAME"));
+await cp(path.join(repoDir, "docs/figure/reme-icon.svg"), path.join(outputDir, "public", "reme-icon.svg"));
 await cp(path.join(repoDir, "docs/figure/reme-logo-fashion.svg"), path.join(outputDir, "public", "reme-logo.svg"));
 
 const sourceMap = {};

--- a/github-pages/scripts/verify-build.mjs
+++ b/github-pages/scripts/verify-build.mjs
@@ -33,7 +33,7 @@ const requiredFiles = [
   "index.html",
   "404.html",
   "CNAME",
-  "favicon.svg",
+  "reme-icon.svg",
   "reme-logo.svg",
   "hashmap.json",
   "sitemap.xml",

--- a/github-pages/tests/generated-content.test.mjs
+++ b/github-pages/tests/generated-content.test.mjs
@@ -71,7 +71,7 @@ test("generates the callable Job reference from default.yaml", async () => {
 test("keeps generated content disposable and excludes internal plans", async () => {
   await assert.rejects(access(path.join(generatedDir, "plans")));
   await access(path.join(generatedDir, ".vitepress", "config.mts"));
-  await access(path.join(generatedDir, "public", "favicon.svg"));
+  await access(path.join(generatedDir, "public", "reme-icon.svg"));
   await access(path.join(generatedDir, "public", "reme-logo.svg"));
   assert.equal(
     (await readFile(path.join(generatedDir, "public", "CNAME"), "utf8")).trim(),


### PR DESCRIPTION
## Summary

Follow-up to #520.

- use the new glass ReMe icon through a dedicated `/reme-icon.svg` asset
- point both the document favicon and navigation brand at the new asset URL
- remove the obsolete `docs/public/favicon.svg` path to avoid stale browser and CDN caches
- update generated-content tests and build artifact verification

## Validation

- `npm test` in `github-pages` (7 tests passed)
- `npm run build` in `github-pages` (19 artifacts verified)
- targeted `pre-commit run --files ...`
- `git diff --check`