### PR TITLE
feat: auto-tag plugin-generated reports

### DIFF
--- a/.github/workflows/release-auto-fin.yml
+++ b/.github/workflows/release-auto-fin.yml
@@ -75,8 +75,8 @@ jobs:
           reme_requirement = Requirement(requirements[0])
           if reme_requirement.name != "reme-ai" or reme_requirement.extras:
               raise SystemExit(f"Expected a base reme-ai dependency, found {requirements[0]!r}")
-          if Version("0.4.1.8") in reme_requirement.specifier or Version("0.4.1.9") not in reme_requirement.specifier:
-              raise SystemExit(f"Expected reme-ai>=0.4.1.9, found {requirements[0]!r}")
+          if Version("0.4.1.11") in reme_requirement.specifier or Version("0.4.1.12") not in reme_requirement.specifier:
+              raise SystemExit(f"Expected reme-ai>=0.4.1.12, found {requirements[0]!r}")
           root_project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
           agentscope_requirements = [
               Requirement(value) for value in root_project["optional-dependencies"]["as"]

--- a/.github/workflows/release-daily-paper.yml
+++ b/.github/workflows/release-daily-paper.yml
@@ -72,8 +72,8 @@ jobs:
           reme_requirements = [requirement for requirement in requirements if requirement.name == "reme-ai"]
           if len(reme_requirements) != 1 or reme_requirements[0].extras:
               raise SystemExit(f"Expected one base reme-ai dependency, found {reme_requirements!r}")
-          if Version("0.4.1.8") in reme_requirements[0].specifier or Version("0.4.1.9") not in reme_requirements[0].specifier:
-              raise SystemExit(f"Expected reme-ai>=0.4.1.9, found {reme_requirements!r}")
+          if Version("0.4.1.11") in reme_requirements[0].specifier or Version("0.4.1.12") not in reme_requirements[0].specifier:
+              raise SystemExit(f"Expected reme-ai>=0.4.1.12, found {reme_requirements!r}")
           if sum(requirement.name == "pypdf" for requirement in requirements) != 1:
               raise SystemExit("Expected exactly one pypdf dependency")
           root_project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]

--- a/docs/en/plugin_management.md
+++ b/docs/en/plugin_management.md
@@ -173,8 +173,9 @@ curl -s http://127.0.0.1:2333/auto_fin \
 
 When the application uses an MCP service, service-enabled plugin Jobs appear as MCP tools instead.
 
-Custom application configs must provide the plugin's runtime dependencies, including an `agent_wrapper.default` and
-the `search` and `read` Jobs used by Auto Fin.
+Custom application configs must provide the plugin's runtime dependencies, including an `agent_wrapper.default`, a
+`file_store.default` with an enabled tag index, and the `search`, `read`, `list_tags`, `frontmatter_read`, and
+`frontmatter_update` Jobs used by Auto Fin and automatic tagging.
 
 ## Benchmark application presets
 

--- a/docs/zh/plugin_management.md
+++ b/docs/zh/plugin_management.md
@@ -167,7 +167,9 @@ curl -s http://127.0.0.1:2333/auto_fin \
 
 当应用使用 MCP service 时，允许对外服务的插件 Job 会显示为 MCP tool。
 
-自定义应用配置需要提供插件的运行依赖，包括 `agent_wrapper.default`，以及 Auto Fin 使用的 `search` 和 `read` Jobs。
+自定义应用配置需要提供插件的运行依赖，包括 `agent_wrapper.default`、启用 tag index 的
+`file_store.default`，以及 Auto Fin 和自动标签使用的 `search`、`read`、`list_tags`、
+`frontmatter_read` 和 `frontmatter_update` Jobs。
 
 ## Benchmark 应用配置
 

--- a/plugins/auto-fin/README.md
+++ b/plugins/auto-fin/README.md
@@ -78,7 +78,7 @@ validate historical wikilinks in code
         ↓
 daily/YYYY-MM-DD/auto_fin.md
         ↓
-generate memory tags and synchronously refresh indexes
+generate memory tags; the background file watcher refreshes indexes
 ```
 
 `auto_fin_data_step` signs and paginates the same endpoint used by the CLS website. It starts at the decision time and
@@ -96,8 +96,9 @@ workspace-relative Markdown targets. Missing, absolute, escaping, backslash, and
 to their readable aliases.
 
 Same-day reruns use the existing report as context and replace it with the revised result. The final write is atomic and
-refreshes the daily index. The workflow then runs `auto_tag_step` for the generated report so its configured memory-tag
-frontmatter stays aligned with ReMe's tag index. No JSONL, intermediate Markdown, or structured Agent output is written.
+refreshes the daily index. The workflow then runs `auto_tag_step` to update the generated report's memory-tag
+frontmatter; the normal background file watcher observes that source-file change and refreshes derived indexes. No
+JSONL, intermediate Markdown, or structured Agent output is written.
 
 ## Parameters
 

--- a/plugins/auto-fin/README.md
+++ b/plugins/auto-fin/README.md
@@ -17,7 +17,7 @@ through `plugins=["auto-fin"]`.
 ### 1. Install ReMe and Auto Fin
 
 ```bash
-python -m pip install "reme-ai[core]>=0.4.1.9"
+python -m pip install "reme-ai[core]>=0.4.1.12"
 reme plugins install reme-auto-fin
 ```
 
@@ -59,7 +59,9 @@ reme start plugins='["auto-fin"]' \
   service.backend=http
 ```
 
-Custom application configs must provide `agent_wrapper.default` and the `search` and `read` Jobs used by Auto Fin.
+Custom application configs must provide `agent_wrapper.default`, a `file_store.default` with an enabled tag index, and
+the `search`, `read`, `list_tags`, `frontmatter_read`, and `frontmatter_update` Jobs used by Auto Fin and automatic
+tagging.
 
 ## Pipeline
 
@@ -75,6 +77,8 @@ research Agent uses search + read on historical memory
 validate historical wikilinks in code
         ↓
 daily/YYYY-MM-DD/auto_fin.md
+        ↓
+generate memory tags and synchronously refresh indexes
 ```
 
 `auto_fin_data_step` signs and paginates the same endpoint used by the CLS website. It starts at the decision time and
@@ -92,7 +96,8 @@ workspace-relative Markdown targets. Missing, absolute, escaping, backslash, and
 to their readable aliases.
 
 Same-day reruns use the existing report as context and replace it with the revised result. The final write is atomic and
-refreshes the daily index. No JSONL, intermediate Markdown, or structured Agent output is written.
+refreshes the daily index. The workflow then runs `auto_tag_step` for the generated report so its configured memory-tag
+frontmatter stays aligned with ReMe's tag index. No JSONL, intermediate Markdown, or structured Agent output is written.
 
 ## Parameters
 

--- a/plugins/auto-fin/README_ZH.md
+++ b/plugins/auto-fin/README_ZH.md
@@ -73,7 +73,7 @@ Research Agent 使用 search + read 检索历史记忆
         ↓
 daily/YYYY-MM-DD/auto_fin.md
         ↓
-生成记忆标签并同步刷新索引
+生成记忆标签，由后台文件 watcher 刷新索引
 ```
 
 `auto_fin_data_step` 使用财联社网页同源接口的签名和分页方式，从分析时刻开始向前翻页，直到完整覆盖严格的最近 24
@@ -87,7 +87,8 @@ Prompt 要求 Agent 只链接实际使用过的历史 Markdown；代码边界则
 workspace 的 Markdown 目标。不存在、绝对路径、越界、带反斜杠和自引用的目标都会降级为可读 alias。
 
 同日重跑会参考当天已有报告并覆盖为修订结果。最终写入使用原子替换并刷新当天索引，随后通过 `auto_tag_step`
-为报告维护与 ReMe tag index 配置一致的记忆标签；流程不会写入 JSONL、中间 Markdown 或 Agent 结构化输出。
+更新报告的记忆标签 frontmatter；常规后台文件 watcher 会观察该源文件变化并刷新派生索引。流程不会写入 JSONL、
+中间 Markdown 或 Agent 结构化输出。
 
 ## 参数
 

--- a/plugins/auto-fin/README_ZH.md
+++ b/plugins/auto-fin/README_ZH.md
@@ -14,7 +14,7 @@ distribution：单个 `reme.plugins` entry point 暴露 `plugin.yaml`，其中�
 ### 1. 安装 ReMe 和 Auto Fin
 
 ```bash
-python -m pip install "reme-ai[core]>=0.4.1.9"
+python -m pip install "reme-ai[core]>=0.4.1.12"
 reme plugins install reme-auto-fin
 ```
 
@@ -54,7 +54,9 @@ reme start plugins='["auto-fin"]' \
   service.backend=http
 ```
 
-自定义应用配置需要提供 `agent_wrapper.default`，以及 Auto Fin 使用的 `search` 和 `read` Jobs。
+自定义应用配置需要提供 `agent_wrapper.default`、启用 tag index 的 `file_store.default`，以及
+Auto Fin 和自动标签使用的 `search`、`read`、`list_tags`、`frontmatter_read` 和
+`frontmatter_update` Jobs。
 
 ## 流程
 
@@ -70,6 +72,8 @@ Research Agent 使用 search + read 检索历史记忆
 代码校验历史 wikilink
         ↓
 daily/YYYY-MM-DD/auto_fin.md
+        ↓
+生成记忆标签并同步刷新索引
 ```
 
 `auto_fin_data_step` 使用财联社网页同源接口的签名和分页方式，从分析时刻开始向前翻页，直到完整覆盖严格的最近 24
@@ -82,8 +86,8 @@ daily/YYYY-MM-DD/auto_fin.md
 Prompt 要求 Agent 只链接实际使用过的历史 Markdown；代码边界则独立保证只保留真实存在、相对
 workspace 的 Markdown 目标。不存在、绝对路径、越界、带反斜杠和自引用的目标都会降级为可读 alias。
 
-同日重跑会参考当天已有报告并覆盖为修订结果。最终写入使用原子替换并刷新当天索引；流程不会写入 JSONL、中间 Markdown 或 Agent
-结构化输出。
+同日重跑会参考当天已有报告并覆盖为修订结果。最终写入使用原子替换并刷新当天索引，随后通过 `auto_tag_step`
+为报告维护与 ReMe tag index 配置一致的记忆标签；流程不会写入 JSONL、中间 Markdown 或 Agent 结构化输出。
 
 ## 参数
 

--- a/plugins/auto-fin/pyproject.toml
+++ b/plugins/auto-fin/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "reme-auto-fin"
-version = "0.1.2"
+version = "0.1.3"
 description = "Auto Fin example plugin for ReMe."
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
-    "reme-ai>=0.4.1.9",
+    "reme-ai>=0.4.1.12",
 ]
 
 [project.entry-points."reme.plugins"]

--- a/plugins/auto-fin/src/reme_auto_fin/merge.py
+++ b/plugins/auto-fin/src/reme_auto_fin/merge.py
@@ -104,6 +104,7 @@ class AutoFinMergeStep(AutoFinStep):
     async def execute(self):
         """Research the selected news and persist the validated report."""
         assert self.context is not None
+        self.context["changes"] = []
         if self.context.get("auto_fin_skipped"):
             return self.context.response
         run_date = date.fromisoformat(str(self._required("auto_fin_date")))
@@ -131,6 +132,7 @@ class AutoFinMergeStep(AutoFinStep):
         markdown = f"# {output.title}\n\n> {output.description}\n\n{output.body}\n\n"
         markdown += "> 未接入可靠行情数据；本文只提供新闻研究和回顾线索，不提供收益、目标价或买卖建议。\n"
         report = self._report_path(run_date)
+        change = "modified" if report.is_file() else "added"
         _write(report, markdown)
         await refresh_day_index(
             SimpleNamespace(workspace_path=self.workspace_path),
@@ -138,6 +140,7 @@ class AutoFinMergeStep(AutoFinStep):
             str(self.config_value("daily_dir")),
         )
         relative = report.relative_to(self.workspace_path).as_posix()
+        self.context["changes"] = [{"change": change, "path": relative}]
         self.context["markdown_path"] = relative
         self.context["auto_fin_digest_path"] = relative
         self.context.response.answer = output.body

--- a/plugins/auto-fin/src/reme_auto_fin/plugin.yaml
+++ b/plugins/auto-fin/src/reme_auto_fin/plugin.yaml
@@ -43,6 +43,8 @@ application_defaults:
         - backend: auto_fin_topic_step
         - backend: auto_fin_merge_step
           job_tools: [search, read]
+        - backend: auto_tag_step
+          max_tags_per_file: 3
 
     auto_fin_cron:
       backend: cron

--- a/plugins/auto-fin/src/reme_auto_fin/plugin.yaml
+++ b/plugins/auto-fin/src/reme_auto_fin/plugin.yaml
@@ -44,7 +44,6 @@ application_defaults:
         - backend: auto_fin_merge_step
           job_tools: [search, read]
         - backend: auto_tag_step
-          max_tags_per_file: 3
 
     auto_fin_cron:
       backend: cron

--- a/plugins/auto-fin/tests/test_auto_fin.py
+++ b/plugins/auto-fin/tests/test_auto_fin.py
@@ -266,7 +266,7 @@ def test_plugin_config_has_default_topics_and_no_intermediate_index_step():
         "auto_tag_step",
     ]
     assert job["steps"][2]["job_tools"] == ["search", "read"]
-    assert job["steps"][3]["max_tags_per_file"] == 3
+    assert job["steps"][3] == {"backend": "auto_tag_step"}
     assert jobs["auto_fin_cron"]["cron"] == "0 18 * * *"
     assert jobs["auto_fin_cron"]["steps"] == job["steps"]
     assert (

--- a/plugins/auto-fin/tests/test_auto_fin.py
+++ b/plugins/auto-fin/tests/test_auto_fin.py
@@ -219,6 +219,7 @@ async def test_merge_writes_only_final_report_and_validates_historical_links(tmp
     assert "missing.md" not in report and "outside.md" not in report
     assert not (tmp_path / "daily" / "2026-08-10" / "auto_fin_news.md").exists()
     assert not (tmp_path / "resource").exists()
+    assert context["changes"] == [{"change": "added", "path": "daily/2026-08-10/auto_fin.md"}]
     assert response.metadata["source_paths"] == ["daily/2026-08-01/auto_fin.md"]
 
 
@@ -262,8 +263,10 @@ def test_plugin_config_has_default_topics_and_no_intermediate_index_step():
         "auto_fin_data_step",
         "auto_fin_topic_step",
         "auto_fin_merge_step",
+        "auto_tag_step",
     ]
     assert job["steps"][2]["job_tools"] == ["search", "read"]
+    assert job["steps"][3]["max_tags_per_file"] == 3
     assert jobs["auto_fin_cron"]["cron"] == "0 18 * * *"
     assert jobs["auto_fin_cron"]["steps"] == job["steps"]
     assert (

--- a/plugins/daily_paper/README.md
+++ b/plugins/daily_paper/README.md
@@ -13,7 +13,7 @@ their Job configuration under `application_defaults`. Enable the installed plugi
 ### 1. Install ReMe and Daily Paper
 
 ```bash
-python -m pip install "reme-ai[core]>=0.4.1.9"
+python -m pip install "reme-ai[core]>=0.4.1.12"
 reme plugins install reme-daily-paper
 ```
 
@@ -51,6 +51,10 @@ To run the Job once without starting a long-lived service:
 reme start plugins='["daily-paper"]' job=daily_paper topics="Agent memory"
 ```
 
+Custom application configs must provide `agent_wrapper.default`, a `file_store.default` with an enabled tag index, and
+the `search`, `read`, `list_tags`, `frontmatter_read`, and `frontmatter_update` Jobs used by Daily Paper and automatic
+tagging.
+
 ## Pipeline
 
 ```text
@@ -64,7 +68,9 @@ download and parse arXiv PDFs, then write three Chinese analyses
                  ↓
 use search + read to connect prior memory and generate a brief
                  ↓
-refresh the daily index and optionally send the brief to DingTalk
+generate memory tags and synchronously refresh indexes
+                 ↓
+optionally send the brief to DingTalk
 ```
 
 `daily_paper_collect_step` concurrently reads the weekly and monthly rankings for the run date plus the strictly
@@ -81,8 +87,9 @@ PDFs and files without a text layer fail explicitly.
 
 `daily_paper_digest_step` treats those three analyses as the factual source and receives only the read-only
 `search` and `read` tools for linking earlier memory. Code validates historical wikilinks, appends links to all
-three source notes, and rebuilds the daily index. The optional `dingtalk_markdown_send_step` sends the final brief when
-conversation IDs are configured and otherwise skips without side effects.
+three source notes, and rebuilds the daily index. The workflow then runs `auto_tag_step` for all three analyses and the
+final brief before the optional `dingtalk_markdown_send_step` sends the brief. DingTalk delivery skips without side
+effects when conversation IDs are not configured.
 
 ## Parameters
 

--- a/plugins/daily_paper/README.md
+++ b/plugins/daily_paper/README.md
@@ -68,7 +68,7 @@ download and parse arXiv PDFs, then write three Chinese analyses
                  ↓
 use search + read to connect prior memory and generate a brief
                  ↓
-generate memory tags and synchronously refresh indexes
+generate memory tags; the background file watcher refreshes indexes
                  ↓
 optionally send the brief to DingTalk
 ```
@@ -87,9 +87,10 @@ PDFs and files without a text layer fail explicitly.
 
 `daily_paper_digest_step` treats those three analyses as the factual source and receives only the read-only
 `search` and `read` tools for linking earlier memory. Code validates historical wikilinks, appends links to all
-three source notes, and rebuilds the daily index. The workflow then runs `auto_tag_step` for all three analyses and the
-final brief before the optional `dingtalk_markdown_send_step` sends the brief. DingTalk delivery skips without side
-effects when conversation IDs are not configured.
+three source notes, and rebuilds the daily index. The workflow then runs `auto_tag_step` to update the memory-tag
+frontmatter of all three analyses and the final brief. The normal background file watcher observes those source-file
+changes and refreshes derived indexes before the optional `dingtalk_markdown_send_step` sends the brief. DingTalk
+delivery skips without side effects when conversation IDs are not configured.
 
 ## Parameters
 

--- a/plugins/daily_paper/README_ZH.md
+++ b/plugins/daily_paper/README_ZH.md
@@ -64,7 +64,7 @@ RRF 排序后由 Agent 精选三篇
           ↓
 使用 search + read 关联历史记忆并生成简报
           ↓
-生成记忆标签并同步刷新索引
+生成记忆标签，由后台文件 watcher 刷新索引
           ↓
 按需发送到钉钉
 ```
@@ -79,8 +79,9 @@ RRF 排序后由 Agent 精选三篇
 文本。三篇中文解读按精选顺序写入当天目录；扫描版或没有文本层的 PDF 会明确失败。
 
 `daily_paper_digest_step` 以本次生成的三篇解读为事实来源，只开放只读的 `search` 和 `read` 来关联较早记忆。
-代码会校验历史 wikilink、追加三篇源笔记链接，并重建当日索引。随后 `auto_tag_step` 会为三篇解读及最终简报维护
-记忆标签，再由可选的 `dingtalk_markdown_send_step` 发送最终简报；未配置群会话时无副作用跳过。
+代码会校验历史 wikilink、追加三篇源笔记链接，并重建当日索引。随后 `auto_tag_step` 会更新三篇解读及最终简报的
+记忆标签 frontmatter，常规后台文件 watcher 会观察这些源文件变化并刷新派生索引，再由可选的
+`dingtalk_markdown_send_step` 发送最终简报；未配置群会话时无副作用跳过。
 
 ## 参数
 

--- a/plugins/daily_paper/README_ZH.md
+++ b/plugins/daily_paper/README_ZH.md
@@ -11,7 +11,7 @@ Step backend，并在 `application_defaults` 下提供 Job 配置；通过 `plug
 ### 1. 安装 ReMe 和每日论文插件
 
 ```bash
-python -m pip install "reme-ai[core]>=0.4.1.9"
+python -m pip install "reme-ai[core]>=0.4.1.12"
 reme plugins install reme-daily-paper
 ```
 
@@ -47,6 +47,10 @@ curl -s http://127.0.0.1:2333/daily_paper \
 reme start plugins='["daily-paper"]' job=daily_paper topics="Agent memory"
 ```
 
+自定义应用配置需要提供 `agent_wrapper.default`、启用 tag index 的 `file_store.default`，以及
+Daily Paper 和自动标签使用的 `search`、`read`、`list_tags`、`frontmatter_read` 和
+`frontmatter_update` Jobs。
+
 ## 流程
 
 ```text
@@ -60,7 +64,9 @@ RRF 排序后由 Agent 精选三篇
           ↓
 使用 search + read 关联历史记忆并生成简报
           ↓
-写入当日索引，并按需发送到钉钉
+生成记忆标签并同步刷新索引
+          ↓
+按需发送到钉钉
 ```
 
 `daily_paper_collect_step` 并发读取运行日期所在周和所在月的榜单，以及严格前一日的 Daily Papers。候选按 arXiv ID
@@ -73,8 +79,8 @@ RRF 排序后由 Agent 精选三篇
 文本。三篇中文解读按精选顺序写入当天目录；扫描版或没有文本层的 PDF 会明确失败。
 
 `daily_paper_digest_step` 以本次生成的三篇解读为事实来源，只开放只读的 `search` 和 `read` 来关联较早记忆。
-代码会校验历史 wikilink、追加三篇源笔记链接，并重建当日索引。可选的 `dingtalk_markdown_send_step` 在配置群会话后
-发送最终简报；未配置时无副作用跳过。
+代码会校验历史 wikilink、追加三篇源笔记链接，并重建当日索引。随后 `auto_tag_step` 会为三篇解读及最终简报维护
+记忆标签，再由可选的 `dingtalk_markdown_send_step` 发送最终简报；未配置群会话时无副作用跳过。
 
 ## 参数
 

--- a/plugins/daily_paper/pyproject.toml
+++ b/plugins/daily_paper/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reme-daily-paper"
-version = "0.1.2"
+version = "0.1.3"
 description = "Daily Paper research and reading-note plugin for ReMe."
 readme = "README.md"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
     "pypdf>=5.0.0",
-    "reme-ai>=0.4.1.9",
+    "reme-ai>=0.4.1.12",
 ]
 
 [project.entry-points."reme.plugins"]

--- a/plugins/daily_paper/src/reme_daily_paper/analyze.py
+++ b/plugins/daily_paper/src/reme_daily_paper/analyze.py
@@ -157,6 +157,14 @@ class DailyPaperAnalyzeStep(DailyPaperStep):
         )
         if existing_note is not None and existing_note != note_path:
             existing_note.unlink()
+        changes = list(self.context.get("changes") or [])
+        changes.append(
+            {
+                "change": "modified" if existing_note is not None else "added",
+                "path": note_rel,
+            },
+        )
+        self.context["changes"] = changes
         self.logger.info(
             f"[{self.name}] paper done arxiv_id={paper.arxiv_id} note_path={note_rel}",
         )
@@ -172,6 +180,7 @@ class DailyPaperAnalyzeStep(DailyPaperStep):
 
     async def execute(self):
         assert self.context is not None
+        self.context["changes"] = []
         if self._skip():
             self.logger.info(f"[{self.name}] skip existing digest")
             return self.context.response

--- a/plugins/daily_paper/src/reme_daily_paper/analyze.py
+++ b/plugins/daily_paper/src/reme_daily_paper/analyze.py
@@ -155,12 +155,14 @@ class DailyPaperAnalyzeStep(DailyPaperStep):
                 "pdf_text_truncated": truncated,
             },
         )
-        if existing_note is not None and existing_note != note_path:
-            existing_note.unlink()
         changes = list(self.context.get("changes") or [])
+        if existing_note is not None and existing_note != note_path:
+            existing_rel = existing_note.relative_to(self.workspace_path).as_posix()
+            existing_note.unlink()
+            changes.append({"change": "deleted", "path": existing_rel})
         changes.append(
             {
-                "change": "modified" if existing_note is not None else "added",
+                "change": "modified" if existing_note == note_path else "added",
                 "path": note_rel,
             },
         )

--- a/plugins/daily_paper/src/reme_daily_paper/digest.py
+++ b/plugins/daily_paper/src/reme_daily_paper/digest.py
@@ -108,7 +108,7 @@ class DailyPaperDigestStep(DailyPaperStep):
         title = normalize_chinese_title(output.title, f"每日论文简报-{day}")
         existing_rel = str(self._state("existing_digest_path") or "").strip()
         existing_path = self.workspace_path / existing_rel if existing_rel else None
-        digest_change = "modified" if existing_path is not None and existing_path.is_file() else "added"
+        existing_was_file = existing_path is not None and existing_path.is_file()
         title, digest_path = resolve_unique_note_path(
             self.workspace_path / daily_dir / day,
             title,
@@ -136,9 +136,11 @@ class DailyPaperDigestStep(DailyPaperStep):
                 "generated_at": utc_now_iso(),
             },
         )
-        if existing_path is not None and existing_path != digest_path:
-            existing_path.unlink()
         changes = list(self.context.get("changes") or [])
+        if existing_was_file and existing_path != digest_path:
+            existing_path.unlink()
+            changes.append({"change": "deleted", "path": existing_rel})
+        digest_change = "modified" if existing_was_file and existing_path == digest_path else "added"
         changes.append({"change": digest_change, "path": digest_rel})
         self.context["changes"] = changes
         self._set_state("digest_path", digest_rel)

--- a/plugins/daily_paper/src/reme_daily_paper/digest.py
+++ b/plugins/daily_paper/src/reme_daily_paper/digest.py
@@ -108,6 +108,7 @@ class DailyPaperDigestStep(DailyPaperStep):
         title = normalize_chinese_title(output.title, f"每日论文简报-{day}")
         existing_rel = str(self._state("existing_digest_path") or "").strip()
         existing_path = self.workspace_path / existing_rel if existing_rel else None
+        digest_change = "modified" if existing_path is not None and existing_path.is_file() else "added"
         title, digest_path = resolve_unique_note_path(
             self.workspace_path / daily_dir / day,
             title,
@@ -137,6 +138,9 @@ class DailyPaperDigestStep(DailyPaperStep):
         )
         if existing_path is not None and existing_path != digest_path:
             existing_path.unlink()
+        changes = list(self.context.get("changes") or [])
+        changes.append({"change": digest_change, "path": digest_rel})
+        self.context["changes"] = changes
         self._set_state("digest_path", digest_rel)
         self.logger.info(f"[{self.name}] digest written path={digest_rel}")
         self.logger.info(

--- a/plugins/daily_paper/src/reme_daily_paper/plugin.yaml
+++ b/plugins/daily_paper/src/reme_daily_paper/plugin.yaml
@@ -55,7 +55,6 @@ application_defaults:
         - backend: daily_paper_digest_step
           job_tools: [search, read]
         - backend: auto_tag_step
-          max_tags_per_file: 3
         - backend: dingtalk_markdown_send_step
           input_mapping:
             daily_paper_digest_path: markdown_path

--- a/plugins/daily_paper/src/reme_daily_paper/plugin.yaml
+++ b/plugins/daily_paper/src/reme_daily_paper/plugin.yaml
@@ -54,6 +54,8 @@ application_defaults:
         - backend: daily_paper_analyze_step
         - backend: daily_paper_digest_step
           job_tools: [search, read]
+        - backend: auto_tag_step
+          max_tags_per_file: 3
         - backend: dingtalk_markdown_send_step
           input_mapping:
             daily_paper_digest_path: markdown_path

--- a/plugins/daily_paper/tests/test_daily_paper.py
+++ b/plugins/daily_paper/tests/test_daily_paper.py
@@ -63,7 +63,19 @@ def test_plugin_manifest_declares_complete_runtime_surface():
         "daily_paper_analyze_step",
         "daily_paper_digest_step",
     }
-    assert set(_plugin_config()["jobs"]) == {"daily_paper", "daily_paper_cron"}
+    jobs = _plugin_config()["jobs"]
+    assert set(jobs) == {"daily_paper", "daily_paper_cron"}
+    assert [step["backend"] for step in jobs["daily_paper"]["steps"]] == [
+        "daily_paper_collect_step",
+        "daily_paper_rank_step",
+        "daily_paper_select_step",
+        "daily_paper_analyze_step",
+        "daily_paper_digest_step",
+        "auto_tag_step",
+        "dingtalk_markdown_send_step",
+    ]
+    assert jobs["daily_paper"]["steps"][5]["max_tags_per_file"] == 3
+    assert jobs["daily_paper_cron"]["steps"] == jobs["daily_paper"]["steps"]
 
 
 class _QueuedAgentWrapper(BaseAgentWrapper):
@@ -898,6 +910,12 @@ async def test_pipeline_filters_strict_yesterday_and_writes_outputs(
         "Clear evidence",
     ]
     assert digest.metadata["arxiv_ids"] == ["2607.10001", "2607.10004", "2607.10005"]
+    assert context["changes"] == [
+        {"change": "added", "path": "daily/2026-07-21/记忆代理研究.md"},
+        {"change": "added", "path": "daily/2026-07-21/上下文压缩研究.md"},
+        {"change": "added", "path": "daily/2026-07-21/持续学习研究.md"},
+        {"change": "added", "path": "daily/2026-07-21/今日智能体论文简报.md"},
+    ]
     assert cc_wrapper.calls[0]["kwargs"] == {"output_schema": PaperPickList}
     assert "用户感兴趣的主题" not in cc_wrapper.calls[0]["inputs"]
     assert "用户未提供明确的 topic 倾向" in cc_wrapper.calls[0]["inputs"]

--- a/plugins/daily_paper/tests/test_daily_paper.py
+++ b/plugins/daily_paper/tests/test_daily_paper.py
@@ -74,7 +74,7 @@ def test_plugin_manifest_declares_complete_runtime_surface():
         "auto_tag_step",
         "dingtalk_markdown_send_step",
     ]
-    assert jobs["daily_paper"]["steps"][5]["max_tags_per_file"] == 3
+    assert jobs["daily_paper"]["steps"][5] == {"backend": "auto_tag_step"}
     assert jobs["daily_paper_cron"]["steps"] == jobs["daily_paper"]["steps"]
 
 
@@ -1002,6 +1002,10 @@ async def test_digest_force_migrates_old_fixed_filename_to_chinese_title(tmp_pat
     assert new_path.is_file()
     assert not old_path.exists()
     assert context["daily_paper_digest_path"] == "daily/2026-07-21/全新论文简报.md"
+    assert context["changes"] == [
+        {"change": "deleted", "path": "daily/2026-07-21/daily-paper-brief.md"},
+        {"change": "added", "path": "daily/2026-07-21/全新论文简报.md"},
+    ]
 
 
 @pytest.mark.asyncio

--- a/reme/__init__.py
+++ b/reme/__init__.py
@@ -1,6 +1,6 @@
 """ReMe CLI package."""
 
-__version__ = "0.4.1.11"
+__version__ = "0.4.1.12"
 
 from . import config
 from . import constants

--- a/reme/components/file_store/local_file_store.py
+++ b/reme/components/file_store/local_file_store.py
@@ -56,7 +56,6 @@ class LocalFileStore(BaseFileStore):
         from ..embedding_store import LocalEmbeddingStore
         from ..file_graph import LocalFileGraph
         from ..keyword_index import BM25Index
-        from ..tag_index import LocalTagIndex
 
         if not embedding_store and not keyword_index:
             raise ValueError("At least one of embedding_store or keyword_index must be set.")
@@ -66,7 +65,7 @@ class LocalFileStore(BaseFileStore):
         self.embedding_store = self.bind(embedding_store, BaseEmbeddingStore, default_factory=LocalEmbeddingStore)
         self.keyword_index = self.bind(keyword_index, BaseKeywordIndex, default_factory=BM25Index)
         self.file_graph = self.bind(file_graph, BaseFileGraph, default_factory=LocalFileGraph)
-        self.tag_index = self.bind(tag_index, BaseTagIndex, default_factory=LocalTagIndex)
+        self.tag_index = self.bind(tag_index, BaseTagIndex, optional=False)
 
         self.encoding = encoding
         self.store_version = store_version

--- a/reme/components/file_store/local_file_store.py
+++ b/reme/components/file_store/local_file_store.py
@@ -56,6 +56,7 @@ class LocalFileStore(BaseFileStore):
         from ..embedding_store import LocalEmbeddingStore
         from ..file_graph import LocalFileGraph
         from ..keyword_index import BM25Index
+        from ..tag_index import LocalTagIndex
 
         if not embedding_store and not keyword_index:
             raise ValueError("At least one of embedding_store or keyword_index must be set.")
@@ -65,7 +66,12 @@ class LocalFileStore(BaseFileStore):
         self.embedding_store = self.bind(embedding_store, BaseEmbeddingStore, default_factory=LocalEmbeddingStore)
         self.keyword_index = self.bind(keyword_index, BaseKeywordIndex, default_factory=BM25Index)
         self.file_graph = self.bind(file_graph, BaseFileGraph, default_factory=LocalFileGraph)
-        self.tag_index = self.bind(tag_index, BaseTagIndex, optional=False)
+        self.tag_index = self.bind(
+            tag_index,
+            BaseTagIndex,
+            default_factory=LocalTagIndex if tag_index == "default" else None,
+            optional=False,
+        )
 
         self.encoding = encoding
         self.store_version = store_version

--- a/reme/components/tag_index/base_tag_index.py
+++ b/reme/components/tag_index/base_tag_index.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import ClassVar, Literal, TypedDict
 
 from ..base_component import BaseComponent
-from ...constants import DEFAULT_MEMORY_TAG_KEY
+from ...constants import DEFAULT_MAX_MEMORY_TAG_LENGTH, DEFAULT_MAX_MEMORY_TAGS, DEFAULT_MEMORY_TAG_KEY
 from ...enumeration import ComponentEnum
 from ...schema import FileNode
 
@@ -29,10 +29,24 @@ class BaseTagIndex(BaseComponent):
     component_type = ComponentEnum.TAG_INDEX
     reserved_tag_keys: ClassVar[frozenset[str]] = frozenset()
 
-    def __init__(self, tag_key: object = DEFAULT_MEMORY_TAG_KEY, **kwargs):
+    def __init__(
+        self,
+        tag_key: object = DEFAULT_MEMORY_TAG_KEY,
+        max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
+        max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self._tag_key = self._validate_tag_key(tag_key)
+        self.max_tags_per_file = self._positive_int("max_tags_per_file", max_tags_per_file)
+        self.max_tag_length = self._positive_int("max_tag_length", max_tag_length)
         self.is_healthy = True
+
+    @staticmethod
+    def _positive_int(name: str, value: object) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return value
 
     @property
     def tag_key(self) -> str:

--- a/reme/components/tag_index/base_tag_index.py
+++ b/reme/components/tag_index/base_tag_index.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import ClassVar, Literal, TypedDict
 
 from ..base_component import BaseComponent
+from ...constants import DEFAULT_MEMORY_TAG_KEY
 from ...enumeration import ComponentEnum
 from ...schema import FileNode
 
@@ -28,7 +29,7 @@ class BaseTagIndex(BaseComponent):
     component_type = ComponentEnum.TAG_INDEX
     reserved_tag_keys: ClassVar[frozenset[str]] = frozenset()
 
-    def __init__(self, tag_key: object = "memory_tags", **kwargs):
+    def __init__(self, tag_key: object = DEFAULT_MEMORY_TAG_KEY, **kwargs):
         super().__init__(**kwargs)
         self._tag_key = self._validate_tag_key(tag_key)
         self.is_healthy = True

--- a/reme/components/tag_index/local_tag_index.py
+++ b/reme/components/tag_index/local_tag_index.py
@@ -5,6 +5,7 @@ from pathlib import PurePosixPath
 
 from .base_tag_index import BaseTagIndex, TagListItem, TagListResult, TagOrder, TagOrderBy
 from ..component_registry import R
+from ...constants import DEFAULT_MAX_MEMORY_TAG_LENGTH, DEFAULT_MAX_MEMORY_TAGS, DEFAULT_MEMORY_TAG_KEY
 from ...schema import FileFrontMatter, FileNode
 
 
@@ -22,9 +23,9 @@ class LocalTagIndex(BaseTagIndex):
 
     def __init__(
         self,
-        tag_key: object = "memory_tags",
-        max_tags_per_file: int = 3,
-        max_tag_length: int = 64,
+        tag_key: object = DEFAULT_MEMORY_TAG_KEY,
+        max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
+        max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
         **kwargs,
     ):
         super().__init__(tag_key=tag_key, **kwargs)

--- a/reme/components/tag_index/local_tag_index.py
+++ b/reme/components/tag_index/local_tag_index.py
@@ -5,7 +5,6 @@ from pathlib import PurePosixPath
 
 from .base_tag_index import BaseTagIndex, TagListItem, TagListResult, TagOrder, TagOrderBy
 from ..component_registry import R
-from ...constants import DEFAULT_MAX_MEMORY_TAG_LENGTH, DEFAULT_MAX_MEMORY_TAGS, DEFAULT_MEMORY_TAG_KEY
 from ...schema import FileFrontMatter, FileNode
 
 
@@ -21,16 +20,8 @@ class LocalTagIndex(BaseTagIndex):
         "status",
     }
 
-    def __init__(
-        self,
-        tag_key: object = DEFAULT_MEMORY_TAG_KEY,
-        max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
-        max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
-        **kwargs,
-    ):
-        super().__init__(tag_key=tag_key, **kwargs)
-        self.max_tags_per_file = self._positive_int("max_tags_per_file", max_tags_per_file)
-        self.max_tag_length = self._positive_int("max_tag_length", max_tag_length)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.path_to_tags: dict[str, tuple[str, ...]] = {}
         self.tag_to_paths: dict[str, set[str]] = {}
         self._maintenance_lock = asyncio.Lock()
@@ -38,12 +29,6 @@ class LocalTagIndex(BaseTagIndex):
     @property
     def n_files(self) -> int:
         return len(self.path_to_tags)
-
-    @staticmethod
-    def _positive_int(name: str, value: object) -> int:
-        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-            raise ValueError(f"{name} must be a positive integer")
-        return value
 
     def _normalize_tags(self, value: object, *, limit: int | None) -> list[str]:
         """Normalize a strict tag list, optionally limiting the result count."""

--- a/reme/config/default.yaml
+++ b/reme/config/default.yaml
@@ -189,7 +189,6 @@ jobs:
     steps:
       - backend: auto_memory_step
       - backend: auto_tag_step
-        max_tags_per_file: 3
 
   auto_memory_cc:
     backend: base
@@ -208,7 +207,6 @@ jobs:
     steps:
       - backend: auto_memory_cc_step
       - backend: auto_tag_step
-        max_tags_per_file: 3
 
   auto_resource:
     backend: base

--- a/reme/constants.py
+++ b/reme/constants.py
@@ -18,3 +18,8 @@ DEFAULT_MAX_IMAGE_BYTES = 5 * 1024 * 1024
 # Background content-processing jobs skip files above this size. File watchers
 # and catalogs still track them so deletes and later size reductions are seen.
 DEFAULT_MAX_FILE_BYTES = 20 * 1024 * 1024
+
+# Memory-tag generation and indexing defaults.
+DEFAULT_MEMORY_TAG_KEY = "memory_tags"
+DEFAULT_MAX_MEMORY_TAGS = 3
+DEFAULT_MAX_MEMORY_TAG_LENGTH = 64

--- a/reme/steps/base_step.py
+++ b/reme/steps/base_step.py
@@ -71,12 +71,18 @@ class Ref:
         obj.__dict__.pop(self._cache_attr, None)
 
     def _resolve(self, obj: "BaseStep"):
-        for source in (obj.kwargs, obj.context or {}):
+        sources = (obj.kwargs, obj.context or {})
+        for source in sources:
             value = source.get(self.key)
             if isinstance(value, self.base_cls):
                 return value
 
-        name = obj.kwargs.get(self.key, "default")
+        name = "default"
+        for source in sources:
+            value = source.get(self.key)
+            if isinstance(value, str):
+                name = value
+                break
         if obj.app_context is None:
             if self.optional:
                 return None

--- a/reme/steps/evolve/auto_tag.py
+++ b/reme/steps/evolve/auto_tag.py
@@ -10,6 +10,7 @@ from ..base_step import BaseStep
 from ..file_io._path import display_path, resolve_path
 from ..index import normalize_posix_path
 from ...components import R
+from ...constants import DEFAULT_MAX_MEMORY_TAG_LENGTH, DEFAULT_MAX_MEMORY_TAGS
 
 _SUPPORTED_CHANGES = {"added", "modified"}
 
@@ -18,6 +19,34 @@ _SUPPORTED_CHANGES = {"added", "modified"}
 class _TagTarget:
     change: Literal["added", "modified"]
     path: str
+
+
+def normalize_memory_tags(
+    value: object,
+    *,
+    max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
+    max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
+) -> list[str]:
+    """Normalize source tags while preserving canonical display casing."""
+    if not isinstance(value, list):
+        return []
+
+    tags: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        tag = "_".join(item.split())
+        if not tag or len(tag) > max_tag_length or not any(char.isalnum() for char in tag):
+            continue
+        canonical = tag.casefold()
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        tags.append(tag)
+        if len(tags) >= max_tags_per_file:
+            break
+    return tags
 
 
 @R.register("auto_tag_step")
@@ -94,7 +123,11 @@ class AutoTagStep(BaseStep):
 
         path = self.workspace_path / target.path
         metadata = dict(frontmatter.loads(path.read_text(encoding="utf-8")).metadata or {})
-        normalized = tag_index.normalize_tags(metadata.get(tag_key))
+        normalized = normalize_memory_tags(
+            metadata.get(tag_key),
+            max_tags_per_file=tag_index.max_tags_per_file,
+            max_tag_length=tag_index.max_tag_length,
+        )
         if metadata.get(tag_key) != normalized:
             response = await self.run_job(
                 "frontmatter_update",
@@ -142,10 +175,10 @@ class AutoTagStep(BaseStep):
 
         failed = sum(not item["success"] for item in results)
         succeeded = len(results) - failed
-        self.context.response.success = initial_success and failed == 0
-        if initial_success and failed:
+        self.context.response.success = initial_success
+        if not initial_answer and failed:
             self.context.response.answer = f"Tagged {succeeded} file(s); {failed} failed"
-        elif initial_success and not initial_answer and succeeded:
+        elif not initial_answer and succeeded:
             self.context.response.answer = f"Tagged {succeeded} file(s)"
         else:
             self.context.response.answer = initial_answer

--- a/reme/steps/evolve/auto_tag.py
+++ b/reme/steps/evolve/auto_tag.py
@@ -1,21 +1,21 @@
 """Generate entity-oriented memory tags for added or modified Markdown files."""
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Literal
 
 import frontmatter
 
 from ._evolve import agent_reply_result_text
 from ..base_step import BaseStep
-from ..file_io import parse_daily_date, refresh_day_index
 from ..file_io._path import display_path, resolve_path
 from ..index import normalize_posix_path
 from ...components import R
-from ...components.runtime_context import RuntimeContext
+from ...constants import (
+    DEFAULT_MAX_MEMORY_TAG_LENGTH,
+    DEFAULT_MAX_MEMORY_TAGS,
+    DEFAULT_MEMORY_TAG_KEY,
+)
 
-_DEFAULT_MAX_MEMORY_TAGS = 3
-_DEFAULT_MAX_MEMORY_TAG_LENGTH = 64
 _SUPPORTED_CHANGES = {"added", "modified"}
 
 
@@ -34,8 +34,8 @@ def _positive_int(value: object, *, name: str) -> int:
 def normalize_memory_tags(
     value: object,
     *,
-    max_tags_per_file: int = _DEFAULT_MAX_MEMORY_TAGS,
-    max_tag_length: int = _DEFAULT_MAX_MEMORY_TAG_LENGTH,
+    max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
+    max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
 ) -> list[str]:
     """Normalize human-readable entity labels for frontmatter storage."""
     max_tags_per_file = _positive_int(max_tags_per_file, name="max_tags_per_file")
@@ -65,21 +65,20 @@ def normalize_memory_tags(
 class AutoTagStep(BaseStep):
     """Update memory tags for Markdown files described by the common ``changes`` contract."""
 
-    def __init__(self, max_tags_per_file: int = _DEFAULT_MAX_MEMORY_TAGS, **kwargs):
+    def __init__(
+        self,
+        tag_key: str = DEFAULT_MEMORY_TAG_KEY,
+        max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
+        max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
+        self.tag_key = str(tag_key).strip()
+        if not self.tag_key:
+            raise ValueError("tag_key must be a non-empty string")
         self.max_tags_per_file = _positive_int(max_tags_per_file, name="max_tags_per_file")
+        self.max_tag_length = _positive_int(max_tag_length, name="max_tag_length")
         self.tools = ["read", "list_tags", "frontmatter_read", "frontmatter_update"]
-
-    @staticmethod
-    def _index_limit(tag_index, name: str, fallback: int | None) -> int | None:
-        """Read one positive integer index limit, falling back when unavailable or invalid."""
-        try:
-            value = getattr(tag_index, name)
-        except (AttributeError, TypeError, ValueError):
-            return fallback
-        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-            return fallback
-        return value
 
     def _targets(self) -> tuple[list[_TagTarget], list[dict[str, str]]]:
         """Validate, normalize, and de-duplicate added/modified Markdown changes."""
@@ -88,7 +87,7 @@ class AutoTagStep(BaseStep):
         if not isinstance(raw_changes, list):
             raise ValueError("AutoTagStep requires changes: list[dict]")
 
-        workspace = Path(self.file_store.workspace_path or ".").resolve()
+        workspace = self.workspace_path.resolve()
         targets: dict[str, _TagTarget] = {}
         ignored: list[dict[str, str]] = []
         for item in raw_changes:
@@ -125,79 +124,39 @@ class AutoTagStep(BaseStep):
             targets[path] = _TagTarget(change=normalized_change, path=path)
         return list(targets.values()), ignored
 
-    async def _process_target(self, target: _TagTarget, tag_key: str, max_tag_length: int) -> str:
+    async def _process_target(self, target: _TagTarget) -> str:
         result = await self.agent_wrapper.reply(
-            self.prompt_format("user_message", path=target.path, change=target.change, tag_key=tag_key),
+            self.prompt_format("user_message", path=target.path, change=target.change, tag_key=self.tag_key),
             system_prompt=self.prompt_format(
                 "system_prompt",
-                tag_key=tag_key,
+                tag_key=self.tag_key,
                 max_tags_per_file=self.max_tags_per_file,
             ),
             job_tools=self.tools,
             injected_job_kwargs={
                 "_allowed_paths": [target.path],
-                "_allowed_frontmatter_keys": [tag_key],
+                "_allowed_frontmatter_keys": [self.tag_key],
             },
         )
 
-        path = Path(self.file_store.workspace_path or ".") / target.path
+        path = self.workspace_path / target.path
         metadata = dict(frontmatter.loads(path.read_text(encoding="utf-8")).metadata or {})
         normalized = normalize_memory_tags(
-            metadata.get(tag_key),
+            metadata.get(self.tag_key),
             max_tags_per_file=self.max_tags_per_file,
-            max_tag_length=max_tag_length,
+            max_tag_length=self.max_tag_length,
         )
-        if metadata.get(tag_key) != normalized:
+        if metadata.get(self.tag_key) != normalized:
             response = await self.run_job(
                 "frontmatter_update",
                 path=target.path,
-                metadata={tag_key: normalized},
+                metadata={self.tag_key: normalized},
                 _allowed_paths=[target.path],
-                _allowed_frontmatter_keys=[tag_key],
+                _allowed_frontmatter_keys=[self.tag_key],
             )
             if not response.success:
                 raise RuntimeError(str(response.answer))
         return agent_reply_result_text(result)
-
-    async def _sync_file_index(self, changes: list[dict[str, str]]) -> list[dict]:
-        """Synchronously expose freshly written tags through the file-store indexes."""
-        if not changes or self.app_context is None:
-            return []
-        step_cls, params = self._resolve_dispatch_step({"backend": "update_index_step", "persist": False})
-        response = await step_cls(**params)(RuntimeContext(changes=changes))
-        if not isinstance(response.answer, list):
-            raise RuntimeError(f"Unexpected update_index_step response: {response.answer!r}")
-        if not self.file_store.require_tag_index().is_healthy:
-            raise RuntimeError("tag index unavailable after update")
-        return response.answer
-
-    async def _sync_results(self, results: list[dict]) -> list[dict]:
-        """Sync successful targets and convert incremental-index errors into target failures."""
-        successful_changes = [{"change": item["change"], "path": item["path"]} for item in results if item["success"]]
-        index_updates: list[dict] = []
-        try:
-            index_updates = await self._sync_file_index(successful_changes)
-            index_failures = {
-                item["path"]: str(item.get("error") or "index update failed")
-                for item in index_updates
-                if not item.get("success")
-            }
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            index_failures = {item["path"]: str(exc) for item in successful_changes}
-            self.logger.warning(f"[{self.name}] failed to synchronize file index: {exc}")
-        for item in results:
-            if item["success"] and item["path"] in index_failures:
-                item["success"] = False
-                item["error"] = f"index update failed: {index_failures[item['path']]}"
-        return index_updates
-
-    def _daily_date(self, path: str) -> str | None:
-        daily_dir = normalize_posix_path(str(self.config_value("daily_dir"))).strip("/")
-        prefix = f"{daily_dir}/"
-        if not path.startswith(prefix):
-            return None
-        parts = path[len(prefix) :].split("/")
-        return parse_daily_date(parts[0]) if len(parts) == 2 else None
 
     async def execute(self):
         assert self.context is not None
@@ -211,36 +170,9 @@ class AutoTagStep(BaseStep):
             return self.context.response
 
         results: list[dict] = []
-        indexes: list[dict] = []
-        if targets and not self.file_store.tag_index_enabled:
-            self.context.response.success = False
-            if initial_success:
-                self.context.response.answer = "Error: tag index is not configured"
-            return self.context.response
-
-        tag_index = self.file_store.require_tag_index() if targets else None
-        if tag_index is not None and not tag_index.is_healthy:
-            self.context.response.success = False
-            if initial_success:
-                self.context.response.answer = "Error: tag index unavailable"
-            return self.context.response
-        max_tag_length = self._index_limit(tag_index, "max_tag_length", _DEFAULT_MAX_MEMORY_TAG_LENGTH)
-        index_max_tags = self._index_limit(tag_index, "max_tags_per_file", None)
-        if index_max_tags is not None and self.max_tags_per_file > index_max_tags:
-            self.context.response.success = False
-            if initial_success:
-                self.context.response.answer = (
-                    f"Error: auto_tag max_tags_per_file ({self.max_tags_per_file}) exceeds "
-                    f"tag index limit ({index_max_tags})"
-                )
-            return self.context.response
-
-        dates: set[str] = set()
         for target in targets:
-            if day := self._daily_date(target.path):
-                dates.add(day)
             try:
-                summary = await self._process_target(target, tag_index.tag_key, max_tag_length)
+                summary = await self._process_target(target)
                 results.append(
                     {
                         "change": target.change,
@@ -260,11 +192,6 @@ class AutoTagStep(BaseStep):
                 )
                 self.logger.warning(f"[{self.name}] failed path={target.path}: {exc}")
 
-        index_updates = await self._sync_results(results)
-
-        for day in sorted(dates):
-            indexes.append(await refresh_day_index(self.file_store, day, self.config_value("daily_dir")))
-
         failed = sum(not item["success"] for item in results)
         succeeded = len(results) - failed
         self.context.response.success = initial_success and failed == 0
@@ -280,7 +207,5 @@ class AutoTagStep(BaseStep):
             "failed": failed,
             "ignored": ignored,
             "results": results,
-            "index_updates": index_updates,
-            "indexes": indexes,
         }
         return self.context.response

--- a/reme/steps/evolve/auto_tag.py
+++ b/reme/steps/evolve/auto_tag.py
@@ -12,6 +12,7 @@ from ..file_io import parse_daily_date, refresh_day_index
 from ..file_io._path import display_path, resolve_path
 from ..index import normalize_posix_path
 from ...components import R
+from ...components.runtime_context import RuntimeContext
 
 _DEFAULT_MAX_MEMORY_TAGS = 3
 _DEFAULT_MAX_MEMORY_TAG_LENGTH = 64
@@ -98,7 +99,12 @@ class AutoTagStep(BaseStep):
             change = str(item.get("change") or "").strip().lower()
             raw_path = str(item.get("path") or "").strip()
             if change not in _SUPPORTED_CHANGES:
-                ignored.append({"path": raw_path, "reason": f"unsupported change: {change or 'missing'}"})
+                ignored.append(
+                    {
+                        "path": raw_path,
+                        "reason": f"unsupported change: {change or 'missing'}",
+                    },
+                )
                 continue
 
             target, error = resolve_path(workspace, raw_path)
@@ -153,6 +159,38 @@ class AutoTagStep(BaseStep):
                 raise RuntimeError(str(response.answer))
         return agent_reply_result_text(result)
 
+    async def _sync_file_index(self, changes: list[dict[str, str]]) -> list[dict]:
+        """Synchronously expose freshly written tags through the file-store indexes."""
+        if not changes or self.app_context is None:
+            return []
+        step_cls, params = self._resolve_dispatch_step({"backend": "update_index_step", "persist": False})
+        response = await step_cls(**params)(RuntimeContext(changes=changes))
+        if not isinstance(response.answer, list):
+            raise RuntimeError(f"Unexpected update_index_step response: {response.answer!r}")
+        if not self.file_store.require_tag_index().is_healthy:
+            raise RuntimeError("tag index unavailable after update")
+        return response.answer
+
+    async def _sync_results(self, results: list[dict]) -> list[dict]:
+        """Sync successful targets and convert incremental-index errors into target failures."""
+        successful_changes = [{"change": item["change"], "path": item["path"]} for item in results if item["success"]]
+        index_updates: list[dict] = []
+        try:
+            index_updates = await self._sync_file_index(successful_changes)
+            index_failures = {
+                item["path"]: str(item.get("error") or "index update failed")
+                for item in index_updates
+                if not item.get("success")
+            }
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            index_failures = {item["path"]: str(exc) for item in successful_changes}
+            self.logger.warning(f"[{self.name}] failed to synchronize file index: {exc}")
+        for item in results:
+            if item["success"] and item["path"] in index_failures:
+                item["success"] = False
+                item["error"] = f"index update failed: {index_failures[item['path']]}"
+        return index_updates
+
     def _daily_date(self, path: str) -> str | None:
         daily_dir = normalize_posix_path(str(self.config_value("daily_dir"))).strip("/")
         prefix = f"{daily_dir}/"
@@ -204,13 +242,25 @@ class AutoTagStep(BaseStep):
             try:
                 summary = await self._process_target(target, tag_index.tag_key, max_tag_length)
                 results.append(
-                    {"change": target.change, "path": target.path, "success": True, "summary": summary},
+                    {
+                        "change": target.change,
+                        "path": target.path,
+                        "success": True,
+                        "summary": summary,
+                    },
                 )
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 results.append(
-                    {"change": target.change, "path": target.path, "success": False, "error": str(exc)},
+                    {
+                        "change": target.change,
+                        "path": target.path,
+                        "success": False,
+                        "error": str(exc),
+                    },
                 )
                 self.logger.warning(f"[{self.name}] failed path={target.path}: {exc}")
+
+        index_updates = await self._sync_results(results)
 
         for day in sorted(dates):
             indexes.append(await refresh_day_index(self.file_store, day, self.config_value("daily_dir")))
@@ -230,6 +280,7 @@ class AutoTagStep(BaseStep):
             "failed": failed,
             "ignored": ignored,
             "results": results,
+            "index_updates": index_updates,
             "indexes": indexes,
         }
         return self.context.response

--- a/reme/steps/evolve/auto_tag.py
+++ b/reme/steps/evolve/auto_tag.py
@@ -10,11 +10,6 @@ from ..base_step import BaseStep
 from ..file_io._path import display_path, resolve_path
 from ..index import normalize_posix_path
 from ...components import R
-from ...constants import (
-    DEFAULT_MAX_MEMORY_TAG_LENGTH,
-    DEFAULT_MAX_MEMORY_TAGS,
-    DEFAULT_MEMORY_TAG_KEY,
-)
 
 _SUPPORTED_CHANGES = {"added", "modified"}
 
@@ -25,59 +20,12 @@ class _TagTarget:
     path: str
 
 
-def _positive_int(value: object, *, name: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise ValueError(f"{name} must be a positive integer")
-    return value
-
-
-def normalize_memory_tags(
-    value: object,
-    *,
-    max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
-    max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
-) -> list[str]:
-    """Normalize human-readable entity labels for frontmatter storage."""
-    max_tags_per_file = _positive_int(max_tags_per_file, name="max_tags_per_file")
-    max_tag_length = _positive_int(max_tag_length, name="max_tag_length")
-    if not isinstance(value, list):
-        return []
-
-    tags: list[str] = []
-    seen: set[str] = set()
-    for item in value:
-        if not isinstance(item, str):
-            continue
-        tag = "_".join(item.split())
-        if not tag or len(tag) > max_tag_length or not any(char.isalnum() for char in tag):
-            continue
-        canonical = tag.casefold()
-        if canonical in seen:
-            continue
-        seen.add(canonical)
-        tags.append(tag)
-        if len(tags) >= max_tags_per_file:
-            break
-    return tags
-
-
 @R.register("auto_tag_step")
 class AutoTagStep(BaseStep):
     """Update memory tags for Markdown files described by the common ``changes`` contract."""
 
-    def __init__(
-        self,
-        tag_key: str = DEFAULT_MEMORY_TAG_KEY,
-        max_tags_per_file: int = DEFAULT_MAX_MEMORY_TAGS,
-        max_tag_length: int = DEFAULT_MAX_MEMORY_TAG_LENGTH,
-        **kwargs,
-    ):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.tag_key = str(tag_key).strip()
-        if not self.tag_key:
-            raise ValueError("tag_key must be a non-empty string")
-        self.max_tags_per_file = _positive_int(max_tags_per_file, name="max_tags_per_file")
-        self.max_tag_length = _positive_int(max_tag_length, name="max_tag_length")
         self.tools = ["read", "list_tags", "frontmatter_read", "frontmatter_update"]
 
     def _targets(self) -> tuple[list[_TagTarget], list[dict[str, str]]]:
@@ -125,34 +73,34 @@ class AutoTagStep(BaseStep):
         return list(targets.values()), ignored
 
     async def _process_target(self, target: _TagTarget) -> str:
+        file_store = self.file_store
+        tag_index = file_store.require_tag_index()
+        tag_key = tag_index.tag_key
+        tool_context = {
+            "file_store": file_store.name,
+            "_allowed_paths": [target.path],
+            "_allowed_frontmatter_keys": [tag_key],
+        }
         result = await self.agent_wrapper.reply(
-            self.prompt_format("user_message", path=target.path, change=target.change, tag_key=self.tag_key),
+            self.prompt_format("user_message", path=target.path, change=target.change, tag_key=tag_key),
             system_prompt=self.prompt_format(
                 "system_prompt",
-                tag_key=self.tag_key,
-                max_tags_per_file=self.max_tags_per_file,
+                tag_key=tag_key,
+                max_tags_per_file=tag_index.max_tags_per_file,
             ),
             job_tools=self.tools,
-            injected_job_kwargs={
-                "_allowed_paths": [target.path],
-                "_allowed_frontmatter_keys": [self.tag_key],
-            },
+            injected_job_kwargs=tool_context,
         )
 
         path = self.workspace_path / target.path
         metadata = dict(frontmatter.loads(path.read_text(encoding="utf-8")).metadata or {})
-        normalized = normalize_memory_tags(
-            metadata.get(self.tag_key),
-            max_tags_per_file=self.max_tags_per_file,
-            max_tag_length=self.max_tag_length,
-        )
-        if metadata.get(self.tag_key) != normalized:
+        normalized = tag_index.normalize_tags(metadata.get(tag_key))
+        if metadata.get(tag_key) != normalized:
             response = await self.run_job(
                 "frontmatter_update",
                 path=target.path,
-                metadata={self.tag_key: normalized},
-                _allowed_paths=[target.path],
-                _allowed_frontmatter_keys=[self.tag_key],
+                metadata={tag_key: normalized},
+                **tool_context,
             )
             if not response.success:
                 raise RuntimeError(str(response.answer))

--- a/reme/utils/logger_utils.py
+++ b/reme/utils/logger_utils.py
@@ -25,8 +25,14 @@ class _ForwardToLoggerHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         target = logging.getLogger(self.target_name)
-        if target.isEnabledFor(record.levelno):
-            target.handle(record)
+        # Python 3.13 treats both ``isEnabledFor`` and ``handle`` as disabled
+        # during a nested logger call. Apply their stable public checks here,
+        # then dispatch directly so forwarded ReMe records are not dropped.
+        if target.disabled or target.manager.disable >= record.levelno or record.levelno < target.getEffectiveLevel():
+            return
+        filtered = target.filter(record)
+        if filtered:
+            target.callHandlers(filtered if isinstance(filtered, logging.LogRecord) else record)
 
 
 class _QwenPawStdlibFormatter(logging.Formatter):

--- a/tests/integration/test_auto_tag.py
+++ b/tests/integration/test_auto_tag.py
@@ -1,0 +1,302 @@
+"""Real-LLM integration tests for ``auto_tag_step``.
+
+The fixtures mimic the final Markdown written by the Auto Fin and Daily Paper
+plugins, then invoke AutoTagStep through a normal application Job.  The tests
+load the repository ``.env`` and therefore call the configured real LLM.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import frontmatter
+
+INTEGRATION_DIR = Path(__file__).resolve().parent
+REPOSITORY = INTEGRATION_DIR.parents[1]
+sys.path.insert(0, str(REPOSITORY))
+sys.path.insert(0, str(INTEGRATION_DIR))
+
+# pylint: disable=wrong-import-position
+from _workspace_fixture import workspace_env  # noqa: E402
+
+from reme.enumeration import ComponentEnum  # noqa: E402
+from reme.utils import load_env  # noqa: E402
+
+AUTO_TAG_JOB = {
+    "integration_auto_tag": {
+        "backend": "base",
+        "enable_serve": False,
+        "steps": [{"backend": "auto_tag_step", "max_tags_per_file": 3}],
+    },
+}
+
+AUTO_FIN_REPORT = """\
+---
+name: auto_fin
+description: 宁德时代海外电池业务与产能进展的盘后研究
+kind: auto-fin-brief
+---
+
+# 宁德时代：欧洲电池业务进入产能兑现期
+
+> 本文围绕宁德时代这一家公司，复盘其欧洲电池工厂的量产进展与客户交付节奏。
+
+## 核心变化
+
+宁德时代确认匈牙利工厂首条电芯产线开始试生产。管理层称，后续爬坡速度仍取决于良率、当地供应链和
+客户认证。该进展可能缩短欧洲客户的交付半径，但资本开支和产能利用率仍是主要风险。
+
+## 观察框架
+
+后续应继续跟踪宁德时代的海外产能利用率、单位成本与订单兑现情况。本文只提供新闻研究和回顾线索，
+不提供收益、目标价或买卖建议。
+"""
+
+DAILY_PAPER_NOTES = {
+    "daily/2026-09-10/openai-agent-eval.md": """\
+---
+name: openai-agent-eval
+description: OpenAI 智能体可靠性评测论文解读
+kind: daily-paper-analysis
+arxiv_id: "2609.10001"
+---
+
+# OpenAI 智能体可靠性评测
+
+这篇论文以 OpenAI 为唯一机构研究对象，分析其智能体在长任务中的失败恢复机制。实验比较了重试预算、
+工具错误和上下文压缩对完成率的影响，并讨论 OpenAI 对可靠性评测的设计选择。
+""",
+    "daily/2026-09-10/anthropic-context.md": """\
+---
+name: anthropic-context
+description: Anthropic 长上下文研究论文解读
+kind: daily-paper-analysis
+arxiv_id: "2609.10002"
+---
+
+# Anthropic 长上下文研究
+
+论文只研究 Anthropic 的长上下文模型。作者测试信息位于不同位置时的召回差异，并分析 Anthropic 模型的
+注意力退化现象；上下文压缩只是实验方法，不是本文要标记的现实实体。
+""",
+    "daily/2026-09-10/nvidia-blackwell.md": """\
+---
+name: nvidia-blackwell
+description: NVIDIA Blackwell 训练系统论文解读
+kind: daily-paper-analysis
+arxiv_id: "2609.10003"
+---
+
+# NVIDIA Blackwell 训练系统
+
+本文的机构研究对象是 NVIDIA。论文评估 Blackwell 集群的大模型训练吞吐、故障恢复和互连扩展效率，
+并给出 NVIDIA 在超大规模训练系统上的工程取舍。
+""",
+}
+
+DAILY_PAPER_DIGEST = """\
+---
+name: 每日论文简报-2026-09-10
+description: OpenAI、Anthropic 与 NVIDIA 三项研究的每日论文简报
+kind: daily-paper-brief
+---
+
+# 每日论文简报：智能体、长上下文与训练系统
+
+今天的三篇论文分别围绕三个相互独立的机构实体展开：OpenAI 的智能体可靠性评测、Anthropic 的长上下文
+研究，以及 NVIDIA 的 Blackwell 训练系统。这三家机构都是本期简报的并列核心，而非顺带提及。
+
+## 来源
+
+- [[daily/2026-09-10/openai-agent-eval.md]]
+- [[daily/2026-09-10/anthropic-context.md]]
+- [[daily/2026-09-10/nvidia-blackwell.md]]
+"""
+
+GENERIC_TAGS = {
+    "ai",
+    "人工智能",
+    "金融",
+    "股票",
+    "论文",
+    "研究",
+    "智能体",
+    "长上下文",
+    "训练系统",
+    "电池",
+    "半导体",
+}
+
+
+def _write(workspace: Path, relative: str, content: str) -> Path:
+    target = workspace / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+def _post(path: Path) -> frontmatter.Post:
+    return frontmatter.loads(path.read_text(encoding="utf-8"))
+
+
+def _tags(path: Path) -> list[str]:
+    value = _post(path).metadata.get("memory_tags")
+    assert isinstance(value, list), f"memory_tags was not written as a list: {value!r}"
+    assert all(isinstance(item, str) and item.strip() for item in value)
+    assert len(value) <= 3
+    assert not ({item.casefold() for item in value} & {item.casefold() for item in GENERIC_TAGS})
+    return value
+
+
+def _assert_tag(tags: list[str], expected: str) -> None:
+    assert expected.casefold() in {tag.casefold() for tag in tags}, f"expected entity {expected!r}, got {tags!r}"
+
+
+def _assert_any_tag(tags: list[str], expected: set[str]) -> None:
+    actual = {tag.casefold() for tag in tags}
+    accepted = {tag.casefold() for tag in expected}
+    assert actual & accepted, f"expected one of {sorted(expected)!r}, got {tags!r}"
+
+
+async def _run_tag_job(env, changes: list[dict[str, str]]):
+    app = await env.make_app(jobs=AUTO_TAG_JOB)
+    response = await app.run_job("integration_auto_tag", changes=changes)
+    assert response.success is True, f"auto-tag failed: {response.answer!r}; metadata={response.metadata!r}"
+    auto_tag = response.metadata["auto_tag"]
+    assert auto_tag["processed"] == len(changes)
+    assert auto_tag["succeeded"] == len(changes)
+    assert auto_tag["failed"] == 0
+    assert auto_tag["ignored"] == []
+    return app, response
+
+
+def _tag_index(app):
+    file_store = app.context.components[ComponentEnum.FILE_STORE]["default"]
+    return file_store.require_tag_index()
+
+
+def test_auto_tag_auto_fin_report_uses_company_entity():
+    """An Auto Fin report should be tagged with its company, not broad finance topics."""
+
+    async def run():
+        load_env(REPOSITORY / ".env")
+        with workspace_env(load_env_file=False) as env:
+            relative = "daily/2026-09-10/auto_fin.md"
+            path = _write(env.workspace_dir, relative, AUTO_FIN_REPORT)
+            before = _post(path)
+            try:
+                app, response = await _run_tag_job(env, [{"change": "added", "path": relative}])
+                tags = _tags(path)
+                _assert_any_tag(tags, {"宁德时代", "CATL"})
+                assert len(tags) == 1, f"single-entity report received extra tags: {tags!r}"
+                after = _post(path)
+                assert after.content == before.content
+                assert {key: value for key, value in after.metadata.items() if key != "memory_tags"} == before.metadata
+                indexed = await _tag_index(app).tags_for_path(relative)
+                assert indexed == [tags[0].casefold()]
+                assert response.metadata["auto_tag"]["indexes"][0]["date"] == "2026-09-10"
+            finally:
+                await env.close_all()
+
+    asyncio.run(run())
+
+
+def test_auto_tag_daily_paper_batch_tags_analyses_and_digest():
+    """The three analyses get one entity each and the digest gets all three."""
+
+    async def run():
+        load_env(REPOSITORY / ".env")
+        with workspace_env(load_env_file=False) as env:
+            paths = {
+                relative: _write(env.workspace_dir, relative, content)
+                for relative, content in DAILY_PAPER_NOTES.items()
+            }
+            digest_rel = "daily/2026-09-10/daily-paper-brief.md"
+            paths[digest_rel] = _write(env.workspace_dir, digest_rel, DAILY_PAPER_DIGEST)
+            before = {relative: _post(path) for relative, path in paths.items()}
+            changes = [{"change": "added", "path": relative} for relative in paths]
+            try:
+                app, response = await _run_tag_job(env, changes)
+                expected = {
+                    "daily/2026-09-10/openai-agent-eval.md": "OpenAI",
+                    "daily/2026-09-10/anthropic-context.md": "Anthropic",
+                    "daily/2026-09-10/nvidia-blackwell.md": "NVIDIA",
+                }
+                for relative, entity in expected.items():
+                    tags = _tags(paths[relative])
+                    assert len(tags) == 1, f"single-entity analysis received extra tags: {relative} -> {tags!r}"
+                    _assert_tag(tags, entity)
+
+                digest_tags = _tags(paths[digest_rel])
+                assert {tag.casefold() for tag in digest_tags} == {
+                    "openai",
+                    "anthropic",
+                    "nvidia",
+                }
+                for relative, path in paths.items():
+                    after = _post(path)
+                    assert after.content == before[relative].content
+                    assert {key: value for key, value in after.metadata.items() if key != "memory_tags"} == before[
+                        relative
+                    ].metadata
+                    indexed = await _tag_index(app).tags_for_path(relative)
+                    assert {tag.casefold() for tag in indexed} == {tag.casefold() for tag in _tags(path)}
+
+                auto_tag = response.metadata["auto_tag"]
+                assert [item["path"] for item in auto_tag["results"]] == list(paths)
+                assert len(auto_tag["indexes"]) == 1, "one daily index refresh is enough for a same-day batch"
+            finally:
+                await env.close_all()
+
+    asyncio.run(run())
+
+
+def test_auto_tag_modified_note_reuses_existing_canonical_tag():
+    """A modified note should reuse an existing workspace spelling for the same entity."""
+
+    async def run():
+        load_env(REPOSITORY / ".env")
+        with workspace_env(load_env_file=False) as env:
+            _write(
+                env.workspace_dir,
+                "daily/2026-09-09/openai-history.md",
+                "---\nname: openai-history\nmemory_tags: [OpenAI]\n---\n# OpenAI 历史记录\n",
+            )
+            relative = "daily/2026-09-10/openai-update.md"
+            target = _write(
+                env.workspace_dir,
+                relative,
+                """\
+---
+name: openai-update
+description: OpenAI, Inc. 产品更新记录
+memory_tags: [大模型]
+status: reviewed
+---
+
+# OpenAI, Inc. 产品更新
+
+这份记忆只围绕 OpenAI 公司，记录其产品发布节奏。文中的“大模型”是技术类别，不是现实实体标签。
+""",
+            )
+            body_before = _post(target).content
+            try:
+                app, response = await _run_tag_job(env, [{"change": "modified", "path": relative}])
+                tags = _tags(target)
+                assert [tag.casefold() for tag in tags] == ["openai"]
+                post = _post(target)
+                assert post.content == body_before
+                assert post.metadata["status"] == "reviewed"
+                indexed = await _tag_index(app).tags_for_path(relative)
+                assert indexed == ["openai"]
+                assert response.metadata["auto_tag"]["results"][0]["change"] == "modified"
+            finally:
+                await env.close_all()
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    test_auto_tag_auto_fin_report_uses_company_entity()
+    test_auto_tag_daily_paper_batch_tags_analyses_and_digest()
+    test_auto_tag_modified_note_reuses_existing_canonical_tag()

--- a/tests/integration/test_auto_tag.py
+++ b/tests/integration/test_auto_tag.py
@@ -19,14 +19,13 @@ sys.path.insert(0, str(INTEGRATION_DIR))
 # pylint: disable=wrong-import-position
 from _workspace_fixture import workspace_env  # noqa: E402
 
-from reme.enumeration import ComponentEnum  # noqa: E402
 from reme.utils import load_env  # noqa: E402
 
 AUTO_TAG_JOB = {
     "integration_auto_tag": {
         "backend": "base",
         "enable_serve": False,
-        "steps": [{"backend": "auto_tag_step", "max_tags_per_file": 3}],
+        "steps": [{"backend": "auto_tag_step"}],
     },
 }
 
@@ -170,11 +169,6 @@ async def _run_tag_job(env, changes: list[dict[str, str]]):
     return app, response
 
 
-def _tag_index(app):
-    file_store = app.context.components[ComponentEnum.FILE_STORE]["default"]
-    return file_store.require_tag_index()
-
-
 def test_auto_tag_auto_fin_report_uses_company_entity():
     """An Auto Fin report should be tagged with its company, not broad finance topics."""
 
@@ -185,16 +179,13 @@ def test_auto_tag_auto_fin_report_uses_company_entity():
             path = _write(env.workspace_dir, relative, AUTO_FIN_REPORT)
             before = _post(path)
             try:
-                app, response = await _run_tag_job(env, [{"change": "added", "path": relative}])
+                _app, _response = await _run_tag_job(env, [{"change": "added", "path": relative}])
                 tags = _tags(path)
                 _assert_any_tag(tags, {"宁德时代", "CATL"})
                 assert len(tags) == 1, f"single-entity report received extra tags: {tags!r}"
                 after = _post(path)
                 assert after.content == before.content
                 assert {key: value for key, value in after.metadata.items() if key != "memory_tags"} == before.metadata
-                indexed = await _tag_index(app).tags_for_path(relative)
-                assert indexed == [tags[0].casefold()]
-                assert response.metadata["auto_tag"]["indexes"][0]["date"] == "2026-09-10"
             finally:
                 await env.close_all()
 
@@ -216,7 +207,7 @@ def test_auto_tag_daily_paper_batch_tags_analyses_and_digest():
             before = {relative: _post(path) for relative, path in paths.items()}
             changes = [{"change": "added", "path": relative} for relative in paths]
             try:
-                app, response = await _run_tag_job(env, changes)
+                _app, response = await _run_tag_job(env, changes)
                 expected = {
                     "daily/2026-09-10/openai-agent-eval.md": "OpenAI",
                     "daily/2026-09-10/anthropic-context.md": "Anthropic",
@@ -239,12 +230,8 @@ def test_auto_tag_daily_paper_batch_tags_analyses_and_digest():
                     assert {key: value for key, value in after.metadata.items() if key != "memory_tags"} == before[
                         relative
                     ].metadata
-                    indexed = await _tag_index(app).tags_for_path(relative)
-                    assert {tag.casefold() for tag in indexed} == {tag.casefold() for tag in _tags(path)}
-
                 auto_tag = response.metadata["auto_tag"]
                 assert [item["path"] for item in auto_tag["results"]] == list(paths)
-                assert len(auto_tag["indexes"]) == 1, "one daily index refresh is enough for a same-day batch"
             finally:
                 await env.close_all()
 
@@ -281,14 +268,12 @@ status: reviewed
             )
             body_before = _post(target).content
             try:
-                app, response = await _run_tag_job(env, [{"change": "modified", "path": relative}])
+                _app, response = await _run_tag_job(env, [{"change": "modified", "path": relative}])
                 tags = _tags(target)
                 assert [tag.casefold() for tag in tags] == ["openai"]
                 post = _post(target)
                 assert post.content == body_before
                 assert post.metadata["status"] == "reviewed"
-                indexed = await _tag_index(app).tags_for_path(relative)
-                assert indexed == ["openai"]
                 assert response.metadata["auto_tag"]["results"][0]["change"] == "modified"
             finally:
                 await env.close_all()

--- a/tests/unit/test_auto_tag.py
+++ b/tests/unit/test_auto_tag.py
@@ -1,6 +1,6 @@
 """Focused tests for the standalone automatic tagging Step."""
 
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring,protected-access
 
 from pathlib import Path
 
@@ -210,3 +210,38 @@ async def test_auto_tag_uses_configured_key_and_normalizes_agent_output(tmp_path
         max_tags_per_file=2,
         max_tag_length=3,
     ) == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_auto_tag_syncs_successful_targets_and_reports_index_failures(tmp_path, monkeypatch):
+    store = LocalFileStore(name="store", embedding_store="", tag_index="")
+    step = AutoTagStep(file_store=store, agent_wrapper=_TaggingWrapper(tmp_path))
+    synced: list[list[dict[str, str]]] = []
+
+    async def sync_file_index(changes):
+        synced.append(changes)
+        return [
+            {"success": True, "path": "daily/ok.md"},
+            {"success": False, "path": "daily/stale.md", "error": "parse failed"},
+        ]
+
+    monkeypatch.setattr(step, "_sync_file_index", sync_file_index)
+    results = [
+        {"change": "added", "path": "daily/ok.md", "success": True},
+        {"change": "modified", "path": "daily/stale.md", "success": True},
+        {"change": "added", "path": "daily/tag-failed.md", "success": False, "error": "tagging failed"},
+    ]
+
+    updates = await step._sync_results(results)
+
+    assert synced == [
+        [
+            {"change": "added", "path": "daily/ok.md"},
+            {"change": "modified", "path": "daily/stale.md"},
+        ],
+    ]
+    assert updates[1]["error"] == "parse failed"
+    assert results[0]["success"] is True
+    assert results[1]["success"] is False
+    assert results[1]["error"] == "index update failed: parse failed"
+    assert results[2]["error"] == "tagging failed"

--- a/tests/unit/test_auto_tag.py
+++ b/tests/unit/test_auto_tag.py
@@ -8,9 +8,11 @@ import frontmatter
 import pytest
 
 from reme.components.agent_wrapper import BaseAgentWrapper
+from reme.components.file_store import LocalFileStore
 from reme.components.runtime_context import RuntimeContext
+from reme.components.tag_index import LocalTagIndex
 from reme.schema import Response
-from reme.steps.evolve.auto_tag import AutoTagStep, normalize_memory_tags
+from reme.steps.evolve.auto_tag import AutoTagStep
 
 
 class _TaggingWrapper(BaseAgentWrapper):
@@ -47,6 +49,12 @@ def _write_note(path: Path) -> None:
     path.write_text("---\nname: note\ndescription: useful note\n---\nbody\n", encoding="utf-8")
 
 
+def _file_store(*, name: str = "default", **tag_index_kwargs) -> LocalFileStore:
+    store = LocalFileStore(name=name, embedding_store="", tag_index="")
+    store.tag_index = LocalTagIndex(**tag_index_kwargs)
+    return store
+
+
 @pytest.mark.asyncio
 async def test_auto_tag_handles_noop_invalid_changes_and_no_tag_index(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -68,12 +76,15 @@ async def test_auto_tag_handles_noop_invalid_changes_and_no_tag_index(tmp_path, 
     note = tmp_path / "daily/2026-09-09/note.md"
     _write_note(note)
     change = RuntimeContext(changes=[{"change": "added", "path": "daily/2026-09-09/note.md"}])
-    response = await AutoTagStep(agent_wrapper=wrapper)(change)
+    response = await AutoTagStep(agent_wrapper=wrapper, file_store=LocalFileStore(embedding_store="", tag_index=""))(
+        change,
+    )
 
-    assert response.success is True
-    assert response.answer == "Tagged 1 file(s)"
-    assert len(wrapper.calls) == 1
-    assert frontmatter.loads(note.read_text(encoding="utf-8")).metadata["memory_tags"] == ["宁德时代", "黄金"]
+    assert response.success is False
+    assert response.answer == "Tagged 0 file(s); 1 failed"
+    assert not wrapper.calls
+    assert "memory_tags" not in frontmatter.loads(note.read_text(encoding="utf-8")).metadata
+    assert response.metadata["auto_tag"]["results"][0]["error"] == "tag index is not configured"
 
 
 @pytest.mark.asyncio
@@ -87,7 +98,7 @@ async def test_auto_tag_filters_paths_and_continues_after_one_file_fails(tmp_pat
     (tmp_path / "daily/2026-09-09/plain.txt").write_text("text", encoding="utf-8")
 
     wrapper = _TaggingWrapper(tmp_path, fail_name="failed.md")
-    step = AutoTagStep(agent_wrapper=wrapper)
+    step = AutoTagStep(agent_wrapper=wrapper, file_store=_file_store())
     context = RuntimeContext(
         changes=[
             {"change": "modified", "path": "daily/2026-09-09/failed.md"},
@@ -104,10 +115,12 @@ async def test_auto_tag_filters_paths_and_continues_after_one_file_fails(tmp_pat
     assert response.success is False
     assert [call[1]["injected_job_kwargs"] for call in wrapper.calls] == [
         {
+            "file_store": "default",
             "_allowed_paths": ["daily/2026-09-09/failed.md"],
             "_allowed_frontmatter_keys": ["memory_tags"],
         },
         {
+            "file_store": "default",
             "_allowed_paths": ["daily/2026-09-09/first.md"],
             "_allowed_frontmatter_keys": ["memory_tags"],
         },
@@ -152,11 +165,13 @@ async def test_auto_tag_uses_configured_key_and_normalizes_agent_output(tmp_path
         tag_key="keywords",
         tags=["OpenAI", "openai", "Sam   Altman", "++", 100, "宁德时代", "黄金"],
     )
-    step = AutoTagStep(agent_wrapper=wrapper, tag_key="keywords", max_tags_per_file=2, max_tag_length=8)
+    store = _file_store(name="archive", tag_key="keywords", max_tags_per_file=2, max_tag_length=8)
+    step = AutoTagStep(agent_wrapper=wrapper, file_store=store)
 
     async def update_frontmatter(name, /, **kwargs):
         assert name == "frontmatter_update"
         assert kwargs["_allowed_frontmatter_keys"] == ["keywords"]
+        assert kwargs["file_store"] == "archive"
         post = frontmatter.loads(note.read_text(encoding="utf-8"))
         post.metadata.update(kwargs["metadata"])
         note.write_text(frontmatter.dumps(post), encoding="utf-8")
@@ -171,11 +186,7 @@ async def test_auto_tag_uses_configured_key_and_normalizes_agent_output(tmp_path
     assert response.success is True
     assert response.answer == "Created memory/note.md"
     assert frontmatter.loads(note.read_text(encoding="utf-8")).metadata["keywords"] == [
-        "OpenAI",
-        "宁德时代",
+        "openai",
+        "100",
     ]
-    assert normalize_memory_tags(
-        ["one", "two", "three"],
-        max_tags_per_file=2,
-        max_tag_length=3,
-    ) == ["one", "two"]
+    assert wrapper.calls[0][1]["injected_job_kwargs"]["file_store"] == "archive"

--- a/tests/unit/test_auto_tag.py
+++ b/tests/unit/test_auto_tag.py
@@ -80,7 +80,7 @@ async def test_auto_tag_handles_noop_invalid_changes_and_no_tag_index(tmp_path, 
         change,
     )
 
-    assert response.success is False
+    assert response.success is True
     assert response.answer == "Tagged 0 file(s); 1 failed"
     assert not wrapper.calls
     assert "memory_tags" not in frontmatter.loads(note.read_text(encoding="utf-8")).metadata
@@ -109,10 +109,12 @@ async def test_auto_tag_filters_paths_and_continues_after_one_file_fails(tmp_pat
             {"change": "deleted", "path": "daily/2026-09-09/deleted.md"},
         ],
     )
+    context.response.answer = "Generated report"
 
     response = await step(context)
 
-    assert response.success is False
+    assert response.success is True
+    assert response.answer == "Generated report"
     assert [call[1]["injected_job_kwargs"] for call in wrapper.calls] == [
         {
             "file_store": "default",
@@ -186,7 +188,7 @@ async def test_auto_tag_uses_configured_key_and_normalizes_agent_output(tmp_path
     assert response.success is True
     assert response.answer == "Created memory/note.md"
     assert frontmatter.loads(note.read_text(encoding="utf-8")).metadata["keywords"] == [
-        "openai",
-        "100",
+        "OpenAI",
+        "宁德时代",
     ]
     assert wrapper.calls[0][1]["injected_job_kwargs"]["file_store"] == "archive"

--- a/tests/unit/test_auto_tag.py
+++ b/tests/unit/test_auto_tag.py
@@ -1,6 +1,6 @@
 """Focused tests for the standalone automatic tagging Step."""
 
-# pylint: disable=missing-function-docstring,protected-access
+# pylint: disable=missing-function-docstring
 
 from pathlib import Path
 
@@ -8,9 +8,7 @@ import frontmatter
 import pytest
 
 from reme.components.agent_wrapper import BaseAgentWrapper
-from reme.components.file_store import LocalFileStore
 from reme.components.runtime_context import RuntimeContext
-from reme.components.tag_index import LocalTagIndex
 from reme.schema import Response
 from reme.steps.evolve.auto_tag import AutoTagStep, normalize_memory_tags
 
@@ -50,19 +48,18 @@ def _write_note(path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_auto_tag_handles_noop_and_rejects_invalid_preconditions(tmp_path, monkeypatch):
+async def test_auto_tag_handles_noop_invalid_changes_and_no_tag_index(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     wrapper = _TaggingWrapper(tmp_path)
-    unindexed_store = LocalFileStore(name="store", embedding_store="", tag_index="")
 
     context = RuntimeContext(changes=[])
     context.response.answer = "Skipped: no messages"
-    response = await AutoTagStep(file_store=unindexed_store, agent_wrapper=wrapper)(context)
+    response = await AutoTagStep(agent_wrapper=wrapper)(context)
     assert response.success is True
     assert response.answer == "Skipped: no messages"
     assert response.metadata["auto_tag"]["processed"] == 0
 
-    response = await AutoTagStep(file_store=unindexed_store, agent_wrapper=wrapper)(
+    response = await AutoTagStep(agent_wrapper=wrapper)(
         RuntimeContext(changes="daily/note.md"),
     )
     assert response.success is False
@@ -70,36 +67,13 @@ async def test_auto_tag_handles_noop_and_rejects_invalid_preconditions(tmp_path,
 
     note = tmp_path / "daily/2026-09-09/note.md"
     _write_note(note)
-    before = note.read_bytes()
     change = RuntimeContext(changes=[{"change": "added", "path": "daily/2026-09-09/note.md"}])
-    response = await AutoTagStep(file_store=unindexed_store, agent_wrapper=wrapper)(change)
+    response = await AutoTagStep(agent_wrapper=wrapper)(change)
 
-    assert response.success is False
-    assert response.answer == "Error: tag index is not configured"
-    assert not wrapper.calls
-    assert note.read_bytes() == before
-
-    indexed_store = LocalFileStore(name="store", embedding_store="", tag_index="")
-    indexed_store.tag_index = LocalTagIndex(max_tags_per_file=2)
-    response = await AutoTagStep(
-        file_store=indexed_store,
-        agent_wrapper=wrapper,
-        max_tags_per_file=3,
-    )(RuntimeContext(changes=[{"change": "added", "path": "daily/2026-09-09/note.md"}]))
-    assert response.success is False
-    assert response.answer == "Error: auto_tag max_tags_per_file (3) exceeds tag index limit (2)"
-    assert not wrapper.calls
-    assert note.read_bytes() == before
-
-    indexed_store.tag_index = LocalTagIndex()
-    indexed_store.tag_index.set_healthy(False)
-    response = await AutoTagStep(file_store=indexed_store, agent_wrapper=wrapper)(
-        RuntimeContext(changes=[{"change": "added", "path": "daily/2026-09-09/note.md"}]),
-    )
-    assert response.success is False
-    assert response.answer == "Error: tag index unavailable"
-    assert not wrapper.calls
-    assert note.read_bytes() == before
+    assert response.success is True
+    assert response.answer == "Tagged 1 file(s)"
+    assert len(wrapper.calls) == 1
+    assert frontmatter.loads(note.read_text(encoding="utf-8")).metadata["memory_tags"] == ["宁德时代", "黄金"]
 
 
 @pytest.mark.asyncio
@@ -112,10 +86,8 @@ async def test_auto_tag_filters_paths_and_continues_after_one_file_fails(tmp_pat
     (tmp_path / "daily/2026-09-09/notes").mkdir()
     (tmp_path / "daily/2026-09-09/plain.txt").write_text("text", encoding="utf-8")
 
-    store = LocalFileStore(name="store", embedding_store="", tag_index="")
-    store.tag_index = LocalTagIndex()
     wrapper = _TaggingWrapper(tmp_path, fail_name="failed.md")
-    step = AutoTagStep(file_store=store, agent_wrapper=wrapper)
+    step = AutoTagStep(agent_wrapper=wrapper)
     context = RuntimeContext(
         changes=[
             {"change": "modified", "path": "daily/2026-09-09/failed.md"},
@@ -168,7 +140,6 @@ async def test_auto_tag_filters_paths_and_continues_after_one_file_fails(tmp_pat
             "summary": "tagged daily/2026-09-09/first.md",
         },
     ]
-    assert "memory_tags: ['宁德时代', '黄金']" in (tmp_path / "daily/2026-09-09.md").read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio
@@ -176,14 +147,12 @@ async def test_auto_tag_uses_configured_key_and_normalizes_agent_output(tmp_path
     monkeypatch.chdir(tmp_path)
     note = tmp_path / "memory/note.md"
     _write_note(note)
-    store = LocalFileStore(name="store", embedding_store="", tag_index="")
-    store.tag_index = LocalTagIndex(tag_key="keywords", max_tag_length=8)
     wrapper = _TaggingWrapper(
         tmp_path,
         tag_key="keywords",
         tags=["OpenAI", "openai", "Sam   Altman", "++", 100, "宁德时代", "黄金"],
     )
-    step = AutoTagStep(file_store=store, agent_wrapper=wrapper, max_tags_per_file=2)
+    step = AutoTagStep(agent_wrapper=wrapper, tag_key="keywords", max_tags_per_file=2, max_tag_length=8)
 
     async def update_frontmatter(name, /, **kwargs):
         assert name == "frontmatter_update"
@@ -210,38 +179,3 @@ async def test_auto_tag_uses_configured_key_and_normalizes_agent_output(tmp_path
         max_tags_per_file=2,
         max_tag_length=3,
     ) == ["one", "two"]
-
-
-@pytest.mark.asyncio
-async def test_auto_tag_syncs_successful_targets_and_reports_index_failures(tmp_path, monkeypatch):
-    store = LocalFileStore(name="store", embedding_store="", tag_index="")
-    step = AutoTagStep(file_store=store, agent_wrapper=_TaggingWrapper(tmp_path))
-    synced: list[list[dict[str, str]]] = []
-
-    async def sync_file_index(changes):
-        synced.append(changes)
-        return [
-            {"success": True, "path": "daily/ok.md"},
-            {"success": False, "path": "daily/stale.md", "error": "parse failed"},
-        ]
-
-    monkeypatch.setattr(step, "_sync_file_index", sync_file_index)
-    results = [
-        {"change": "added", "path": "daily/ok.md", "success": True},
-        {"change": "modified", "path": "daily/stale.md", "success": True},
-        {"change": "added", "path": "daily/tag-failed.md", "success": False, "error": "tagging failed"},
-    ]
-
-    updates = await step._sync_results(results)
-
-    assert synced == [
-        [
-            {"change": "added", "path": "daily/ok.md"},
-            {"change": "modified", "path": "daily/stale.md"},
-        ],
-    ]
-    assert updates[1]["error"] == "parse failed"
-    assert results[0]["success"] is True
-    assert results[1]["success"] is False
-    assert results[1]["error"] == "index update failed: parse failed"
-    assert results[2]["error"] == "tagging failed"

--- a/tests/unit/test_background_steps.py
+++ b/tests/unit/test_background_steps.py
@@ -1998,7 +1998,7 @@ def test_auto_memory_reports_modified_for_create_and_false_for_skip():
         with tempfile.TemporaryDirectory() as tmpdir, temp_chdir(tmpdir):
             cwd = Path.cwd()
             app_ctx = _make_app_context(cwd)
-            fs = LocalFileStore(name="test_store", embedding_store="", tag_index="default")
+            fs = LocalFileStore(name="test_store", embedding_store="", tag_index="")
             wrapper = _FakeAgentWrapper()
             await fs.start()
             _install_file_jobs(app_ctx, fs)

--- a/tests/unit/test_evolve_utils.py
+++ b/tests/unit/test_evolve_utils.py
@@ -10,7 +10,6 @@ import pytest
 
 from reme.steps.evolve._evolve import agent_reply_result_text, format_history
 from reme.steps.evolve.auto_memory import AutoMemoryStep, _sanitize_msg_for_save
-from reme.steps.evolve.auto_tag import normalize_memory_tags
 
 
 def test_agent_reply_result_text_uses_last_text_block():
@@ -74,26 +73,6 @@ def test_sanitize_msg_for_save_drops_tool_results_and_base64_data():
     assert [block.type for block in sanitized.content] == ["text", "tool_call"]
     assert sanitized.content[0].text == "real conversation"
     assert sanitized.content[1].name == "memory_search"
-
-
-def test_auto_tag_normalizes_frontmatter_tags():
-    """Memory tags preserve entity names, de-duplicate, and stop at three."""
-    assert normalize_memory_tags(
-        [
-            "OpenAI",
-            "openai",
-            "Sam   Altman",
-            "++",
-            100,
-            "宁德时代",
-            "黄金",
-        ],
-    ) == ["OpenAI", "Sam_Altman", "宁德时代"]
-    # pylint: disable=use-implicit-booleaness-not-comparison
-    assert normalize_memory_tags(None) == []
-    assert normalize_memory_tags("OpenAI") == []
-    # pylint: enable=use-implicit-booleaness-not-comparison
-    assert normalize_memory_tags(["x" * 65, True, {}, "宁德时代"]) == ["宁德时代"]
 
 
 def test_auto_memory_accepts_message_timestamp_aliases():

--- a/tests/unit/test_injected_job_kwargs.py
+++ b/tests/unit/test_injected_job_kwargs.py
@@ -261,11 +261,11 @@ def test_configs_define_original_jobs_without_daily_variants():
     default = resolve_app_config(config="default", log_config=False)
     assert default["jobs"]["auto_memory"]["steps"] == [
         {"backend": "auto_memory_step"},
-        {"backend": "auto_tag_step", "max_tags_per_file": 3},
+        {"backend": "auto_tag_step"},
     ]
     assert default["jobs"]["auto_memory_cc"]["steps"] == [
         {"backend": "auto_memory_cc_step"},
-        {"backend": "auto_tag_step", "max_tags_per_file": 3},
+        {"backend": "auto_tag_step"},
     ]
 
 

--- a/tests/unit/test_package_versions.py
+++ b/tests/unit/test_package_versions.py
@@ -56,8 +56,8 @@ def test_studio_packages_have_independent_identity() -> None:
     assert main_config["project"]["optional-dependencies"]["core"].count("reme-ai[as]") == 1
     assert main_config["project"]["optional-dependencies"]["core"].count("reme_studio") == 1
     assert "qwenpaw" not in main_config["project"]["optional-dependencies"]
-    assert auto_fin_config["project"]["version"] == "0.1.2"
-    assert daily_paper_config["project"]["version"] == "0.1.2"
+    assert auto_fin_config["project"]["version"] == "0.1.3"
+    assert daily_paper_config["project"]["version"] == "0.1.3"
     assert main_config["tool"]["setuptools"]["packages"]["find"]["include"] == ["reme", "reme.*"]
     assert "reme_studio*" in main_config["tool"]["setuptools"]["packages"]["find"]["exclude"]
 
@@ -167,8 +167,8 @@ def test_auto_fin_requires_reme_base() -> None:
 
     assert len(reme_requirements) == 1
     assert not reme_requirements[0].extras
-    assert Version("0.4.1.8") not in reme_requirements[0].specifier
-    assert Version("0.4.1.9") in reme_requirements[0].specifier
+    assert Version("0.4.1.11") not in reme_requirements[0].specifier
+    assert Version("0.4.1.12") in reme_requirements[0].specifier
 
 
 def test_daily_paper_license_matches_repository() -> None:
@@ -185,8 +185,8 @@ def test_daily_paper_declares_runtime_dependencies() -> None:
     by_name = {requirement.name: requirement for requirement in requirements}
 
     assert not by_name["reme-ai"].extras
-    assert Version("0.4.1.8") not in by_name["reme-ai"].specifier
-    assert Version("0.4.1.9") in by_name["reme-ai"].specifier
+    assert Version("0.4.1.11") not in by_name["reme-ai"].specifier
+    assert Version("0.4.1.12") in by_name["reme-ai"].specifier
     assert "pypdf" in by_name
 
 

--- a/tests/unit/test_tag_index.py
+++ b/tests/unit/test_tag_index.py
@@ -27,9 +27,7 @@ def _chunk(chunk_id: str, path: str, text: str) -> FileChunk:
 
 
 def _standalone_file_store_with_tag_index(**kwargs) -> LocalFileStore:
-    store = LocalFileStore(tag_index="", **kwargs)
-    store.tag_index = LocalTagIndex()
-    return store
+    return LocalFileStore(tag_index="default", **kwargs)
 
 
 def test_tag_normalization_and_bidirectional_mutations() -> None:
@@ -289,14 +287,20 @@ def test_configured_frontmatter_key_contract() -> None:
     assert not index.is_healthy
 
 
-def test_file_store_tag_index_binding_has_no_default_factory() -> None:
-    """Require configured tag indexes instead of silently constructing one."""
-    store = LocalFileStore(name="test", embedding_store="", tag_index="custom")
-    dependency = store.dependency_bindings["tag_index"]
+def test_file_store_tag_index_binding_only_defaults_for_default_name() -> None:
+    """Support standalone defaults without silently substituting named dependencies."""
+    default_store = LocalFileStore(name="default-store", embedding_store="", tag_index="default")
+    custom_store = LocalFileStore(name="custom-store", embedding_store="", tag_index="custom")
 
-    assert dependency.name == "custom"
-    assert dependency.default_factory is None
-    assert dependency.optional is False
+    default_dependency = default_store.dependency_bindings["tag_index"]
+    assert default_dependency.name == "default"
+    assert default_dependency.default_factory is LocalTagIndex
+    assert default_dependency.optional is False
+
+    custom_dependency = custom_store.dependency_bindings["tag_index"]
+    assert custom_dependency.name == "custom"
+    assert custom_dependency.default_factory is None
+    assert custom_dependency.optional is False
 
 
 def test_file_store_without_tag_index_name_disables_tag_index() -> None:

--- a/tests/unit/test_tag_index.py
+++ b/tests/unit/test_tag_index.py
@@ -7,10 +7,12 @@ from pathlib import Path
 
 import pytest
 
+from reme.components.application_context import ApplicationContext
 from reme.components.file_chunker import MarkdownFileChunker
 from reme.components.file_store import LocalFileStore
 from reme.components.tag_index import LocalTagIndex
 from reme.config import resolve_app_config
+from reme.enumeration import ComponentEnum
 from reme.schema import FileChunk, FileFrontMatter, FileNode
 from reme.steps.index.list_tags import ListTagsStep
 
@@ -22,6 +24,12 @@ def _node(path: str, tags: object = None, *, key: str = "memory_tags") -> FileNo
 
 def _chunk(chunk_id: str, path: str, text: str) -> FileChunk:
     return FileChunk(id=chunk_id, path=path, text=text, start_line=1, end_line=1)
+
+
+def _standalone_file_store_with_tag_index(**kwargs) -> LocalFileStore:
+    store = LocalFileStore(tag_index="", **kwargs)
+    store.tag_index = LocalTagIndex()
+    return store
 
 
 def test_tag_normalization_and_bidirectional_mutations() -> None:
@@ -259,6 +267,38 @@ def test_configured_frontmatter_key_contract() -> None:
     assert not index.is_healthy
 
 
+def test_file_store_tag_index_binding_has_no_default_factory() -> None:
+    """Require configured tag indexes instead of silently constructing one."""
+    store = LocalFileStore(name="test", embedding_store="", tag_index="custom")
+    dependency = store.dependency_bindings["tag_index"]
+
+    assert dependency.name == "custom"
+    assert dependency.default_factory is None
+    assert dependency.optional is False
+
+
+@pytest.mark.parametrize("tag_index_name", ["", "custom", "missing"])
+def test_file_store_resolves_configured_tag_index(tag_index_name: str, tmp_path: Path) -> None:
+    """Resolve tag indexes by configured component name and fail on missing names."""
+
+    async def run() -> None:
+        context = ApplicationContext(workspace_dir=str(tmp_path))
+        index = LocalTagIndex(name="custom", tag_key="keywords")
+        context.components = {ComponentEnum.TAG_INDEX: {"custom": index}}
+        store = LocalFileStore(app_context=context, embedding_store="", tag_index=tag_index_name)
+
+        if tag_index_name == "missing":
+            with pytest.raises(ValueError, match="tag_index 'missing' not found"):
+                await store.start()
+            assert not store.is_started
+        else:
+            await store._resolve_bindings()
+            assert store.tag_index is (index if tag_index_name else None)
+            assert store.tag_index_enabled is bool(tag_index_name)
+
+    asyncio.run(run())
+
+
 def test_file_store_updates_tag_index_from_file_nodes(monkeypatch, tmp_path: Path) -> None:
     """Keep daily and digest tags aligned through file-store mutations."""
 
@@ -269,7 +309,7 @@ def test_file_store_updates_tag_index_from_file_nodes(monkeypatch, tmp_path: Pat
 
     async def run() -> None:
         monkeypatch.chdir(tmp_path)
-        store = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        store = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await store.start()
         assert isinstance(store.tag_index, LocalTagIndex)
         assert store.tag_index_enabled is True
@@ -304,7 +344,7 @@ def test_tag_failures_do_not_block_other_indexes_and_retry_rebuild(monkeypatch, 
 
     async def run() -> None:
         monkeypatch.chdir(tmp_path)
-        store = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        store = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await store.start()
         assert store.tag_index_enabled
         original_rebuild = store.tag_index.rebuild
@@ -344,7 +384,7 @@ def test_failed_tag_reconciliation_makes_queries_fail_closed(monkeypatch, tmp_pa
 
     async def run() -> None:
         monkeypatch.chdir(tmp_path)
-        store = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        store = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await store.start()
         assert store.tag_index_enabled
         await store.upsert([(_node("daily/a.md", ["old"]), [])])
@@ -371,7 +411,7 @@ def test_tag_rebuild_graph_read_failure_does_not_block_upsert(monkeypatch, tmp_p
 
     async def run() -> None:
         monkeypatch.chdir(tmp_path)
-        store = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        store = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await store.start()
         assert store.tag_index_enabled
         assert store.file_graph is not None
@@ -401,7 +441,7 @@ def test_explicit_reindex_restores_tag_index(monkeypatch, tmp_path: Path) -> Non
 
     async def run() -> None:
         monkeypatch.chdir(tmp_path)
-        store = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        store = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await store.start()
         assert store.tag_index_enabled
         await store.upsert(
@@ -437,7 +477,7 @@ def test_tag_delete_failures_do_not_block_core_deletion(monkeypatch, tmp_path: P
 
     async def run() -> None:
         monkeypatch.chdir(tmp_path)
-        store = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        store = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await store.start()
         assert store.tag_index_enabled
         chunk = _chunk("chunk-a", "daily/a.md", "alpha memory")
@@ -472,7 +512,7 @@ def test_existing_markdown_chunker_supplies_frontmatter_tags(monkeypatch, tmp_pa
         note.write_text("---\nmemory_tags: [Python, ReMe]\n---\nbody\n", encoding="utf-8")
         node, chunks = await MarkdownFileChunker().chunk(note)
 
-        store = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        store = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await store.start()
         await store.upsert([(node, chunks)])
 
@@ -487,14 +527,14 @@ def test_file_store_rebuilds_non_persistent_tag_index_from_graph(monkeypatch, tm
 
     async def run() -> None:
         monkeypatch.chdir(tmp_path)
-        first = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        first = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await first.start()
         await first.upsert([(_node("daily/a.md", ["ReMe"]), [])])
         await first.close()
 
         assert not list((tmp_path / "metadata").glob("tag_index/**/*"))
 
-        restored = LocalFileStore(name="test", embedding_store="", tag_index="default")
+        restored = _standalone_file_store_with_tag_index(name="test", embedding_store="")
         await restored.start()
         assert await restored.tag_index.paths_for_tags(["reme"]) == ["daily/a.md"]
         await restored.close()
@@ -515,9 +555,9 @@ def test_default_config_enables_tag_index_with_explicit_key() -> None:
     assert config["jobs"]["search"]["parameters"]["properties"]["tags"]["default"] == []
     assert config["jobs"]["auto_memory"]["steps"] == [
         {"backend": "auto_memory_step"},
-        {"backend": "auto_tag_step", "max_tags_per_file": 3},
+        {"backend": "auto_tag_step"},
     ]
     assert config["jobs"]["auto_memory_cc"]["steps"] == [
         {"backend": "auto_memory_cc_step"},
-        {"backend": "auto_tag_step", "max_tags_per_file": 3},
+        {"backend": "auto_tag_step"},
     ]

--- a/tests/unit/test_tag_index.py
+++ b/tests/unit/test_tag_index.py
@@ -217,6 +217,28 @@ def test_list_tags_paginates_and_applies_default_sort_orders() -> None:
     assert "empty page" in job["parameters"]["properties"]["page"]["description"]
 
 
+@pytest.mark.asyncio
+async def test_list_tags_resolves_named_file_store_from_runtime_context(tmp_path) -> None:
+    """Injected tool context can route list_tags to the AutoTag Step's file store."""
+    context = ApplicationContext(workspace_dir=str(tmp_path))
+    default_store = LocalFileStore(name="default", embedding_store="", tag_index="")
+    archive_store = LocalFileStore(name="archive", embedding_store="", tag_index="")
+    default_store.tag_index = LocalTagIndex()
+    archive_store.tag_index = LocalTagIndex()
+    await default_store.tag_index.rebuild([_node("daily/default.md", ["default-tag"])])
+    await archive_store.tag_index.rebuild([_node("daily/archive.md", ["archive-tag"])])
+    context.components = {
+        ComponentEnum.FILE_STORE: {
+            "default": default_store,
+            "archive": archive_store,
+        },
+    }
+
+    response = await ListTagsStep(app_context=context)(file_store="archive")
+
+    assert response.answer["items"] == [("archive-tag", 1)]
+
+
 def test_configured_frontmatter_key_contract() -> None:
     """Validate, apply, and invalidate changes to the configured source key."""
 
@@ -275,6 +297,17 @@ def test_file_store_tag_index_binding_has_no_default_factory() -> None:
     assert dependency.name == "custom"
     assert dependency.default_factory is None
     assert dependency.optional is False
+
+
+def test_file_store_without_tag_index_name_disables_tag_index() -> None:
+    """Treat both an omitted tag-index setting and an explicit empty name as disabled."""
+    omitted = LocalFileStore(name="omitted", embedding_store="")
+    explicit = LocalFileStore(name="explicit", embedding_store="", tag_index="")
+
+    assert omitted.tag_index is None
+    assert omitted.tag_index_enabled is False
+    assert explicit.tag_index is None
+    assert explicit.tag_index_enabled is False
 
 
 @pytest.mark.parametrize("tag_index_name", ["", "custom", "missing"])


### PR DESCRIPTION
## Summary

This PR adds automatic entity tagging to the Markdown reports generated by Auto Fin and Daily Paper, while keeping workspace files as the source of truth and leaving all derived-index maintenance to the existing background file watcher.

## Plugin-generated change propagation

### Auto Fin

- Records the generated `daily/YYYY-MM-DD/auto_fin.md` path in the shared `changes` contract.
- Distinguishes an initial report (`added`) from a same-day rewrite (`modified`).
- Runs `auto_tag_step` after the final report is written, so only the durable report is tagged; no intermediate artifact is introduced.

### Daily Paper

- Collects all generated analysis-note paths in the shared `changes` list.
- Adds the final digest path to the same batch before automatic tagging.
- Preserves the batch across the analysis and digest Steps, allowing one `auto_tag_step` invocation to process all generated Markdown files.
- Represents title-driven renames accurately as `deleted` for the old path plus `added` for the new path. `auto_tag_step` ignores the deletion and tags only the new file, while the file watcher observes both filesystem changes for derived-index maintenance.
- Keeps DingTalk delivery after tagging, so the saved workspace documents have their final frontmatter before notification.

## Focused AutoTag responsibility

- Narrows `AutoTagStep` to validating added/modified Markdown targets, asking the agent to update the configured tag frontmatter, normalizing the result, and reporting per-file outcomes.
- Resolves the selected `file_store` and uses its configured tag-index key and limits, keeping source frontmatter consistent with the derived index.
- Preserves canonical display casing such as `OpenAI` in workspace frontmatter while retaining case-insensitive de-duplication and lookup behavior.
- Treats per-file tagging and missing-index failures as best-effort: warnings and structured `auto_tag` metadata expose failures without replacing an earlier Step's answer or successful status. Invalid `changes` payloads remain explicit contract failures.
- Removes synchronous `update_index_step` dispatch, tag-index health checks, and `index_updates` response metadata.
- Removes daily summary regeneration from `AutoTagStep`; daily-summary ownership stays with the Steps that create daily content.
- Uses `BaseStep.workspace_path` for workspace containment instead of obtaining the workspace through `file_store`.
- Retains path containment, Markdown-only filtering, duplicate-change coalescing, frontmatter-key restrictions, tag case-insensitive deduplication, and tag count/length validation.
- Uses the configured tag index as the single source of truth for the tag key, per-file count limit, and length limit; normal job configuration remains:

  ```yaml
  - backend: auto_tag_step
  ```

## File watcher and derived-index ownership

- Leaves file-store, graph, keyword, vector, and tag-index refreshes to the existing `index_update_loop` watching daily and digest Markdown.
- Avoids duplicate parsing/embedding work and races between AutoTag's former eager update and watcher-driven updates.
- Restores the local-first consistency boundary: a completed frontmatter write is no longer reclassified as failed solely because a separate eager index refresh fails.
- Preserves the selected non-default `file_store` across Agent tool calls, so `list_tags` uses the matching tag index; AutoTag still does not synchronously dispatch index updates.
- Resolves stale renamed-path indexing through the canonical filesystem flow: rename changes are represented correctly, and the watcher (or the next initialization scan) reconciles the derived store from current files.

## Tag-index configuration and defaults

- Centralizes the shared tag key, count limit, and length limit in `reme.constants`, keeping AutoTag and the local tag index aligned by default.
- Preserves standalone `LocalTagIndex` construction for the explicit `default` tag-index name, without silently substituting a local index for custom named dependencies.
- Resolves a configured tag index by component name and fails clearly when a non-empty custom name does not exist.
- Keeps an empty `tag_index` setting as the explicit way to run a file store without tag indexing; AutoTag records the missing-index outcome as a best-effort warning and metadata entry.
- Covers standalone default tag-index creation, explicit disabling, and missing named-component failures.

## Integration coverage

- Adds real-LLM integration scenarios for:
  - tagging an Auto Fin report with its central company entity;
  - tagging three Daily Paper analyses and their combined digest;
  - preserving existing frontmatter/body fields while replacing generic tags with a canonical entity tag.
- Updates the integration assertions to test AutoTag's source-file contract, without assuming synchronous index visibility.
- Extends unit and plugin tests for no-index best-effort AutoTag execution, normalized custom frontmatter keys, simplified Step configuration, explicit tag-index binding, missing-component failures, and Daily Paper rename events.

## Documentation, packaging, and release automation

- Documents automatic tagging in the English and Chinese Auto Fin and Daily Paper READMEs and plugin-management guides.
- Clarifies that `auto_tag_step` updates source frontmatter and the background watcher refreshes derived indexes.
- Bumps ReMe to `0.4.1.12` and both plugins to `0.1.3`.
- Raises both plugin requirements and release-workflow dependency gates to `reme-ai>=0.4.1.12`.
- Keeps release documentation and package-version tests aligned with those versions.

## Python 3.13 logging compatibility

- Preserves forwarding of host logging records through QwenPaw on Python 3.13 by applying the target logger's public enable/filter checks and dispatching to handlers without the nested-call suppression that drops forwarded records.

## Validation

- `PYTHONPATH=/Users/yuli/workspace/ReMe pytest tests/unit -q` — **1327 passed, 1 skipped**
- Focused AutoTag/tag-index/injected-context/background tests — **113 passed**
- `pytest tests -q` in `plugins/auto-fin` with local source paths — **9 passed**
- `pytest tests -q` in `plugins/daily_paper` with local source paths — **38 passed**
- `pre-commit run --all-files` — **passed**
- `npm test` in `github-pages` — **11 passed**
- `npm run build` in `github-pages` — **23 documentation artifacts verified**
- `pytest tests/integration/test_auto_tag.py --collect-only -q` — **3 tests collected**

The real-LLM integration tests were collected but not executed because they require configured external model credentials.
