### PR TITLE
feat: add subject-scoped memory recall

### DIFF
--- a/docs/en/auto_dream.md
+++ b/docs/en/auto_dream.md
@@ -81,10 +81,15 @@ The main outputs are:
 2. Scan those day indexes and `daily/<date>/**/*.md`, comparing mtimes with `file_catalog: dream`.
 3. Send all changed files together to the LLM and globally extract structured memory `units`.
 
-`units` are long-term memory units ready to be distilled into digest. Each has `name`, `bucket`, `summary`, and `paths`.
+`units` are long-term memory units ready to be distilled into digest. Each has `name`, `bucket`, `summary`, and `paths`,
+plus a normalized `subject` when its source files have one, or `shared: true` for explicit workspace-shared knowledge.
 A run returns at most `max_units`; extraction merges cross-file evidence for the same abstraction and drops passing
 mentions, per-file summaries, and weak candidates without reusable value. `bucket` may only be `procedure`, `personal`,
 or `wiki`; unknown values are routed to `wiki`.
+
+Extract receives the normalized frontmatter scope for every changed path. It never merges paths with different non-empty
+subjects; Integrate refuses to update a digest node with an incompatible subject or missing `shared: true`. New digest nodes
+inherit the unit scope after the agent writes them, preventing model-level deduplication from collapsing different actors.
 
 If there are no changed files, Extract succeeds with no units; Integrate then has no unit work, and Finish still
 performs its normal catalog summary. If files changed but no LLM is

--- a/docs/en/auto_memory.md
+++ b/docs/en/auto_memory.md
@@ -61,6 +61,20 @@ This keeps different conversations separate without forcing opaque IDs into file
 `session_id` or `source_conversation`; if the Agent supplies a better frontmatter `name`, the system can rename the note and
 retarget inbound wikilinks. To see what happened on a day, start with `YYYY-MM-DD.md`.
 
+### Subject-scoped memory
+
+Pass an optional stable `subject` when the conversation belongs to a person, team, or project:
+
+```bash
+reme auto_memory subject=project-alpha session_id=session-a date=2026-06-20 \
+  messages='[{"role":"user","content":"The deployment uses a blue-green rollout."}]'
+```
+
+The caller owns this identity. Auto Memory writes the exact value as `subject`, refuses to update an existing card whose
+canonical subject (or legacy `target` alias) conflicts, and repairs model-written frontmatter after a successful write.
+Calls without a subject remain backward compatible. Subject-independent knowledge must be marked `shared: true` explicitly;
+it is then eligible for every subject-scoped search.
+
 ## Preserving the Original Information
 
 The distilled daily note is optimized for readability; a filtered source conversation record is retained for trust and

--- a/docs/en/memory_as_file.md
+++ b/docs/en/memory_as_file.md
@@ -158,8 +158,14 @@ source_conversation: [[session/dialog/abc.jsonl]]
 ---
 ```
 
-The current code recognizes `name` and `description` explicitly. Other fields are preserved as additional metadata. The
-write interface merges `name`, `description`, and `metadata` into frontmatter.
+The current code recognizes `name`, `description`, `subject`, and `shared` explicitly. Other fields are preserved as
+additional metadata. `subject` is the canonical stable identity of the person, team, or project a memory is about. Older
+files may use `target`; it is read as an alias only when `subject` is absent, and `subject` wins if both are present.
+Use `shared: true` to mark subject-independent workspace knowledge explicitly. A missing subject does not imply shared
+memory. The write interface merges `name`, `description`, and `metadata` into frontmatter.
+
+For example, a subject-scoped daily card can use `subject: project-alpha`, while a reusable workspace-wide procedure
+can use `shared: true` and `kind: procedure`.
 
 Treat frontmatter as a node-level summary and the body as evidence, explanation, and relationships. For example:
 
@@ -238,8 +244,9 @@ FileLink
 Older documents containing wrappers such as `related:: [[path]]`,
 `- related:: [[path]]`, or `[related:: [[path]]]` remain readable. ReMe ignores the surrounding text and indexes the
 inner `[[path]]` as an ordinary link. Graph changes are applied when source files pass through the normal ingestion
-path. `reme reindex` only rebuilds BM25 and embedding indexes from existing chunks; it does not reparse files or rebuild
-the derived graph.
+path. `reme reindex` with the default `scope: all` clears and rebuilds source-derived chunks from watched Markdown files,
+then rebuilds BM25, embeddings, tags, and the derived graph. This is the migration path for frontmatter-derived fields
+such as `subject`; narrow scopes (`bm25`, `embedding`, `tag`) remain index-only operations.
 
 ### Sources and Relationships
 

--- a/docs/en/memory_search.md
+++ b/docs/en/memory_search.md
@@ -3,8 +3,8 @@
 Memory Search is ReMe's memory retrieval entry point. The default background loop continuously builds Markdown under
 `daily/` and `digest/` into a searchable chunk index and wikilink graph. At query time, it first recalls the most
 relevant fragments and then expands context along the bidirectional links of the files containing those fragments.
-`reme reindex` rebuilds derived BM25 and embedding indexes from the authoritative in-memory `file_chunks`; it does not
-rescan workspace files, rechunk content, or rewrite the wikilink graph.
+`reme reindex` with `scope: all` reparses watched Markdown source files before rebuilding derived chunks, BM25, embeddings,
+tags, and the wikilink graph. This makes frontmatter-derived metadata rebuildable. Narrow scopes remain index-only.
 
 <p align="center">
   <img src="../figure/auto-index-and-memory-search.svg" alt="ReMe Auto Index and Memory Search indexing, recall, fusion, and link expansion" width="92%">
@@ -29,8 +29,8 @@ The default `index_update_loop` watches two memory directories:
 - `digest_dir`: long-term distilled digest nodes.
 
 The live watcher handles only the `md` suffix. A separate `resource_watch_loop` watches `resource_dir`, and Auto
-Resource turns those inputs into daily cards that enter the live index. Manual `reindex` operates on chunks already
-accepted by those ingestion paths and therefore does not expand the set of searched files.
+Resource turns those inputs into daily cards that enter the live index. Manual `reindex` with its default `scope: all`
+rebuilds the same watched source boundary while refreshing frontmatter-derived chunk metadata.
 
 ## How the Index Is Built
 
@@ -122,8 +122,8 @@ Embedded integrations that have already verified a provider can call `resume_emb
 missing vectors in the same vector space. Vector-space changes must use the explicit `reindex` job with
 `scope: embedding`; vector search remains unavailable until that job finishes successfully.
 Use `scope: bm25` to rebuild only keyword search, or `scope: tag` to rebuild the optional tag index from the current
-file graph. `scope: all` rebuilds BM25 first, then embeddings, and finally tags. BM25 and embedding rebuilds use the
-current `file_chunks` snapshot; the tag rebuild uses `FileNode` frontmatter from the file graph.
+file graph. `scope: all` reparses watched Markdown first, then rebuilds BM25, embeddings, and tags. The source files are
+therefore authoritative for chunk metadata such as `subject`.
 
 ## How to Search
 
@@ -139,6 +139,7 @@ search:
     min_score: number
     start_date: string
     end_date: string
+    subject: string
   steps:
     - backend: search_step
       vector_weight: 0.7
@@ -152,6 +153,15 @@ Call it with:
 ```bash
 reme search query="recent discussions about indexing" limit=5
 ```
+
+To recall memory for one person, team, or project while still allowing explicitly shared workspace knowledge:
+
+```bash
+reme search query="deployment decision" subject=project-alpha limit=10
+```
+
+Subject filtering is `subject == project-alpha OR shared == true`. Files with neither a matching subject nor an explicit
+`shared: true` marker are excluded; a missing subject is not treated as shared.
 
 Use `start_date` and `end_date` for inclusive `YYYY-MM-DD` filtering:
 

--- a/docs/zh/auto_dream.md
+++ b/docs/zh/auto_dream.md
@@ -78,9 +78,14 @@ Auto Dream 只扫描 Markdown 日期索引和笔记，不读取 proactive 状态
 2. 扫描这些日期的索引页和 `daily/<date>/**/*.md`，与 `file_catalog: dream` 中记录的 mtime 对比。
 3. 只把 changed files 一起交给 LLM，全局抽取结构化 memory `units`。
 
-`units` 是准备沉淀进 digest 的长期记忆单元，包含 `name`、`bucket`、`summary`、`paths`。一次最多返回 `max_units`
+`units` 是准备沉淀进 digest 的长期记忆单元，包含 `name`、`bucket`、`summary`、`paths`；来源有作用域时还会包含规范化的
+`subject`，明确共享的 workspace 知识才包含 `shared: true`。一次最多返回 `max_units`
 个，抽取器会优先合并指向同一抽象的跨文件证据，并丢弃短暂提及、逐文件摘要和缺少复用价值的弱候选。`bucket` 只允许
 `procedure`、`personal`、`wiki`；未知值会路由到 `wiki`。
+
+Extract 会接收每个 changed path 的规范化 frontmatter 作用域，绝不会把不同 non-empty subject 的 path 合并进同一 unit；
+Integrate 也会拒绝更新 subject 不兼容或缺少 `shared: true` 的 digest node。Agent 写入新节点后，系统会补齐 unit 的作用域，避免
+模型层面的去重把不同主体错误合并成一条记忆。
 
 如果没有 changed files，Extract 会成功返回空 units；Integrate 随后没有 unit 可处理，Finish 仍会正常汇总 catalog。
 如果有变化但没有配置 LLM，Extract 会失败，因为抽取依赖 LLM。

--- a/docs/zh/auto_memory.md
+++ b/docs/zh/auto_memory.md
@@ -55,6 +55,19 @@ source_conversation: "[[session/dialog/session-a.jsonl]]"
 这样既能分开不同对话，又不必把不透明的 ID 当文件名。更新时会按 `session_id` 或 `source_conversation` 找到旧卡片；如果 Agent
 提供了更好的 frontmatter `name`，系统可重命名并重定向入链。查看某天内容时从 `YYYY-MM-DD.md` 开始。
 
+### Subject 作用域记忆
+
+如果对话属于某个人、团队或项目，可以传入稳定的 `subject`：
+
+```bash
+reme auto_memory subject=project-alpha session_id=session-a date=2026-06-20 \
+  messages='[{"role":"user","content":"部署采用 blue-green rollout。"}]'
+```
+
+这个身份由调用方拥有。Auto Memory 会把原值写入 `subject`；如果已有卡片的规范 subject（或旧 `target` 别名）冲突，会拒绝更新；
+成功写入后即使模型写错 frontmatter，也会由系统修复。未传 subject 的调用保持向后兼容。与 subject 无关、要对所有 workspace 共享的
+知识必须显式标记 `shared: true`，之后才会进入每个 subject-scoped search。
+
 ## 同时保存原始信息
 
 整理后的 daily note 负责“好读”，过滤后的对话来源记录负责“可信”。

--- a/docs/zh/memory_as_file.md
+++ b/docs/zh/memory_as_file.md
@@ -143,8 +143,13 @@ source_conversation: [[session/dialog/abc.jsonl]]
 ---
 ```
 
-当前代码固定识别 `name` 和 `description`，其他字段会作为额外 metadata 保留。写入接口会把 `name`、`description` 和
-`metadata` 合并成 frontmatter。
+当前代码固定识别 `name`、`description`、`subject` 和 `shared`，其他字段会作为额外 metadata 保留。`subject` 是记忆所
+对应的人、团队或项目的规范稳定身份。旧文件可以使用 `target`；只有在没有 `subject` 时才把它作为读取别名，如果两者
+同时存在则以 `subject` 为准。与 subject 无关、要在 workspace 共享的知识必须显式使用 `shared: true`；缺失 subject
+不等于 shared。写入接口会把 `name`、`description` 和 `metadata` 合并成 frontmatter。
+
+例如，subject 作用域的 daily 卡片可以写 `subject: project-alpha`；可复用、面向整个 workspace 的流程可以写
+`shared: true` 和 `kind: procedure`。
 
 推荐把 frontmatter 当作“节点级摘要”，把正文当作“证据、解释和关系”。例如：
 
@@ -219,8 +224,9 @@ FileLink
 
 旧文档中的 `related:: [[path]]`、`- related:: [[path]]` 或
 `[related:: [[path]]]` 仍然可以读取。ReMe 会忽略外围文本，把内部 `[[path]]`
-作为普通链接建立索引。源文件通过正常摄取路径时会应用图谱变更。`reme reindex` 只基于现有 chunks 重建 BM25 和 Embedding
-索引，不会重新解析文件或重建派生图谱。
+作为普通链接建立索引。源文件通过正常摄取路径时会应用图谱变更。默认 `scope: all` 的 `reme reindex` 会清理并从监听的
+Markdown 源文件重建 chunks，再重建 BM25、Embedding、tag 和派生图谱；新增或修正 `subject` 这类 frontmatter 派生字段时应
+使用它完成迁移。较窄的 `bm25`、`embedding`、`tag` scope 仍然只重建对应索引。
 
 ### 来源和关系
 

--- a/docs/zh/memory_search.md
+++ b/docs/zh/memory_search.md
@@ -2,7 +2,8 @@
 
 Memory Search 是 ReMe 的记忆检索入口。默认后台持续把 `daily/`、`digest/` 里的 Markdown 构建成可搜索的 chunk 索引和
 wikilink 图谱；查询时先召回最相关的片段，再沿着片段所在文件的双向链接展开上下文。`reme reindex` 以权威的内存态
-`file_chunks` 为输入重建派生的 BM25 和 Embedding 索引；它不会重新扫描工作区、重新分块或改写 wikilink 图谱。
+默认 `scope: all` 的 `reme reindex` 会先重新解析监听的 Markdown 源文件，再重建派生 chunks、BM25、Embedding、tag 和
+wikilink 图谱，因此 frontmatter 派生 metadata 可以从源文件恢复。较窄的 scope 仍然只重建对应索引。
 
 <p align="center">
   <img src="../figure/auto-index-and-memory-search.svg" alt="ReMe Auto Index and Memory Search 索引、召回、融合与链接展开流程" width="92%">
@@ -26,7 +27,7 @@ workspace files
 - `digest_dir`：长期沉淀后的 digest 节点。
 
 默认实时后缀只有 `md`。`resource_dir` 由独立的 `resource_watch_loop` 监听，并经 Auto Resource 转换成 daily 卡片后进入实时索引。
-手动 `reindex` 只处理这些摄取路径已经接受的 chunk，因此不会扩大搜索文件范围。
+默认 `scope: all` 的手动 `reindex` 仍然只处理同一组监听目录，但会刷新 frontmatter 派生的 chunk metadata。
 
 ## 索引怎么构建
 
@@ -110,9 +111,8 @@ Embedding store 可通过 `health_check_timeout` 配置启动探测。临时失�
 
 已经完成真实服务验证的嵌入式集成可以调用 `resume_embedding(verified=True)`，修复同一向量空间内缺失的向量。
 切换 Embedding 向量空间必须显式运行 `reindex` Job，并传入 `scope: embedding`；该 Job 成功完成前向量搜索保持不可用。
-`scope: bm25` 只重建关键词索引；`scope: tag` 从当前文件图重建可选的标签索引；`scope: all` 依次重建
-BM25、Embedding 和标签索引。BM25 和 Embedding 使用当前的 `file_chunks` 快照，标签索引使用文件图中
-`FileNode` 的 frontmatter。
+`scope: bm25` 只重建关键词索引；`scope: tag` 从当前文件图重建可选的标签索引；`scope: all` 会先重新解析监听的 Markdown，
+再依次重建 BM25、Embedding 和标签索引。因此 `subject` 这类 chunk metadata 以源文件为准。
 
 ## 怎么搜索
 
@@ -128,6 +128,7 @@ search:
     min_score: number
     start_date: string
     end_date: string
+    subject: string
   steps:
     - backend: search_step
       vector_weight: 0.7
@@ -141,6 +142,15 @@ search:
 ```bash
 reme search query="最近关于索引的讨论" limit=5
 ```
+
+如果要按人、团队或项目召回，同时保留明确标记为共享的 workspace 知识：
+
+```bash
+reme search query="部署决策" subject=project-alpha limit=10
+```
+
+subject 过滤策略是 `subject == project-alpha OR shared == true`。既没有匹配 subject、也没有显式 `shared: true` 的文件会
+被排除；缺失 subject 不会自动视作 shared。
 
 `start_date` 和 `end_date` 可以按 `YYYY-MM-DD` 做包含边界的日期过滤：
 

--- a/reme/components/file_chunker/markdown_file_chunker.py
+++ b/reme/components/file_chunker/markdown_file_chunker.py
@@ -30,6 +30,8 @@ from ...schema import (
     FileChunk,
     FileFrontMatter,
     FileNode,
+    is_shared_memory,
+    normalized_subject,
 )
 from ...utils.wikilink_handler import WikilinkHandler
 
@@ -145,10 +147,17 @@ class MarkdownFileChunker(DefaultFileChunker):
                 with MarkdownRenderer() as renderer:
                     tree = self._build_tree(Document(content), renderer, line_offset=line_offset)
                     chunks = self._chunk_node(tree, (), rel_path, renderer)
-            if self.include_frontmatter_in_metadata:
+            # Subject scope is retrieval-critical and survives the historical
+            # opt-in gate even when a caller does not copy all frontmatter.
+            if self.include_frontmatter_in_metadata or normalized_subject(front_matter) or is_shared_memory(front_matter):
+                allow_keys = self.include_frontmatter_keys_in_metadata or None
+                if not self.include_frontmatter_in_metadata and allow_keys is None:
+                    # Scope fields are the only frontmatter that retrieval must
+                    # inherit when the historical opt-in flag remains false.
+                    allow_keys = ["subject", "shared", "kind"]
                 chunk_metadata = self._chunk_metadata(
                     front_matter,
-                    allow_keys=self.include_frontmatter_keys_in_metadata or None,
+                    allow_keys=allow_keys,
                 )
                 for chunk in chunks:
                     chunk.metadata = chunk_metadata.copy()
@@ -257,7 +266,14 @@ class MarkdownFileChunker(DefaultFileChunker):
         ``allow_keys`` (when non-empty) restricts the output to that subset of
         field names; absent or empty means "all fields with non-empty values".
         """
-        dumped = front_matter.model_dump(mode="json")
+        dumped = front_matter.model_dump(mode="json", exclude_none=True)
+        # Do not expose the overloaded legacy key to retrieval. Normalize it
+        # into the one canonical key so old and new files share a filter shape.
+        dumped.pop("target", None)
+        if subject := normalized_subject(front_matter):
+            dumped["subject"] = subject
+        if not is_shared_memory(front_matter):
+            dumped.pop("shared", None)
         filtered = dumped if not allow_keys else {k: dumped.get(k) for k in allow_keys if k in dumped}
         return {key: value for key, value in filtered.items() if value not in (None, "")}
 

--- a/reme/components/file_store/local_file_store.py
+++ b/reme/components/file_store/local_file_store.py
@@ -1061,6 +1061,15 @@ class LocalFileStore(BaseFileStore):
                 return False
 
         metadata_filter = dict(search_filter.get("metadata") or {})
+        metadata_any = search_filter.get("metadata_any") or []
+        if isinstance(metadata_any, dict):
+            metadata_any = [metadata_any]
+        if metadata_any and not any(
+            isinstance(candidate, dict)
+            and all(cls._value_matches(chunk.metadata.get(key), value) for key, value in candidate.items())
+            for candidate in metadata_any
+        ):
+            return False
         reserved = {
             "path",
             "paths",
@@ -1069,6 +1078,7 @@ class LocalFileStore(BaseFileStore):
             "prefix",
             "prefixes",
             "metadata",
+            "metadata_any",
             "start_date",
             "end_date",
             "strict_date_filter",

--- a/reme/config/default.yaml
+++ b/reme/config/default.yaml
@@ -184,6 +184,10 @@ jobs:
           type: string
           description: "YYYY-MM-DD daily note date; empty = infer from message timestamps or today"
           default: ""
+        subject:
+          type: string
+          description: "optional stable person, team, or project identity this memory is about"
+          default: ""
       required:
         - messages
     steps:
@@ -390,7 +394,7 @@ jobs:
 
   reindex:
     backend: base
-    description: "rebuild BM25, embedding, and/or tag indexes without rescanning workspace files"
+    description: "reparse Markdown sources and rebuild BM25, embedding, and/or tag indexes"
     parameters:
       type: object
       properties:
@@ -398,6 +402,10 @@ jobs:
           type: string
           enum: [all, bm25, embedding, tag]
           default: all
+        rescan_sources:
+          type: boolean
+          description: "for scope=all, rebuild chunks from workspace Markdown before rebuilding indexes"
+          default: true
     steps:
       - backend: reindex_step
 
@@ -424,6 +432,10 @@ jobs:
         end_date:
           type: string
           description: "optional inclusive end date filter (YYYY-MM-DD); results later than this date are excluded"
+        subject:
+          type: string
+          description: "optional memory subject; includes exact subject matches and explicitly shared:true memory"
+          default: ""
       required:
         - query
     steps:
@@ -879,8 +891,8 @@ components:
       supported_extensions: [ "md" ]
       embed_toc: true
       max_ast_sections: 100
-      include_frontmatter_in_metadata: false
-      include_frontmatter_keys_in_metadata: []  # empty = all non-empty frontmatter keys
+      include_frontmatter_in_metadata: true
+      include_frontmatter_keys_in_metadata: [ "subject", "shared", "kind" ]
     json:
       backend: json
       supported_extensions: [ "json" ]

--- a/reme/schema/__init__.py
+++ b/reme/schema/__init__.py
@@ -15,7 +15,7 @@ from .proactive import (
 )
 from .emb_node import EmbNode
 from .file_chunk import FileChunk
-from .file_front_matter import FileFrontMatter
+from .file_front_matter import FileFrontMatter, is_shared_memory, normalized_subject, subject_scope
 from .graph_snapshot import GraphSnapshot, GraphSnapshotEdge, GraphSnapshotNode
 from .file_link import FileLink
 from .file_node import FileNode
@@ -34,6 +34,9 @@ __all__ = [
     "EmbNode",
     "FileChunk",
     "FileFrontMatter",
+    "is_shared_memory",
+    "normalized_subject",
+    "subject_scope",
     "FileLink",
     "FileNode",
     "GraphSnapshot",

--- a/reme/schema/dream.py
+++ b/reme/schema/dream.py
@@ -17,6 +17,8 @@ class DreamUnit(BaseModel):
     bucket: DreamBucketEnum = Field(description="Digest bucket; unknown raw values route to wiki before validation.")
     summary: str = Field(description="Grounded abstraction summary with evidence pointers.")
     paths: list[str] = Field(default_factory=list, description="Workspace-relative source paths.")
+    subject: str | None = Field(default=None, description="Normalized source memory subject, when scoped.")
+    shared: bool = Field(default=False, description="Whether the unit is explicitly workspace-shared.")
 
 
 class DreamExtractOutput(BaseModel):

--- a/reme/schema/file_front_matter.py
+++ b/reme/schema/file_front_matter.py
@@ -1,8 +1,14 @@
 """FileFrontMatter — parsed Markdown front matter."""
 
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+SUBJECT_KEY = "subject"
+LEGACY_SUBJECT_KEY = "target"
+SHARED_KEY = "shared"
 
 
 class FileFrontMatter(BaseModel):
@@ -12,6 +18,14 @@ class FileFrontMatter(BaseModel):
 
     name: str = Field(default="", description="Document name")
     description: str = Field(default="", description="Document description")
+    subject: str | None = Field(
+        default=None,
+        description="Canonical stable identity of the person, team, or project this memory is about.",
+    )
+    shared: bool | None = Field(
+        default=None,
+        description="Explicitly marks a subject-independent workspace-shared memory when true.",
+    )
 
     @property
     def model_extra(self) -> dict[str, Any] | None:
@@ -21,3 +35,41 @@ class FileFrontMatter(BaseModel):
             A dictionary of extra fields, or `None` if `config.extra` is not set to `"allow"`.
         """
         return self.__pydantic_extra__
+
+
+def _frontmatter_mapping(value: FileFrontMatter | Mapping | None) -> Mapping:
+    if isinstance(value, FileFrontMatter):
+        return value.model_dump(mode="python", exclude_none=True)
+    return value if isinstance(value, Mapping) else {}
+
+
+def normalized_subject(value: FileFrontMatter | Mapping | None) -> str | None:
+    """Return canonical ``subject``, falling back to legacy ``target``.
+
+    If both fields exist, ``subject`` wins. This makes migration deterministic
+    and prevents an old overloaded ``target`` value from overriding the new
+    canonical identity.
+    """
+    metadata = _frontmatter_mapping(value)
+    canonical = metadata.get(SUBJECT_KEY)
+    if canonical is not None and not isinstance(canonical, (dict, list, tuple, set)):
+        canonical_text = str(canonical).strip()
+        if canonical_text:
+            return canonical_text
+    legacy = metadata.get(LEGACY_SUBJECT_KEY)
+    if legacy is not None and not isinstance(legacy, (dict, list, tuple, set)):
+        legacy_text = str(legacy).strip()
+        if legacy_text:
+            return legacy_text
+    return None
+
+
+def is_shared_memory(value: FileFrontMatter | Mapping | None) -> bool:
+    """Return whether a file explicitly opts into workspace-shared recall."""
+    shared = _frontmatter_mapping(value).get(SHARED_KEY)
+    return shared is True or (isinstance(shared, str) and shared.strip().casefold() == "true")
+
+
+def subject_scope(value: FileFrontMatter | Mapping | None) -> dict[str, str | bool | None]:
+    """Return normalized subject scope used by indexing and Dream guards."""
+    return {SUBJECT_KEY: normalized_subject(value), SHARED_KEY: is_shared_memory(value)}

--- a/reme/steps/evolve/auto_memory.py
+++ b/reme/steps/evolve/auto_memory.py
@@ -14,6 +14,7 @@ from ..file_io import extract_daily_date, parse_daily_date, refresh_day_index
 from ..file_io import validate_filename_component, validate_session_id
 from ..index import normalize_posix_path
 from ...components import R
+from ...schema import normalized_subject
 
 _SESSION_ID_KEY = "session_id"
 _SOURCE_CONVERSATION_KEY = "source_conversation"
@@ -123,6 +124,17 @@ class AutoMemoryStep(BaseStep):
         """Whether this step should generate and normalize frontmatter tags."""
         return bool(self.kwargs.get("enable_tags", False))
 
+    def _requested_subject(self) -> str | None:
+        """Read the caller-owned subject as a scalar, preserving empty as unset."""
+        assert self.context is not None
+        raw = self.context.get("subject")
+        if raw in (None, ""):
+            return None
+        if isinstance(raw, (dict, list, tuple, set)):
+            raise ValueError("subject must be a scalar string")
+        subject = str(raw).strip()
+        return subject or None
+
     def _frontmatter(self, path: str) -> dict:
         post = frontmatter.loads((self.file_store.workspace_path / path).read_text(encoding="utf-8"))
         return dict(post.metadata or {})
@@ -158,12 +170,15 @@ class AutoMemoryStep(BaseStep):
         notes = list_response.metadata.get("notes") or []
         return self._find_session_note(notes, session_id)
 
-    async def _ensure_memory_frontmatter(self, path: str, session_id: str) -> None:
+    async def _ensure_memory_frontmatter(self, path: str, session_id: str, subject: str | None = None) -> None:
         current = self._frontmatter(path)
         metadata = {
             _SESSION_ID_KEY: session_id,
             _SOURCE_CONVERSATION_KEY: self._session_link(session_id),
         }
+        effective_subject = subject or normalized_subject(current)
+        if effective_subject:
+            metadata["subject"] = effective_subject
         if self._tags_enabled():
             metadata[_TAGS_KEY] = _normalize_tags(current.get(_TAGS_KEY))
         if all(current.get(key) == value for key, value in metadata.items()):
@@ -322,6 +337,13 @@ class AutoMemoryStep(BaseStep):
         session_id: str = self.context.get("session_id", "")
         memory_hint: str = self.context.get("memory_hint", "")
         raw_date = self.context.get("date", "")
+        try:
+            requested_subject = self._requested_subject()
+        except ValueError as exc:
+            self.context.response.success = False
+            self.context.response.answer = f"Error: {exc}"
+            self.context.response.metadata.update({"modified": False, "subject": self.context.get("subject")})
+            return
         tz = self.app_context.app_config.timezone if self.app_context is not None else None
         current = now(tz)
 
@@ -372,6 +394,17 @@ class AutoMemoryStep(BaseStep):
 
         note_path = str(note["path"]) if note else ""
         created = note is None
+        existing_subject = normalized_subject(self._frontmatter(note_path)) if note_path else None
+        if requested_subject and existing_subject and requested_subject != existing_subject:
+            message = f"subject mismatch: existing note is scoped to {existing_subject!r}"
+            self.context.response.success = False
+            self.context.response.answer = f"Error: {message}"
+            self.context.response.metadata.update(
+                {"date": day, "path": note_path, "created": False, "modified": False, "subject": existing_subject}
+            )
+            self.logger.warning(f"[{self.name}] {message} requested={requested_subject!r} path={note_path!r}")
+            return
+        effective_subject = requested_subject or existing_subject
         before_note_path = note_path
         before_note_bytes = self._note_bytes(note_path) if note_path else None
         self.logger.info(
@@ -387,7 +420,11 @@ class AutoMemoryStep(BaseStep):
             note_path=note_path,
             session_id=session_id,
             session_file=self._session_source_path(session_id),
+            subject=effective_subject or "(none)",
             history=self._format_history(messages),
+        )
+        user_message = (
+            f"Memory subject (immutable when supplied): {effective_subject or '(none)'}\n\n{user_message}"
         )
 
         self.logger.info(f"[{self.name}] agent start path={note_path} template={template_key}")
@@ -426,8 +463,8 @@ class AutoMemoryStep(BaseStep):
                 return
             note_path = str(note["path"])
         try:
-            if not created or self._tags_enabled():
-                await self._ensure_memory_frontmatter(note_path, session_id)
+            if not created or self._tags_enabled() or effective_subject:
+                await self._ensure_memory_frontmatter(note_path, session_id, effective_subject)
             if not created:
                 note_path = await self._rename_from_frontmatter_name(note_path, day)
         except RuntimeError as exc:
@@ -462,6 +499,7 @@ class AutoMemoryStep(BaseStep):
                 "modified": modified,
                 "n_messages": len(messages),
                 "source_conversation": source_conversation,
+                "subject": effective_subject,
                 "index": index_payload,
             },
         )

--- a/reme/steps/evolve/auto_memory.yaml
+++ b/reme/steps/evolve/auto_memory.yaml
@@ -20,6 +20,8 @@ system_prompt: |
 
   - `name` = a concise, stable topic/event filename stem, such as `cold-remedies` or `project-kickoff-decision`. Do not include today's date or the daily directory date; the outer daily path already records the date. For existing notes, update it when a better filename is clearly warranted.
   - `description` = a thorough summary; vague descriptions like "notes" / "misc" are unacceptable.
+  - `subject` is caller-supplied scope. When the prompt contains a concrete subject, copy it exactly into frontmatter and never invent, replace, or broaden it.
+  - The legacy `target` key may be read for older notes, but all new or repaired notes use `subject`. Use `shared: true` only when the memory is intentionally workspace-shared and subject-independent.
   [enable_tags] - `tags` = 0–8 unique retrieval keywords for the complete note. Always include the field, using `[]` when no useful tags exist. Each tag must be one string with no whitespace, may contain technical punctuation (for example `GPT-5`, `C++`, `C#`, or `.NET`), must contain at least one letter or digit, and must be at most 64 characters. Store numeric tags as strings, for example `"100"`.
   - **Never set `status`** — it is a field reserved for downstream processing.
 system_prompt_zh: |
@@ -44,6 +46,8 @@ system_prompt_zh: |
 
   - `name` = 简洁、稳定的主题/事件文件名 stem，例如 `cold-remedies` 或 `project-kickoff-decision`。不要包含今天日期或日记目录日期；外层日记路径已经记录日期。对已有笔记，如果明显有更好的文件名，就更新它。
   - `description` = 详细总结；模糊的描述如 "notes" / "misc" 不可接受。
+  - `subject` 是调用方提供的作用域。当提示中有明确 subject 时，必须原样写入 frontmatter，不能臆造、替换或扩大作用域。
+  - 旧笔记可以读取 legacy `target`，但新建或修复的笔记统一使用 `subject`。只有明确与 subject 无关、应在 workspace 共享的记忆才使用 `shared: true`。
   [enable_tags] - `tags` = 针对完整笔记的 0–8 个不重复检索关键词。该字段必须始终存在；没有合适关键词时使用 `[]`。每个 tag 必须是一个不含空白字符的字符串，可以包含技术名称中的标点（例如 `GPT-5`、`C++`、`C#` 或 `.NET`），必须至少包含一个字母或数字，且不得超过 64 个字符。数字 tag 也保存为字符串，例如 `"100"`。
   - **永远不要设置 `status`**——它是下游处理保留的字段。
 
@@ -76,6 +80,7 @@ user_message_create: |
   - Do not include today's date or the daily directory date in `name`; the note already lives under today's daily path.
   - `name` must be a valid single filename component: no slash, backslash, leading/trailing whitespace, or characters like `< > : " | ? *`.
   - `description` must be a thorough summary of the body — specific enough that the description alone conveys all key information.
+  - If a Memory subject was supplied by the caller, metadata must contain exactly that subject string. Do not derive a different subject from the conversation.
   [enable_tags] - Generate 0–8 `tags` from the complete note. Always pass `metadata={{"tags": [...]}}`, including an empty list when there are no useful tags. Follow the system prompt's tag format exactly.
 
   ## Step 3 — Summary
@@ -114,6 +119,7 @@ user_message_create_zh: |
   - `name` 不要包含今天日期或日记目录日期；笔记已经位于当天日记路径下。
   - `name` 必须是合法的单个文件名组件：不能包含 slash、反斜杠、首尾空白，或 `< > : " | ? *` 等字符。
   - `description` 必须是正文的详尽总结——具体到仅凭 description 就能传达全部核心信息。
+  - 如果 Memory subject 不是 `(none)`，必须在 metadata 中原样写入该 subject；不能根据对话改写或推导另一个 subject。
   [enable_tags] - 根据完整笔记生成 0–8 个 `tags`。必须始终传入 `metadata={{"tags": [...]}}`，没有合适关键词时也要传入空数组。严格遵守 system prompt 的 tag 格式。
 
   ## 步骤 3 — 总结
@@ -160,7 +166,7 @@ user_message_update: |
 
   Execution:
   1. Use `edit path={note_path} old=<original fragment> new=<replacement fragment>` for each section that needs updating. You may call `edit` multiple times.
-  2. After body changes, refresh frontmatter with `frontmatter_update path={note_path} metadata={{"name": "<updated filename stem>", "description": "<updated summary>"}}`.
+  2. After body changes, refresh frontmatter with `frontmatter_update path={note_path} metadata={{"name": "<updated filename stem>", "description": "<updated summary>", "subject": "<exact Memory subject>"}}` when a concrete subject was supplied. The subject value is immutable.
   [enable_tags]    Also regenerate 0–8 tags from the complete merged note and include `"tags": [<tag>, ...]` in the same metadata object. Always include `tags`, using `[]` when none are useful.
      - Keep the existing `name` only when it is already the best concise topic/event filename stem. The system will rename the file after your final response.
      - Do not add today's date or the daily directory date to `name`.
@@ -174,6 +180,7 @@ user_message_update: |
   [enable_tags] Also pass `metadata={{"tags": [<tag>, ...]}}` in this call.
 
   - Use a concise, stable topic/event `name`; filename changes are applied after your final response.
+  - Preserve the immutable Memory subject exactly when it is not `(none)`; do not change it while updating the body.
   - Do not include today's date or the daily directory date in `name`.
   - `description` must be a thorough summary of the body — specific enough that the description alone conveys all key information.
   [enable_tags] - Generate 0–8 tags from the complete body and always include `metadata={{"tags": [...]}}`, using `[]` when none are useful.
@@ -209,6 +216,7 @@ user_message_update_zh: |
   ## 步骤 2 — 读取现有内容
 
   调用 `read path={note_path}` 查看当前笔记内容。
+  Memory subject（如有则不可修改）由调用方提供，必须原样保留。
   - 如果正文为空（只有 frontmatter 无实际内容）→ 按新建处理，跳到 **步骤 3b**。
   - 如果有正文内容 → 转到 **步骤 3a** 进行合并。
 

--- a/reme/steps/evolve/dream/extract.py
+++ b/reme/steps/evolve/dream/extract.py
@@ -1,13 +1,16 @@
 """Global dream extract step."""
 
 import json
+from pathlib import Path
+
+import frontmatter
 
 from ...base_step import BaseStep
 from ...file_io import refresh_day_index
 from .._evolve import agent_reply_result_text
 from ....components import R
 from ....enumeration import DreamBucketEnum
-from ....schema import DreamState
+from ....schema import DreamState, is_shared_memory, normalized_subject
 from .utils import (
     clean_paths,
     daily_dir,
@@ -32,6 +35,7 @@ class DreamExtractStep(BaseStep):
         super().__init__(**kwargs)
         self.scan_days = scan_days
         self.max_units = max_units
+        self._path_scopes: dict[str, dict] = {}
 
     async def execute(self):
         assert self.context is not None
@@ -106,6 +110,7 @@ class DreamExtractStep(BaseStep):
         if not changed:
             self.logger.info(f"[{self.name}] skip no changed input dates={','.join(dates)}")
             return self._finish(state, True, f"No changed dream input for {', '.join(dates)}")
+        self._path_scopes = self._load_path_scopes(workspace, changed)
         if not llm_available(self):
             state.errors.append("no llm configured; dream extract requires an LLM")
             state.failed_paths = list(changed)
@@ -124,6 +129,7 @@ class DreamExtractStep(BaseStep):
                         hint=hint or "(none)",
                         max_units=max_units,
                         changed_paths_json=json.dumps(changed, ensure_ascii=False, indent=2),
+                        path_scopes_json=json.dumps(self._path_scopes, ensure_ascii=False, indent=2),
                         material_blob=pack_paths(workspace, changed),
                     ),
                     system_prompt=self.prompt_format(
@@ -176,6 +182,21 @@ class DreamExtractStep(BaseStep):
                 self.logger.error(f"[{self.name}] stat failed on {rel}: {e}")
         return out
 
+    @staticmethod
+    def _load_path_scopes(workspace: Path, paths: list[str]) -> dict[str, dict]:
+        """Read source scopes once; model output cannot broaden them later."""
+        scopes: dict[str, dict] = {}
+        for path in paths:
+            try:
+                post = frontmatter.loads((workspace / path).read_text(encoding="utf-8"))
+                scopes[path] = {
+                    "subject": normalized_subject(post.metadata),
+                    "shared": is_shared_memory(post.metadata),
+                }
+            except (OSError, UnicodeError, ValueError):
+                scopes[path] = {"subject": None, "shared": False}
+        return scopes
+
     def clean_output(self, state: DreamState, meta: dict, max_units: int | None = None) -> None:
         """Clean up output"""
         allowed = set(state.changed_paths)
@@ -190,12 +211,30 @@ class DreamExtractStep(BaseStep):
             paths = clean_paths(raw.get("paths"), allowed)
             if not name or not summary or not paths:
                 continue
+            source_scopes = [self._path_scopes[path] for path in paths if path in self._path_scopes]
+            source_subjects = {scope["subject"] for scope in source_scopes if scope.get("subject")}
+            if len(source_subjects) > 1:
+                self.logger.warning(
+                    f"[{self.name}] unit {name!r} spans incompatible subjects; dropping merged unit",
+                )
+                state.warnings.append(f"unit {name!r} dropped because its source paths have different subjects")
+                continue
+            subject = next(iter(source_subjects), None)
+            shared = bool(source_scopes) and any(scope.get("shared") for scope in source_scopes) and not subject
+            if not source_scopes:
+                subject = normalized_subject({"subject": raw.get("subject")})
+                shared = bool(raw.get("shared")) and not subject
             try:
                 bucket = DreamBucketEnum(raw_bucket).value
             except ValueError:
                 self.logger.warning(f"[{self.name}] unit {name!r} emitted bucket {raw_bucket!r}; routing to wiki")
                 bucket = DreamBucketEnum.WIKI.value
-            state.units.append({"name": name, "bucket": bucket, "summary": summary, "paths": paths})
+            unit = {"name": name, "bucket": bucket, "summary": summary, "paths": paths}
+            if subject:
+                unit["subject"] = subject
+            if shared:
+                unit["shared"] = True
+            state.units.append(unit)
 
     def _finish(self, state: DreamState, success: bool, answer: str):
         assert self.context is not None

--- a/reme/steps/evolve/dream/extract.yaml
+++ b/reme/steps/evolve/dream/extract.yaml
@@ -10,6 +10,14 @@ extract_system_prompt: |
   keeps reusable principles, patterns, precedents, workflows, conventions, and
   user/team preferences a future agent should recall.
 
+  ## Subject scope
+
+  Each changed path has a source scope in `path_scopes`. Merge paths only when
+  their non-empty subjects are identical. Never merge evidence belonging to
+  different subjects into one unit. A unit with `shared: true` is explicitly
+  workspace-shared and subject-independent; do not infer that flag from a
+  missing subject.
+
   ## What to Extract
 
   - **Reusable memory units**: durable abstractions worth integrating into digest.
@@ -32,7 +40,7 @@ extract_system_prompt: |
     situations, or when they will evolve independently as more material arrives.
   - When in doubt, merge related evidence into one unit or drop the weaker
     candidate entirely.
-  - Each unit must have name, bucket, summary, and paths.
+  - Each unit must have name, bucket, summary, and paths. Include `subject` when the source scope has one, or `shared: true` only for an explicitly shared source scope.
   - paths must only contain values from changed_paths.
   - Unknown bucket is invalid; if unsure, use wiki.
   - Do not emit passing mentions, known-concept recaps, umbrella event units,
@@ -78,6 +86,12 @@ extract_system_prompt_zh: |
   Digest 是抽象记忆层。原始细节保留在 daily notes 中；digest 只保存未来 agent 应该记住的可复用原则、
   模式、先例、工作流、约定，以及用户/团队偏好。
 
+  ## Subject 作用域
+
+  `path_scopes` 给出每个 changed path 的来源作用域。只有 non-empty subject 完全相同的 path 才能合并；
+  绝不能把不同 subject 的证据合并到同一个 unit。`shared: true` 表示明确的 workspace 共享、与 subject 无关的
+  内容；不能因为 subject 缺失就自行推断 shared。
+
   ## 抽取什么
 
   - **可复用记忆 unit**：值得整合进 digest 的长期抽象。
@@ -93,7 +107,7 @@ extract_system_prompt_zh: |
   - 返回的 units 数量不能超过 max_units。如果候选更多，只保留最强、最可复用的抽象，丢掉较弱候选。
   - 只有当两个抽象会在未来不同场景被召回，或会随着更多材料独立演化时，才拆成两个 unit。
   - 不确定时，把相关证据合并成一个 unit，或直接丢掉较弱候选。
-  - 每个 unit 必须包含 name、bucket、summary、paths。
+  - 每个 unit 必须包含 name、bucket、summary、paths。有 source subject 时写入 `subject`；只有明确共享的来源才写 `shared: true`。
   - paths 只能使用 changed_paths 中出现的值。
   - Unknown bucket 无效；不确定时使用 wiki。
   - 不要输出 passing mention、已知概念复述、事件 umbrella unit、一次性时间戳、参会事实、
@@ -132,8 +146,11 @@ extract_user_message: |
   hint: {hint}
   max_units: {max_units}
 
-  changed_paths:
-  {changed_paths_json}
+    changed_paths:
+    {changed_paths_json}
+
+    path_scopes:
+    {path_scopes_json}
 
   # Changed material
 
@@ -148,8 +165,11 @@ extract_user_message_zh: |
   提示：{hint}
   max_units: {max_units}
 
-  changed_paths:
-  {changed_paths_json}
+    changed_paths:
+    {changed_paths_json}
+
+    path_scopes:
+    {path_scopes_json}
 
   # 变化内容
 

--- a/reme/steps/evolve/dream/integrate.py
+++ b/reme/steps/evolve/dream/integrate.py
@@ -4,11 +4,13 @@ import asyncio
 import json
 from pathlib import Path
 
+import frontmatter
+
 from ...base_step import BaseStep
 from .._evolve import agent_reply_result_text
 from ....components import R
 from ....enumeration import DreamBucketEnum
-from ....schema import IntegrateOutcome
+from ....schema import IntegrateOutcome, is_shared_memory, normalized_subject
 from .utils import llm_available, pack_paths, parse_structured_reply, state_from_context, store_state, workspace_dir
 
 _TOOLS = ("node_search", "read", "frontmatter_read", "write", "edit", "frontmatter_update")
@@ -109,6 +111,8 @@ class DreamIntegrateStep(BaseStep):
         except ValueError:
             bucket = DreamBucketEnum.WIKI.value
         paths = [str(p) for p in unit.get("paths", [])]
+        unit_subject = str(unit.get("subject") or "").strip() or None
+        unit_shared = bool(unit.get("shared"))
         self.logger.info(
             f"[{self.name}] unit {index}/{len(state.units)} start "
             f"name={unit.get('name', '')!r} bucket={bucket} paths={len(paths)}",
@@ -126,6 +130,8 @@ class DreamIntegrateStep(BaseStep):
                         unit_name=unit.get("name", ""),
                         unit_bucket=bucket,
                         unit_summary=unit.get("summary", ""),
+                        unit_subject=unit_subject or "(none)",
+                        unit_shared=str(unit_shared).lower(),
                         unit_paths_json=json.dumps(paths, ensure_ascii=False, indent=2),
                         material_blob=pack_paths(workspace, paths),
                     ),
@@ -149,7 +155,10 @@ class DreamIntegrateStep(BaseStep):
                     changed[0],
                     action="CREATE" if created else "UPDATED",
                     existed_before=changed[0] in unit_before,
+                    expected_subject=unit_subject,
+                    expected_shared=unit_shared,
                 ):
+                    self._ensure_target_scope(workspace, changed[0], unit_subject, unit_shared)
                     self._record_recovered(state, unit, bucket, paths, changed[0], created, e)
                     self.logger.warning(
                         f"[{self.name}] unit {index}/{len(state.units)} recovered from file change "
@@ -177,6 +186,8 @@ class DreamIntegrateStep(BaseStep):
                     outcome.target_path,
                     action=outcome.action,
                     existed_before=outcome.target_path in unit_before,
+                    expected_subject=unit_subject,
+                    expected_shared=unit_shared,
                 ):
                     raise ValueError(f"invalid or missing digest target_path: {outcome.target_path!r}")
             except Exception as e:  # noqa: BLE001
@@ -191,7 +202,10 @@ class DreamIntegrateStep(BaseStep):
                     changed[0],
                     action="CREATE" if created else "UPDATED",
                     existed_before=changed[0] in unit_before,
+                    expected_subject=unit_subject,
+                    expected_shared=unit_shared,
                 ):
+                    self._ensure_target_scope(workspace, changed[0], unit_subject, unit_shared)
                     self._record_recovered(state, unit, bucket, paths, changed[0], created, e)
                     self.logger.warning(
                         f"[{self.name}] unit {index}/{len(state.units)} accepted file change with invalid receipt "
@@ -224,6 +238,7 @@ class DreamIntegrateStep(BaseStep):
                 target_path=outcome.target_path,
                 note=outcome.note,
             )
+            self._ensure_target_scope(workspace, outcome.target_path, unit_subject, unit_shared)
             self.logger.info(
                 f"[{self.name}] unit {index}/{len(state.units)} done "
                 f"action={outcome.action} target_path={outcome.target_path}",
@@ -251,6 +266,8 @@ class DreamIntegrateStep(BaseStep):
         *,
         action: str,
         existed_before: bool,
+        expected_subject: str | None = None,
+        expected_shared: bool = False,
     ) -> bool:
         target = str(target_path or "").strip().replace("\\", "/")
         parts = Path(target).parts
@@ -268,7 +285,41 @@ class DreamIntegrateStep(BaseStep):
             return False
         if action == "CREATE":
             return target_bucket == bucket and not existed_before
-        return existed_before
+        if not existed_before:
+            return False
+        if expected_subject or expected_shared:
+            try:
+                metadata = frontmatter.loads((workspace / target).read_text(encoding="utf-8")).metadata
+            except (OSError, UnicodeError, ValueError):
+                return False
+            if expected_subject and normalized_subject(metadata) != expected_subject:
+                return False
+            if expected_shared != is_shared_memory(metadata):
+                return False
+        return True
+
+    @staticmethod
+    def _ensure_target_scope(
+        workspace: Path,
+        target_path: str,
+        subject: str | None,
+        shared: bool,
+    ) -> None:
+        """Repair agent-created frontmatter to the source-owned scope."""
+        if not subject and not shared:
+            return
+        target = workspace / Path(str(target_path).replace("\\", "/"))
+        if not target.is_file():
+            return
+        post = frontmatter.loads(target.read_text(encoding="utf-8"))
+        metadata = {}
+        if subject:
+            metadata["subject"] = subject
+        if shared:
+            metadata["shared"] = True
+        if any(post.metadata.get(key) != value for key, value in metadata.items()):
+            post.metadata.update(metadata)
+            target.write_text(frontmatter.dumps(post), encoding="utf-8")
 
     @staticmethod
     def _unit_key(unit: dict, bucket: str, paths: list[str]) -> tuple[str, str, tuple[str, ...]]:
@@ -292,16 +343,19 @@ class DreamIntegrateStep(BaseStep):
             for result in state.integrate_results
         )
         if not exists:
-            state.integrate_results.append(
-                {
-                    "unit": unit.get("name", ""),
-                    "bucket": bucket,
-                    "paths": paths,
-                    "action": action,
-                    "target_path": target_path,
-                    "note": note,
-                },
-            )
+            result = {
+                "unit": unit.get("name", ""),
+                "bucket": bucket,
+                "paths": paths,
+                "action": action,
+                "target_path": target_path,
+                "note": note,
+            }
+            if unit.get("subject"):
+                result["subject"] = unit["subject"]
+            if unit.get("shared"):
+                result["shared"] = True
+            state.integrate_results.append(result)
         targets = state.nodes_created if action == "CREATE" else state.nodes_updated
         if target_path not in targets:
             targets.append(target_path)

--- a/reme/steps/evolve/dream/integrate.yaml
+++ b/reme/steps/evolve/dream/integrate.yaml
@@ -492,6 +492,13 @@ integrate_user_message: |
   unit_name: {unit_name}
   unit_bucket: {unit_bucket}
   unit_summary: {unit_summary}
+  unit_subject: {unit_subject}
+  unit_shared: {unit_shared}
+
+  Scope is source-owned. If unit_subject is not `(none)`, update only a digest
+  node with exactly that subject; never merge it into another subject or an
+  unscoped node. If unit_shared is true, update only a node explicitly marked
+  `shared: true`. For CREATE, write the required scope in frontmatter.
 
   unit_paths:
   {unit_paths_json}
@@ -511,6 +518,12 @@ integrate_user_message_zh: |
   unit_name: {unit_name}
   unit_bucket: {unit_bucket}
   unit_summary: {unit_summary}
+  unit_subject：{unit_subject}
+  unit_shared：{unit_shared}
+
+  作用域由来源决定。如果 unit_subject 不是 `(none)`，只能更新 subject 完全相同的 digest node；绝不能
+  与其他 subject 或无作用域 node 合并。如果 unit_shared 为 true，只能更新明确标记 `shared: true` 的 node。
+  CREATE 时必须在 frontmatter 写入要求的作用域。
 
   unit_paths:
   {unit_paths_json}

--- a/reme/steps/index/reindex.py
+++ b/reme/steps/index/reindex.py
@@ -1,19 +1,42 @@
-"""Explicit scoped rebuild of search indexes from already-ingested chunks."""
+"""Explicit scoped rebuild of source-derived search state."""
 
 from ..base_step import BaseStep
+from .init_changes import InitChangesStep
 from ...components import R
 
 
 @R.register("reindex_step")
 class ReindexStep(BaseStep):
-    """Rebuild BM25, embeddings, and/or tags without scanning workspace files."""
+    """Rebuild indexes and, for ``all``, reparse workspace Markdown first."""
+
+    async def _rescan_sources(self) -> dict:
+        """Rebuild chunks from source files so frontmatter migrations repeatably apply."""
+        await self.file_store.clear()
+        scanner = InitChangesStep(
+            app_context=self.app_context,
+            monitor_type="file_store",
+            monitor_name="default",
+            dispatch_steps=[{"backend": "update_index_step"}],
+        )
+        response = await scanner(
+            self.context,
+            watch_dirs=["daily_dir", "digest_dir"],
+            watch_suffixes=["md"],
+        )
+        return dict(response.metadata)
 
     async def execute(self):
         assert self.context is not None
         scope = str(self.context.get("scope", "all"))
+        rescan_sources = bool(self.context.get("rescan_sources", self.kwargs.get("rescan_sources", True)))
+        source_scan = {}
+        if scope == "all" and rescan_sources and self.app_context is not None:
+            source_scan = await self._rescan_sources()
         details = await self.file_store.reindex(scope)
 
         self.context.response.answer = details
         self.context.response.metadata.update(details)
         self.context.response.metadata["scope"] = scope
+        if source_scan:
+            self.context.response.metadata["source_scan"] = source_scan
         return self.context.response

--- a/reme/steps/index/search.py
+++ b/reme/steps/index/search.py
@@ -171,6 +171,13 @@ class SearchStep(BaseStep):
         candidates = min(_MAX_CANDIDATES, max(1, int(limit * candidate_multiplier)))
         search_filter: dict = dict(self.context.get("search_filter", {}) or {})
 
+        # Subject-scoped search is intentionally an OR: personal memories for
+        # the requested identity plus explicitly shared workspace memory.
+        # Subjectless, unmarked files stay out of the scoped result set.
+        subject = str(self.context.get("subject") or "").strip()
+        if subject:
+            search_filter["metadata_any"] = [{"subject": subject}, {"shared": True}]
+
         # Promote top-level date parameters into search_filter for file_store.
         for date_key in ("start_date", "end_date"):
             value = self.context.get(date_key)
@@ -266,6 +273,12 @@ class SearchStep(BaseStep):
             c.model_dump(exclude_none=True, exclude={"embedding"}) for c in fused
         ]
         self.context.response.metadata["link_expansion"] = link_expansion
+        if subject:
+            self.context.response.metadata["subject_scope"] = {
+                "subject": subject,
+                "shared": True,
+                "policy": "subject match OR explicit shared:true",
+            }
         self.context.response.metadata["counts"] = {
             "vector": len(vector_results),
             "keyword": len(keyword_results),

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -121,18 +121,15 @@ def test_default_config_registers_manual_and_scheduled_proactive_refresh():
     assert manual["steps"] == scheduled["steps"]
 
 
-def test_default_config_keeps_frontmatter_chunk_metadata_opt_in():
-    """Markdown frontmatter-to-chunk metadata is disabled by default for compatibility."""
+def test_default_config_exposes_minimal_subject_chunk_metadata():
+    """The default Markdown index exposes only the scope fields needed for retrieval."""
     cfg = _load_config("default.yaml")
 
     markdown = cfg["components"]["file_chunker"]["markdown"]
     assert markdown["embed_toc"] is True
     assert markdown["max_ast_sections"] == 100
-    assert markdown["include_frontmatter_in_metadata"] is False
-    # Allow-list defaults to empty; combined with the False above, chunk metadata stays empty.
-    assert markdown["include_frontmatter_keys_in_metadata"] == [] or markdown.get(
-        "include_frontmatter_keys_in_metadata",
-    ) in (None, [])
+    assert markdown["include_frontmatter_in_metadata"] is True
+    assert markdown["include_frontmatter_keys_in_metadata"] == ["subject", "shared", "kind"]
 
 
 def test_parse_args_rejects_non_key_value_extra_argument():

--- a/tests/unit/test_subject_scoping.py
+++ b/tests/unit/test_subject_scoping.py
@@ -1,0 +1,264 @@
+"""Regression tests for canonical memory subjects and shared recall."""
+
+# pylint: disable=protected-access
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import frontmatter
+
+from reme.components.file_chunker import MarkdownFileChunker
+from reme.components.agent_wrapper import BaseAgentWrapper
+from reme.components.file_store import BaseFileStore, LocalFileStore
+from reme.components.application_context import ApplicationContext
+from reme.components.runtime_context import RuntimeContext
+from reme.enumeration import LinkScopeEnum
+from reme.schema import FileChunk, FileLink, FileNode, normalized_subject
+from reme.steps.evolve.auto_memory import AutoMemoryStep
+from reme.steps.evolve.dream.extract import DreamExtractStep
+from reme.steps.evolve.dream.integrate import DreamIntegrateStep
+from reme.steps.index.search import SearchStep
+
+
+def test_subject_alias_is_deterministic_and_canonical_wins():
+    assert normalized_subject({"target": "legacy-person"}) == "legacy-person"
+    assert normalized_subject({"subject": "new-person", "target": "legacy-person"}) == "new-person"
+    assert normalized_subject({"subject": "  ", "target": "legacy-person"}) == "legacy-person"
+
+
+def test_markdown_chunks_normalize_legacy_subject_and_shared_marker(tmp_path):
+    path = tmp_path / "daily" / "2026-09-01" / "memory.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "---\nname: memory\ntarget: project-alpha\nshared: false\n---\n# body\n",
+        encoding="utf-8",
+    )
+    chunker = MarkdownFileChunker(
+        max_ast_sections=0,
+        include_frontmatter_in_metadata=True,
+        include_frontmatter_keys_in_metadata=["subject", "shared", "kind"],
+    )
+    _, chunks = asyncio.run(chunker.chunk(path))
+    assert chunks[0].metadata == {"subject": "project-alpha"}
+
+    path.write_text("---\nname: memory\nshared: true\n---\n# body\n", encoding="utf-8")
+    _, chunks = asyncio.run(chunker.chunk(path))
+    assert chunks[0].metadata == {"shared": True}
+
+
+def test_local_store_subject_filter_is_subject_or_explicit_shared():
+    personal = FileChunk(id="personal", path="daily/personal.md", text="x", metadata={"subject": "alpha"})
+    shared = FileChunk(id="shared", path="digest/shared.md", text="x", metadata={"shared": True})
+    unscoped = FileChunk(id="unscoped", path="daily/unscoped.md", text="x", metadata={})
+    search_filter = {"metadata_any": [{"subject": "alpha"}, {"shared": True}]}
+
+    assert LocalFileStore._matches_search_filter(personal, search_filter)
+    assert LocalFileStore._matches_search_filter(shared, search_filter)
+    assert not LocalFileStore._matches_search_filter(unscoped, search_filter)
+
+
+class _SearchStore(BaseFileStore):
+    """Small search store that records the public filter passed by SearchStep."""
+
+    def __init__(self, chunks):
+        super().__init__(name="subject-search")
+        self.chunks = chunks
+        self.filters = []
+
+    async def upsert(self, files: list[tuple[FileNode, list[FileChunk]]]) -> None:
+        del files
+
+    async def delete(self, path: str | list[str]) -> None:
+        del path
+
+    async def clear(self) -> None:
+        return None
+
+    async def get_nodes(self, paths: list[str] | None = None) -> list[FileNode]:
+        del paths
+        return []
+
+    async def get_outlinks(self, path: str, scope: LinkScopeEnum = LinkScopeEnum.REAL) -> list[FileLink]:
+        del path, scope
+        return []
+
+    async def get_inlinks(self, path: str, scope: LinkScopeEnum = LinkScopeEnum.REAL) -> list[FileLink]:
+        del path, scope
+        return []
+
+    async def vector_search(self, query: str, limit: int, search_filter: dict) -> list[FileChunk]:
+        del query
+        self.filters.append(search_filter)
+        return self.chunks[:limit]
+
+    async def keyword_search(self, query: str, limit: int, search_filter: dict) -> list[FileChunk]:
+        del query
+        self.filters.append(search_filter)
+        return self.chunks[:limit]
+
+
+def test_search_step_exposes_subject_or_shared_policy():
+    store = _SearchStore([FileChunk(id="c", path="daily/a.md", text="memory", scores={"score": 1.0})])
+
+    async def run():
+        step = SearchStep(file_store=store, expand_links=False, vector_weight=0.0)
+        response = await step(RuntimeContext(query="memory", subject="alpha", limit=5))
+        assert response.metadata["subject_scope"]["policy"] == "subject match OR explicit shared:true"
+
+    asyncio.run(run())
+    assert store.filters == [{"metadata_any": [{"subject": "alpha"}, {"shared": True}]}]
+
+
+def test_auto_memory_rejects_existing_subject_conflict(tmp_path):
+    note_path = tmp_path / "daily" / "2026-09-01" / "memory.md"
+    note_path.parent.mkdir(parents=True)
+    note_path.write_text("---\nsession_id: s1\nsubject: alpha\n---\nold\n", encoding="utf-8")
+    store = LocalFileStore(
+        name="subject-memory",
+        embedding_store="",
+        app_context=ApplicationContext(workspace_dir=str(tmp_path)),
+    )
+    step = AutoMemoryStep(file_store=store)
+    reply = AsyncMock()
+    step.agent_wrapper = SimpleNamespace(reply=reply)
+
+    async def list_note(_day, _session_id):
+        return {"path": "daily/2026-09-01/memory.md", "session_id": "s1"}
+
+    step._list_session_note = list_note
+    response = asyncio.run(
+        step(
+            RuntimeContext(
+                messages=[{"name": "user", "role": "user", "content": "new", "created_at": "2026-09-01T10:00:00"}],
+                session_id="s1",
+                date="2026-09-01",
+                subject="beta",
+            ),
+        ),
+    )
+    response = response or step.context.response
+    assert response.success is False
+    assert "subject mismatch" in response.answer
+    reply.assert_not_awaited()
+
+
+def test_auto_memory_frontmatter_repair_preserves_exact_subject(tmp_path):
+    note_path = tmp_path / "daily" / "2026-09-01" / "memory.md"
+    note_path.parent.mkdir(parents=True)
+    note_path.write_text("---\nname: memory\n---\nbody\n", encoding="utf-8")
+    step = AutoMemoryStep()
+    step.file_store = SimpleNamespace(workspace_path=tmp_path)
+    async def update_frontmatter(*_args, **kwargs):
+        post = frontmatter.loads(note_path.read_text(encoding="utf-8"))
+        post.metadata.update(kwargs["metadata"])
+        note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return SimpleNamespace(success=True, answer="ok")
+
+    step.run_job = AsyncMock(side_effect=update_frontmatter)
+
+    asyncio.run(step._ensure_memory_frontmatter("daily/2026-09-01/memory.md", "s1", "alpha"))
+
+    metadata = frontmatter.loads(note_path.read_text(encoding="utf-8")).metadata
+    assert metadata["subject"] == "alpha"
+    assert step.run_job.await_args.kwargs["metadata"]["subject"] == "alpha"
+
+
+def test_auto_memory_create_repairs_model_note_to_caller_subject(tmp_path):
+    note_path = "daily/2026-09-01/memory.md"
+
+    class _CreateWrapper(BaseAgentWrapper):
+        async def reply(self, *_args, **_kwargs):
+            note_file.parent.mkdir(parents=True, exist_ok=True)
+            note_file.write_text("---\nname: memory\n---\nbody\n", encoding="utf-8")
+            return {"result": "created"}
+
+    store = LocalFileStore(
+        name="subject-create",
+        embedding_store="",
+        app_context=ApplicationContext(workspace_dir=str(tmp_path)),
+    )
+    note_file = tmp_path / note_path
+    step = AutoMemoryStep(file_store=store, agent_wrapper=_CreateWrapper(name="fake"))
+
+    listed_paths = iter([None, {"path": note_path, "session_id": "s1"}])
+
+    async def list_note(_day, _session_id):
+        return next(listed_paths)
+
+    async def update_frontmatter(*_args, **kwargs):
+        post = frontmatter.loads(note_file.read_text(encoding="utf-8"))
+        post.metadata.update(kwargs["metadata"])
+        note_file.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return SimpleNamespace(success=True, answer="ok")
+
+    step._list_session_note = list_note
+    step.run_job = AsyncMock(side_effect=update_frontmatter)
+
+    with patch("reme.steps.evolve.auto_memory.refresh_day_index", new=AsyncMock(return_value={})):
+        response = asyncio.run(
+            step(
+                RuntimeContext(
+                    messages=[
+                        {
+                            "name": "user",
+                            "role": "user",
+                            "content": "remember this",
+                            "created_at": "2026-09-01T10:00:00",
+                        },
+                    ],
+                    session_id="s1",
+                    date="2026-09-01",
+                    subject="alpha",
+                ),
+            ),
+        )
+
+    response = response or step.context.response
+    assert response.success is True
+    assert response.metadata["created"] is True
+    assert frontmatter.loads(note_file.read_text(encoding="utf-8")).metadata["subject"] == "alpha"
+    assert step.run_job.await_args.kwargs["metadata"]["subject"] == "alpha"
+
+
+def test_dream_extract_drops_units_that_merge_different_subjects(tmp_path):
+    first = tmp_path / "daily" / "2026-09-01" / "a.md"
+    second = tmp_path / "daily" / "2026-09-01" / "b.md"
+    first.parent.mkdir(parents=True)
+    first.write_text("---\nsubject: alpha\n---\na\n", encoding="utf-8")
+    second.write_text("---\nsubject: beta\n---\nb\n", encoding="utf-8")
+    step = DreamExtractStep()
+    step._path_scopes = step._load_path_scopes(tmp_path, ["daily/2026-09-01/a.md", "daily/2026-09-01/b.md"])
+    state = SimpleNamespace(changed_paths=list(step._path_scopes), units=[], warnings=[])
+
+    step.clean_output(
+        state,
+        {
+            "units": [
+                {
+                    "name": "merged",
+                    "bucket": "personal",
+                    "summary": "merged summary",
+                    "paths": list(step._path_scopes),
+                },
+            ],
+        },
+    )
+
+    assert state.units == []
+    assert "different subjects" in state.warnings[0]
+
+
+def test_dream_integrate_rejects_incompatible_existing_subject(tmp_path):
+    target = tmp_path / "digest" / "personal" / "alpha.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("---\nsubject: beta\n---\nbody\n", encoding="utf-8")
+    assert not DreamIntegrateStep._valid_target(
+        tmp_path,
+        "digest",
+        "personal",
+        "digest/personal/alpha.md",
+        action="REFINE",
+        existed_before=True,
+        expected_subject="alpha",
+    )


### PR DESCRIPTION
## Summary

Adds canonical subject-scoped memory support across file metadata, search, auto-memory, and dream flows.

## What changed

- Canonical `subject` frontmatter now wins over legacy `target`, with `shared` as the public/shared-memory marker.
- Markdown chunk metadata, local file search, and top-level memory search now respect subject scope.
- Auto-memory now validates caller-owned subject scope, repairs frontmatter, and refuses incompatible subject changes.
- Dream extraction and integration now preserve/validate subject scope and reject mixed-scoped merges.
- Reindex now rescans markdown sources when run in app context.
- Docs were updated in English and Chinese.

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit/test_subject_scoping.py -q`
- `ruff check reme/components/file_chunker/markdown_file_chunker.py reme/components/file_store/local_file_store.py reme/schema/__init__.py reme/schema/dream.py reme/schema/file_front_matter.py reme/steps/evolve/auto_memory.py reme/steps/evolve/dream/extract.py reme/steps/evolve/dream/integrate.py reme/steps/index/reindex.py reme/steps/index/search.py tests/unit/test_config_parser.py tests/unit/test_subject_scoping.py`
- `git diff --check`

Closes #506.
