### PR TITLE
fix(embedding): retry 429 rate-limit errors instead of dropping the batch

### DIFF
--- a/reme/components/embedding_store/local_embedding_store.py
+++ b/reme/components/embedding_store/local_embedding_store.py
@@ -194,6 +194,10 @@ class LocalEmbeddingStore(BaseEmbeddingStore):
                 if attempt < self.max_retries - 1:
                     await asyncio.sleep(2**attempt)
             except Exception as error:
+                if self._is_rate_limited(error):
+                    if attempt < self.max_retries - 1:
+                        await asyncio.sleep(2**attempt)
+                    continue
                 if (
                     self.quota_retry_delay is not None
                     and self._is_insufficient_quota(error)
@@ -209,6 +213,17 @@ class LocalEmbeddingStore(BaseEmbeddingStore):
                 return None
         self.is_healthy = False
         return None
+
+    @staticmethod
+    def _is_rate_limited(error: Exception) -> bool:
+        """Recognize an OpenAI-compatible 429 response without importing a provider SDK."""
+        if getattr(error, "status_code", None) == 429:
+            return True
+        body = getattr(error, "body", None)
+        if not isinstance(body, dict):
+            return False
+        details = body.get("error", body)
+        return isinstance(details, dict) and details.get("code") == "rate_limit_exceeded"
 
     @staticmethod
     def _is_insufficient_quota(error: Exception) -> bool:

--- a/reme/components/embedding_store/local_embedding_store.py
+++ b/reme/components/embedding_store/local_embedding_store.py
@@ -196,8 +196,13 @@ class LocalEmbeddingStore(BaseEmbeddingStore):
             except Exception as error:
                 if self._is_rate_limited(error):
                     if attempt < self.max_retries - 1:
-                        await asyncio.sleep(2**attempt)
-                    continue
+                        delay = 2**attempt
+                        self.logger.warning(f"Embedding rate limited; retrying in {delay:.1f}s")
+                        await asyncio.sleep(delay)
+                        continue
+                    self.logger.exception("Embedding request failed after exhausting rate-limit retries")
+                    self.is_healthy = False
+                    return None
                 if (
                     self.quota_retry_delay is not None
                     and self._is_insufficient_quota(error)

--- a/reme/components/embedding_store/local_embedding_store.py
+++ b/reme/components/embedding_store/local_embedding_store.py
@@ -217,6 +217,8 @@ class LocalEmbeddingStore(BaseEmbeddingStore):
     @staticmethod
     def _is_rate_limited(error: Exception) -> bool:
         """Recognize an OpenAI-compatible 429 response without importing a provider SDK."""
+        if LocalEmbeddingStore._is_insufficient_quota(error):
+            return False
         if getattr(error, "status_code", None) == 429:
             return True
         body = getattr(error, "body", None)

--- a/tests/unit/test_local_embedding_store.py
+++ b/tests/unit/test_local_embedding_store.py
@@ -76,6 +76,40 @@ class InsufficientQuotaError(Exception):
     body = {"error": {"code": "insufficient_quota"}}
 
 
+class RateLimitError(Exception):
+    """OpenAI-compatible 429 error used without importing the provider SDK."""
+
+    status_code = 429
+
+
+class RateLimitedThenSuccessAsEmbedding:
+    """Fail once with a 429, then return a valid embedding."""
+
+    dimensions = 2
+
+    def __init__(self):
+        self.calls = 0
+
+    async def __call__(self, texts: list[str], **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            raise RateLimitError("Requests are too frequent")
+        return [[1.0, 0.0] for _ in texts]
+
+
+class AlwaysRateLimitedAsEmbedding:
+    """Always fail with a 429."""
+
+    dimensions = 2
+
+    def __init__(self):
+        self.calls = 0
+
+    async def __call__(self, _texts: list[str], **_kwargs):
+        self.calls += 1
+        raise RateLimitError("Requests are too frequent")
+
+
 class QuotaThenSuccessAsEmbedding:
     """Fail once for quota, then return a valid embedding."""
 
@@ -266,6 +300,71 @@ def test_insufficient_quota_does_not_retry_without_opt_in(monkeypatch):
         assert result is None
         assert embedding.calls == 1
         assert not sleeps
+
+    run(go())
+
+
+def test_rate_limit_retries_with_backoff_without_opt_in(monkeypatch):
+    """A 429 must retry like a network error, with no quota_retry_delay required."""
+
+    async def go():
+        sleeps = []
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        store = LocalEmbeddingStore(name="t_local_embedding_rate_limit", max_retries=2)
+        embedding = RateLimitedThenSuccessAsEmbedding()
+        store.as_embedding = embedding
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        result = await store._call_with_retry(["text"])
+
+        assert result == [[1.0, 0.0]]
+        assert embedding.calls == 2
+        assert sleeps == [1.0]
+
+    run(go())
+
+
+def test_is_rate_limited_recognizes_status_code_or_body_and_nothing_else():
+    """A 429 is recognized either by status_code or a body-embedded code, never by guesswork."""
+
+    class StatusCodeError(Exception):
+        """A 429 identified by an HTTP status code attribute."""
+
+        status_code = 429
+
+    class BodyCodeError(Exception):
+        """A 429 identified only by a body-embedded error code."""
+
+        body = {"error": {"code": "rate_limit_exceeded"}}
+
+    assert LocalEmbeddingStore._is_rate_limited(StatusCodeError())
+    assert LocalEmbeddingStore._is_rate_limited(BodyCodeError())
+    assert not LocalEmbeddingStore._is_rate_limited(ValueError("unrelated"))
+
+
+def test_rate_limit_exhausts_retries_and_reports_unhealthy(monkeypatch):
+    """Repeated 429s still give up after max_retries, unlike an unclassified error."""
+
+    async def go():
+        sleeps = []
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        store = LocalEmbeddingStore(name="t_local_embedding_rate_limit_exhausted", max_retries=3)
+        embedding = AlwaysRateLimitedAsEmbedding()
+        store.as_embedding = embedding
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        result = await store._call_with_retry(["text"])
+
+        assert result is None
+        assert store.is_healthy is False
+        assert embedding.calls == 3
+        assert sleeps == [1.0, 2.0]
 
     run(go())
 

--- a/tests/unit/test_local_embedding_store.py
+++ b/tests/unit/test_local_embedding_store.py
@@ -73,6 +73,7 @@ class FakeProviderModel:
 class InsufficientQuotaError(Exception):
     """OpenAI-compatible quota error used without importing the provider SDK."""
 
+    status_code = 429
     body = {"error": {"code": "insufficient_quota"}}
 
 
@@ -343,6 +344,13 @@ def test_is_rate_limited_recognizes_status_code_or_body_and_nothing_else():
     assert LocalEmbeddingStore._is_rate_limited(StatusCodeError())
     assert LocalEmbeddingStore._is_rate_limited(BodyCodeError())
     assert not LocalEmbeddingStore._is_rate_limited(ValueError("unrelated"))
+
+
+def test_is_rate_limited_defers_to_insufficient_quota_on_status_code_429():
+    """An insufficient_quota error carrying status_code=429 is not the generic rate-limit case."""
+
+    assert not LocalEmbeddingStore._is_rate_limited(InsufficientQuotaError("quota exhausted"))
+    assert LocalEmbeddingStore._is_insufficient_quota(InsufficientQuotaError("quota exhausted"))
 
 
 def test_rate_limit_exhausts_retries_and_reports_unhealthy(monkeypatch):


### PR DESCRIPTION
Added `_is_rate_limited` right next to `_is_insufficient_quota`, built the same way (checks `status_code` then a body-embedded code, no SDK import), and route a 429 through the same exponential backoff `TimeoutError`/`ConnectionError`/`OSError` already get. It isn't gated behind `quota_retry_delay` like the quota branch: a rate limit is transient by definition, so it always retries now.

I scoped this to 429 only. You also mentioned "probably transient 5xx" and backoff jitter; I didn't reproduce either being needed here and didn't want to guess past what the issue actually shows, so both are left out.

Fixes #523.
